### PR TITLE
feat: server functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ COMandA is a command-line tool that enables the composition of Large Language Mo
 - 🌐 Direct URL input support for web content analysis
 - 🛠️ Extensible DSL for defining complex workflows
 - ⚡ Efficient processing of LLM chains
+- 🔒 HTTP server mode with bearer token authentication
 
 ## Installation
 
@@ -114,6 +115,122 @@ providers:
       - name: llama2
         type: local
         mode: text
+```
+
+### Server Configuration
+
+COMandA can run as an HTTP server, allowing you to process chains of models and actions defined in YAML files via HTTP requests. To configure the server:
+
+```bash
+comanda configure --server
+```
+
+This will prompt you to:
+1. Set the server port (default: 8080)
+2. Set the data directory path (default: data)
+3. Generate a bearer token for authentication
+4. Enable/disable authentication
+
+The server configuration is stored in your `.env` file alongside provider and model settings:
+
+```yaml
+server:
+  port: 8080
+  data_dir: "examples"  # Directory containing YAML files to process
+  bearer_token: "your-generated-token"
+  enabled: true  # Whether authentication is required
+```
+
+To start the server:
+
+```bash
+comanda serve
+```
+
+The server provides the following endpoints:
+
+### 1. Process Endpoint
+
+`GET /process` processes a YAML file from the configured data directory:
+
+```bash
+# Without authentication
+curl "http://localhost:8080/process?filename=openai-example.yaml"
+
+# With authentication (when enabled)
+curl -H "Authorization: Bearer your-token" "http://localhost:8080/process?filename=openai-example.yaml"
+```
+
+Response format:
+```json
+{
+  "success": true,
+  "message": "Successfully processed openai-example.yaml",
+  "output": "Response from gpt-4o-mini:\n..."
+}
+```
+
+Error response:
+```json
+{
+  "success": false,
+  "error": "Error message here",
+  "output": "Any output generated before the error"
+}
+```
+
+### 2. List Endpoint
+
+`GET /list` returns a list of YAML files in the configured data directory:
+
+```bash
+curl -H "Authorization: Bearer your-token" "http://localhost:8080/list"
+```
+
+Response format:
+```json
+{
+  "success": true,
+  "files": [
+    "openai-example.yaml",
+    "image-example.yaml",
+    "screenshot-example.yaml"
+  ]
+}
+```
+
+### 3. Health Check Endpoint
+
+`GET /health` returns the server's current status:
+
+```bash
+curl "http://localhost:8080/health"
+```
+
+Response format:
+```json
+{
+  "status": "ok",
+  "timestamp": "2024-11-02T20:39:13Z"
+}
+```
+
+The server logs all requests to the console, including:
+- Timestamp
+- Request method and path
+- Query parameters
+- Authorization header (token masked)
+- Response status code
+- Request duration
+
+Example server log:
+```
+[2024-11-02 20:39:13] GET /process
+Query Parameters: filename=openai-example.yaml
+Authorization: Bearer ********
+Status: 200
+Duration: 4.302611084s
+--------------------------------------------------------------------------------
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -225,12 +225,9 @@ The server logs all requests to the console, including:
 
 Example server log:
 ```
-[2024-11-02 20:39:13] GET /process
-Query Parameters: filename=openai-example.yaml
-Authorization: Bearer ********
-Status: 200
-Duration: 4.302611084s
---------------------------------------------------------------------------------
+2024/11/02 21:06:33 Request: method=GET path=/health query= auth=Bearer ******** status=200 duration=875µs
+2024/11/02 21:06:37 Request: method=GET path=/list query= auth=Bearer ******** status=200 duration=812.208µs
+2024/11/02 21:06:45 Request: method=GET path=/process query=filename=examples/openai-example.yaml auth=Bearer ******** status=200 duration=3.360269792s
 ```
 
 ## Usage

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/spf13/cobra"
@@ -28,7 +27,10 @@ type Config struct {
 	Providers map[string]Provider `yaml:"providers"`
 }
 
