### PR TITLE
feat: api key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ To remove a model from the configuration:
 comanda configure --remove <model-name>
 ```
 
+To update an API key for a provider (e.g., after key rotation):
+
+```bash
+comanda configure --update-key=<provider-name>
+```
+
+This will prompt you for the new API key and update it in the configuration. For example:
+
+```bash
+comanda configure --update-key=openai
+Enter new API key: sk-...
+Successfully updated API key for provider 'openai'
+```
+
 When configuring a model that already exists, you'll be prompted to update its mode. This allows you to change a model's capabilities without removing and re-adding it.
 
 Example configuration output:

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	listFlag    bool
-	serverFlag  bool
-	encryptFlag bool
-	removeFlag  string
+	listFlag      bool
+	serverFlag    bool
+	encryptFlag   bool
+	removeFlag    string
+	updateKeyFlag string
 )
 
 func checkOllamaInstalled() bool {
@@ -185,7 +186,18 @@ var configureCmd = &cobra.Command{
 			return
 		}
 
-		if removeFlag != "" {
+		if updateKeyFlag != "" {
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Print("Enter new API key: ")
+			apiKey, _ := reader.ReadString('\n')
+			apiKey = strings.TrimSpace(apiKey)
+
+			if err := envConfig.UpdateAPIKey(updateKeyFlag, apiKey); err != nil {
+				fmt.Printf("Error updating API key: %v\n", err)
+				return
+			}
+			fmt.Printf("Successfully updated API key for provider '%s'\n", updateKeyFlag)
+		} else if removeFlag != "" {
 			if err := removeModel(envConfig, removeFlag); err != nil {
 				fmt.Printf("Error: %v\n", err)
 				return
@@ -360,5 +372,6 @@ func init() {
 	configureCmd.Flags().BoolVar(&serverFlag, "server", false, "Configure server settings")
 	configureCmd.Flags().BoolVar(&encryptFlag, "encrypt", false, "Encrypt the configuration file")
 	configureCmd.Flags().StringVar(&removeFlag, "remove", "", "Remove a model by name")
+	configureCmd.Flags().StringVar(&updateKeyFlag, "update-key", "", "Update API key for specified provider")
 	rootCmd.AddCommand(configureCmd)
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced a new feature to update API keys for providers using the `comanda configure` command.
- Added a new flag `--update-key` to specify the provider whose API key needs to be updated.
- Implemented a prompt for users to enter the new API key, which is then updated in the configuration.
- Updated the README.md to include instructions on how to use the new API key update feature.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/configure.go`: - Added a new string variable `updateKeyFlag` to store the provider name for which the API key needs to be updated.
- Implemented logic to handle the `--update-key` flag, prompting the user for a new API key and updating it in the configuration.
- Registered the `--update-key` flag with the `configureCmd` command.
- `README.md`: - Added documentation for the new `--update-key` feature, including usage instructions and an example.
</details>

___
## User Description:
- Rotate provider API keys with comanda configure --update-key={provider}
