### PR TITLE
fix: re-encrypt after change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ go.work
 
 # Environment & Config
 .env
+.comanda_env
 *.env
 .env.*
 config.yaml


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced a new feature to remove a model by name from the configuration.
- Added password validation to ensure encryption passwords are at least 6 characters long.
- Implemented re-encryption of configuration files if they were previously encrypted.
- Enhanced user prompts for encryption and decryption passwords.
- Updated command flags to support the new remove functionality.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/configure.go`: - Added `removeFlag` to handle model removal by name.
- Implemented `validatePassword` function to ensure passwords are at least 6 characters long.
- Introduced `removeModel` function to remove a model from the configuration by name.
- Enhanced encryption process with password validation and re-encryption if the file was previously encrypted.
- Updated command execution logic to handle the new remove flag and re-encryption.
- Added a new command flag for model removal.
</details>

___
## User Description:
- fixed an issue when the encrypted env file was not re-encrypted after a change
- remove model from list lost branch fix