-var listFlag bool
+var (
+	listFlag   bool
+	serverFlag bool
+)
 
 func checkOllamaInstalled() bool {
 	cmd := exec.Command("ollama", "list")
@@ -50,6 +52,55 @@ func isValidOllamaModel(modelName string) bool {
 	return strings.Contains(outputStr, modelName)
 }
 
+func configureServer(reader *bufio.Reader, envConfig *config.EnvConfig) error {
+	serverConfig := envConfig.GetServerConfig()
+
+	// Prompt for port
+	fmt.Printf("Enter server port (default: %d): ", serverConfig.Port)
+	portStr, _ := reader.ReadString('\n')
+	portStr = strings.TrimSpace(portStr)
+	if portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return fmt.Errorf("invalid port number: %v", err)
+		}
+		serverConfig.Port = port
+	}
+
+	// Prompt for data directory
+	fmt.Printf("Enter data directory path (default: %s): ", serverConfig.DataDir)
+	dataDir, _ := reader.ReadString('\n')
+	dataDir = strings.TrimSpace(dataDir)
+	if dataDir != "" {
+		serverConfig.DataDir = dataDir
+	}
+
+	// Create data directory if it doesn't exist
+	if err := os.MkdirAll(serverConfig.DataDir, 0755); err != nil {
+		return fmt.Errorf("error creating data directory: %v", err)
+	}
+
+	// Prompt for bearer token generation
+	fmt.Print("Generate new bearer token? (y/n): ")
+	genToken, _ := reader.ReadString('\n')
+	if strings.TrimSpace(strings.ToLower(genToken)) == "y" {
+		token, err := config.GenerateBearerToken()
+		if err != nil {
+			return fmt.Errorf("error generating bearer token: %v", err)
+		}
+		serverConfig.BearerToken = token
+		fmt.Printf("Generated bearer token: %s\n", token)
+	}
+
+	// Prompt for server enable/disable
+	fmt.Print("Enable server authentication? (y/n): ")
+	enableStr, _ := reader.ReadString('\n')
+	serverConfig.Enabled = strings.TrimSpace(strings.ToLower(enableStr)) == "y"
+
+	envConfig.UpdateServerConfig(*serverConfig)
+	return nil
+}
+
 var configureCmd = &cobra.Command{
 	Use:   "configure",
 	Short: "Configure model settings",
@@ -65,107 +116,112 @@ var configureCmd = &cobra.Command{
 		// Get config path from environment or default
 		configPath := config.GetEnvPath()
 
-		// Read existing configuration
-		var cfg Config
-		configData, err := os.ReadFile(configPath)
-		if err == nil {
-			err = yaml.Unmarshal(configData, &cfg)
-			if err != nil {
-				cfg.Providers = make(map[string]Provider)
-			}
-		} else {
-			cfg.Providers = make(map[string]Provider)
-		}
-
-		// Prompt for provider
-		var provider string
-		for {
-			fmt.Print("Enter provider (openai/anthropic/ollama): ")
-			provider, _ = reader.ReadString('\n')
-			provider = strings.TrimSpace(provider)
-			if provider == "openai" || provider == "anthropic" || provider == "ollama" {
-				break
-			}
-			fmt.Println("Invalid provider. Please enter 'openai', 'anthropic' or 'ollama'")
-		}
-
-		// Special handling for ollama provider
-		if provider == "ollama" {
-			if !checkOllamaInstalled() {
-				fmt.Println("Error: Ollama is not installed or not running. Please install ollama and try again.")
+		// Load existing configuration
+		envConfig, err := config.LoadEnvConfig(configPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				envConfig = &config.EnvConfig{
+					Providers: make(map[string]*config.Provider),
+				}
+			} else {
+				fmt.Printf("Error loading configuration: %v\n", err)
 				return
 			}
 		}
 
-		// Check if provider exists
-		existingProvider, exists := cfg.Providers[provider]
-		var apiKey string
-		if !exists {
-			if provider != "ollama" {
-				// Only prompt for API key if not ollama
-				fmt.Print("Enter API key: ")
-				apiKey, _ = reader.ReadString('\n')
-				apiKey = strings.TrimSpace(apiKey)
-			}
-			existingProvider = Provider{
-				APIKey: apiKey,
-				Models: []Model{},
+		if serverFlag {
+			if err := configureServer(reader, envConfig); err != nil {
+				fmt.Printf("Error configuring server: %v\n", err)
+				return
 			}
 		} else {
-			apiKey = existingProvider.APIKey
-		}
-
-		// Prompt for model name
-		var modelName string
-		for {
-			if provider == "ollama" {
-				fmt.Print("Enter model name (must be pulled in ollama): ")
-			} else {
-				fmt.Print("Enter model name: ")
+			// Prompt for provider
+			var provider string
+			for {
+				fmt.Print("Enter provider (openai/anthropic/ollama): ")
+				provider, _ = reader.ReadString('\n')
+				provider = strings.TrimSpace(provider)
+				if provider == "openai" || provider == "anthropic" || provider == "ollama" {
+					break
+				}
+				fmt.Println("Invalid provider. Please enter 'openai', 'anthropic' or 'ollama'")
 			}
-			modelName, _ = reader.ReadString('\n')
-			modelName = strings.TrimSpace(modelName)
 
+			// Special handling for ollama provider
 			if provider == "ollama" {
-				if !isValidOllamaModel(modelName) {
-					fmt.Printf("Model '%s' is not available in ollama. Please pull it first using 'ollama pull %s'\n", modelName, modelName)
-					continue
+				if !checkOllamaInstalled() {
+					fmt.Println("Error: Ollama is not installed or not running. Please install ollama and try again.")
+					return
 				}
 			}
-			break
+
+			// Check if provider exists
+			existingProvider, err := envConfig.GetProviderConfig(provider)
+			var apiKey string
+			if err != nil {
+				if provider != "ollama" {
+					// Only prompt for API key if not ollama
+					fmt.Print("Enter API key: ")
+					apiKey, _ = reader.ReadString('\n')
+					apiKey = strings.TrimSpace(apiKey)
+				}
+				existingProvider = &config.Provider{
+					APIKey: apiKey,
+					Models: []config.Model{},
+				}
+				envConfig.AddProvider(provider, *existingProvider)
+			} else {
+				apiKey = existingProvider.APIKey
+			}
+
+			// Prompt for model name
+			var modelName string
+			for {
+				if provider == "ollama" {
+					fmt.Print("Enter model name (must be pulled in ollama): ")
+				} else {
+					fmt.Print("Enter model name: ")
+				}
+				modelName, _ = reader.ReadString('\n')
+				modelName = strings.TrimSpace(modelName)
+
+				if provider == "ollama" {
+					if !isValidOllamaModel(modelName) {
+						fmt.Printf("Model '%s' is not available in ollama. Please pull it first using 'ollama pull %s'\n", modelName, modelName)
+						continue
+					}
+				}
+				break
+			}
+
+			// Add new model to provider
+			modelType := "external"
+			if provider == "ollama" {
+				modelType = "local"
+			}
+
+			newModel := config.Model{
+				Name: modelName,
+				Type: modelType,
+			}
+
+			if err := envConfig.AddModelToProvider(provider, newModel); err != nil {
+				fmt.Printf("Error adding model: %v\n", err)
+				return
+			}
 		}
 
-		// Add new model to provider
-		modelType := "external"
-		if provider == "ollama" {
-			modelType = "local"
-		}
-
-		newModel := Model{
-			Name: modelName,
-			Type: modelType,
-		}
-		existingProvider.Models = append(existingProvider.Models, newModel)
-		cfg.Providers[provider] = existingProvider
-
-		// Ensure the directory exists
-		if dir := strings.TrimSuffix(configPath, "/"+filepath.Base(configPath)); dir != "" {
+		// Create parent directory if it doesn't exist
+		if dir := filepath.Dir(configPath); dir != "." && dir != "/" {
 			if err := os.MkdirAll(dir, 0755); err != nil {
 				fmt.Printf("Error creating directory: %v\n", err)
 				return
 			}
 		}
 
-		// Write updated configuration
-		yamlData, err := yaml.Marshal(&cfg)
-		if err != nil {
-			fmt.Printf("Error marshaling configuration: %v\n", err)
-			return
-		}
-
-		err = os.WriteFile(configPath, yamlData, 0644)
-		if err != nil {
-			fmt.Printf("Error writing configuration: %v\n", err)
+		// Save configuration
+		if err := config.SaveEnvConfig(configPath, envConfig); err != nil {
+			fmt.Printf("Error saving configuration: %v\n", err)
 			return
 		}
 
@@ -175,33 +231,40 @@ var configureCmd = &cobra.Command{
 
 func listConfiguration() {
 	configPath := config.GetEnvPath()
-	configData, err := os.ReadFile(configPath)
+	envConfig, err := config.LoadEnvConfig(configPath)
 	if err != nil {
 		fmt.Printf("No configuration found at %s\n", configPath)
 		return
 	}
 
-	var cfg Config
-	err = yaml.Unmarshal(configData, &cfg)
-	if err != nil {
-		fmt.Printf("Error reading configuration: %v\n", err)
-		return
+	fmt.Printf("Configuration from %s:\n\n", configPath)
+
+	// List server configuration if it exists
+	if server := envConfig.GetServerConfig(); server != nil {
+		fmt.Println("Server Configuration:")
+		fmt.Printf("Port: %d\n", server.Port)
+		fmt.Printf("Data Directory: %s\n", server.DataDir)
+		fmt.Printf("Authentication Enabled: %v\n", server.Enabled)
+		if server.BearerToken != "" {
+			fmt.Printf("Bearer Token: %s\n", server.BearerToken)
+		}
+		fmt.Println()
 	}
 
-	if len(cfg.Providers) == 0 {
+	// List providers
+	if len(envConfig.Providers) == 0 {
 		fmt.Println("No providers configured.")
 		return
 	}
 
-	fmt.Printf("Configuration from %s:\n\n", configPath)
 	fmt.Println("Configured Providers:")
-	for provider, data := range cfg.Providers {
-		fmt.Printf("\n%s:\n", provider)
-		if len(data.Models) == 0 {
+	for name, provider := range envConfig.Providers {
+		fmt.Printf("\n%s:\n", name)
+		if len(provider.Models) == 0 {
 			fmt.Println("  No models configured")
 			continue
 		}
-		for _, model := range data.Models {
+		for _, model := range provider.Models {
 			fmt.Printf("  - %s (%s)\n", model.Name, model.Type)
 		}
 	}
@@ -209,5 +272,6 @@ func listConfiguration() {
 
 func init() {
 	configureCmd.Flags().BoolVar(&listFlag, "list", false, "List all configured providers and models")
+	configureCmd.Flags().BoolVar(&serverFlag, "server", false, "Configure server settings")
 	rootCmd.AddCommand(configureCmd)
 }

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -14,7 +14,7 @@ import (
 
 var processCmd = &cobra.Command{
 	Use:   "process [files...]",
-	Short: "Process the DSL configuration",
+	Short: "Process YAML DSL configuration files",
 	Long:  `Process one or more DSL configuration files and execute the specified actions.`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,326 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/processor"
+)
+
+type ProcessResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Output  string `json:"output,omitempty"`
+}
+
+type HealthResponse struct {
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp"`
+}
+
+type ListResponse struct {
+	Success bool     `json:"success"`
+	Files   []string `json:"files"`
+	Error   string   `json:"error,omitempty"`
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func logRequest(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Create wrapped response writer to capture status code
+		wrapped := &responseWriter{w, http.StatusOK}
+
+		// Log request details
+		fmt.Printf("\n[%s] %s %s\n", start.Format("2006-01-02 15:04:05"), r.Method, r.URL.Path)
+		fmt.Printf("Query Parameters: %s\n", r.URL.RawQuery)
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			fmt.Printf("Authorization: %s\n", strings.Replace(auth, auth[7:], "********", 1))
+		}
+
+		// Call the handler
+		handler(wrapped, r)
+
+		// Log response details
+		duration := time.Since(start)
+		fmt.Printf("Status: %d\n", wrapped.statusCode)
+		fmt.Printf("Duration: %v\n", duration)
+		fmt.Println(strings.Repeat("-", 80))
+	}
+}
+
+func checkAuth(serverConfig *config.ServerConfig, w http.ResponseWriter, r *http.Request) bool {
+	if !serverConfig.Enabled {
+		return true
+	}
+
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   "Authorization header required",
+		})
+		return false
+	}
+
+	parts := strings.Split(authHeader, " ")
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   "Invalid authorization header format",
+		})
+		return false
+	}
+
+	if parts[1] != serverConfig.BearerToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   "Invalid bearer token",
+		})
+		return false
+	}
+
+	return true
+}
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start HTTP server for processing YAML files",
+	Long:  `Start an HTTP server that processes YAML DSL configuration files via HTTP requests.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Load environment configuration
+		envConfig, err := config.LoadEnvConfig(config.GetEnvPath())
+		if err != nil {
+			log.Fatalf("Error loading environment configuration: %v", err)
+		}
+
+		// Get server configuration
+		serverConfig := envConfig.GetServerConfig()
+		if serverConfig == nil {
+			log.Fatal("Server configuration not found. Please run 'comanda configure --server' first")
+		}
+
+		// Create data directory if it doesn't exist
+		if err := os.MkdirAll(serverConfig.DataDir, 0755); err != nil {
+			log.Fatalf("Error creating data directory: %v", err)
+		}
+
+		// Health check endpoint
+		http.HandleFunc("/health", logRequest(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(HealthResponse{
+				Status:    "ok",
+				Timestamp: time.Now().Format(time.RFC3339),
+			})
+		}))
+
+		// List files endpoint
+		http.HandleFunc("/list", logRequest(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			if !checkAuth(serverConfig, w, r) {
+				return
+			}
+
+			files, err := filepath.Glob(filepath.Join(serverConfig.DataDir, "*.yaml"))
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				json.NewEncoder(w).Encode(ListResponse{
+					Success: false,
+					Error:   fmt.Sprintf("Error listing files: %v", err),
+				})
+				return
+			}
+
+			// Convert absolute paths to relative paths
+			var relFiles []string
+			for _, file := range files {
+				relFile, err := filepath.Rel(serverConfig.DataDir, file)
+				if err != nil {
+					continue
+				}
+				relFiles = append(relFiles, relFile)
+			}
+
+			json.NewEncoder(w).Encode(ListResponse{
+				Success: true,
+				Files:   relFiles,
+			})
+		}))
+
+		// Process endpoint
+		http.HandleFunc("/process", logRequest(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAuth(serverConfig, w, r) {
+				return
+			}
+			handleProcess(w, r, serverConfig)
+		}))
+
+		fmt.Printf("Starting server on port %d...\n", serverConfig.Port)
+		fmt.Printf("Data directory: %s\n", serverConfig.DataDir)
+		if serverConfig.Enabled {
+			fmt.Println("Authentication is enabled. Bearer token required.")
+			fmt.Printf("Example usage: curl -H 'Authorization: Bearer %s' 'http://localhost:%d/process?filename=examples/openai-example.yaml'\n",
+				serverConfig.BearerToken, serverConfig.Port)
+		} else {
+			fmt.Printf("Example usage: curl 'http://localhost:%d/process?filename=examples/openai-example.yaml'\n", serverConfig.Port)
+		}
+
+		if err := http.ListenAndServe(fmt.Sprintf(":%d", serverConfig.Port), nil); err != nil {
+			log.Fatalf("Server failed to start: %v", err)
+		}
+	},
+}
+
+func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.ServerConfig) {
+	w.Header().Set("Content-Type", "application/json")
+
+	// Only allow GET requests
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   "Only GET requests are supported",
+		})
+		return
+	}
+
+	// Get filename from query parameters
+	filename := r.URL.Query().Get("filename")
+	if filename == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   "filename parameter is required",
+		})
+		return
+	}
+
+	// If filename doesn't start with data directory, prepend it
+	if !strings.HasPrefix(filename, serverConfig.DataDir) {
+		filename = filepath.Join(serverConfig.DataDir, filename)
+	}
+
+	// Get environment file path
+	envPath := config.GetEnvPath()
+
+	// Load environment configuration
+	envConfig, err := config.LoadEnvConfig(envPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(ProcessResponse{
+				Success: false,
+				Error:   fmt.Sprintf("Environment file not found at %s", envPath),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Error loading environment configuration: %v", err),
+		})
+		return
+	}
+
+	// Read YAML file
+	yamlFile, err := os.ReadFile(filename)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Error reading YAML file: %v", err),
+		})
+		return
+	}
+
+	// Parse YAML into DSL config
+	var dslConfig processor.DSLConfig
+	err = yaml.Unmarshal(yamlFile, &dslConfig)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Error parsing YAML file: %v", err),
+		})
+		return
+	}
+
+	// Create a buffer to capture output
+	var buf bytes.Buffer
+
+	// Temporarily replace stdout
+	oldStdout := os.Stdout
+	pipeReader, pipeWriter, _ := os.Pipe()
+	os.Stdout = pipeWriter
+
+	// Create and run processor
+	proc := processor.NewProcessor(&dslConfig, envConfig, verbose)
+	err = proc.Process()
+
+	// Create a WaitGroup to ensure we capture all output
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Copy the output in a separate goroutine
+	go func() {
+		defer wg.Done()
+		io.Copy(&buf, pipeReader)
+	}()
+
+	// Restore stdout
+	pipeWriter.Close()
+	os.Stdout = oldStdout
+
+	// Wait for all output to be captured
+	wg.Wait()
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ProcessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Error processing DSL file: %v", err),
+			Output:  buf.String(),
+		})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(ProcessResponse{
+		Success: true,
+		Message: fmt.Sprintf("Successfully processed %s", filename),
+		Output:  buf.String(),
+	})
+}
+
+func init() {
+	rootCmd.AddCommand(serveCmd)
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced a new HTTP server functionality to process YAML DSL configuration files.
- Added server configuration options including port, data directory, and bearer token authentication.
- Implemented endpoints for processing files, listing available files, and health checks.
- Enhanced the configuration command to include server setup.
- Updated documentation to reflect new server capabilities and usage instructions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/configure.go`: Added server configuration functionality, including prompts for port, data directory, and bearer token. Integrated server configuration into the existing configuration command.
- `cmd/process.go`: Updated command description for processing YAML DSL configuration files.
- `cmd/serve.go`: Introduced a new command to start an HTTP server. Implemented endpoints for health checks, listing files, and processing files with optional authentication.
- `utils/config/env.go`: Added server configuration struct and methods for generating bearer tokens and updating server settings. Modified provider storage to use pointers.
- `README.md`: Updated documentation to include instructions for configuring and using the new HTTP server functionality, including endpoint details and example usage.
</details>

___
## User Description:
- added a serve command to provide an http server
- processing of chains can be triggered via http using the /process?filename route/query param
- the /list route will display the yaml chain files which can be processed
- the /health endpoint provides a basic heart beat
- comanda configure --server walks through the server config including data directory, port and bearer token security
- server config is also stored in the .env yaml file
