### PR TITLE
fix: add google to the new config style

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -83,6 +83,17 @@ func getXAIModels() []string {
 	}
 }
 
+func getGoogleModels() []string {
+	return []string{
+		"gemini-1.5-flash",
+		"gemini-1.5-flash-8b",
+		"gemini-1.5-pro",
+		"gemini-1.0-pro",
+		"text-embedding-004",
+		"aqa",
+	}
+}
+
 func getOllamaModels() ([]OllamaModel, error) {
 	resp, err := http.Get("http://localhost:11434/api/tags")
 	if err != nil {
@@ -539,6 +550,18 @@ var configureCmd = &cobra.Command{
 					return
 				}
 
+			case "google":
+				if apiKey == "" {
+					fmt.Println("Error: API key is required for Google")
+					return
+				}
+				models := getGoogleModels()
+				selectedModels, err = promptForModelSelection(models)
+				if err != nil {
+					fmt.Printf("Error selecting models: %v\n", err)
+					return
+				}
+
 			case "ollama":
 				models, err := getOllamaModels()
 				if err != nil {
@@ -557,27 +580,6 @@ var configureCmd = &cobra.Command{
 				if err != nil {
 					fmt.Printf("Error selecting models: %v\n", err)
 					return
-				}
-
-			default:
-				// For other providers (currently just Google)
-				for {
-					if provider == "google" {
-						fmt.Print("Enter model name (e.g., gemini-pro): ")
-					} else {
-						fmt.Print("Enter model name: ")
-					}
-					modelName, _ := reader.ReadString('\n')
-					modelName = strings.TrimSpace(modelName)
-
-					if provider == "google" {
-						if !strings.HasPrefix(modelName, "gemini-") {
-							fmt.Println("Invalid model name. Google models should start with 'gemini-'")
-							continue
-						}
-					}
-					selectedModels = []string{modelName}
-					break
 				}
 			}
 

--- a/examples/analyze-csv.yaml
+++ b/examples/analyze-csv.yaml
@@ -1,3 +1,5 @@
+# This example shows how to use csv as input and requires the openai provider to be configured
+# and the gpt-4o-mini model to be available.
 step_one:
   input: examples/test.csv
   model: gpt-4o-mini

--- a/utils/models/google.go
+++ b/utils/models/google.go
@@ -40,13 +40,10 @@ func (g *GoogleProvider) debugf(format string, args ...interface{}) {
 	}
 }
 
-// SupportsModel checks if the given model name is supported by Google
-func (g *GoogleProvider) SupportsModel(modelName string) bool {
-	g.debugf("Checking if model is supported: %s", modelName)
-	modelName = strings.ToLower(modelName)
-
-	// Support all Google AI models
-	supportedModels := []string{
+// ValidateModel checks if the specific Google model variant is valid
+func (g *GoogleProvider) ValidateModel(modelName string) bool {
+	g.debugf("Validating model: %s", modelName)
+	validModels := []string{
 		"gemini-1.5-flash",
 		"gemini-1.5-flash-8b",
 		"gemini-1.5-pro",
@@ -55,15 +52,22 @@ func (g *GoogleProvider) SupportsModel(modelName string) bool {
 		"aqa",
 	}
 
-	for _, model := range supportedModels {
-		if modelName == model {
-			g.debugf("Model %s is supported (exact match)", modelName)
+	modelName = strings.ToLower(modelName)
+	// Check exact matches
+	for _, valid := range validModels {
+		if modelName == valid {
+			g.debugf("Found exact model match: %s", modelName)
 			return true
 		}
 	}
 
-	g.debugf("Model %s is not supported", modelName)
+	g.debugf("Model %s validation failed - no matches found", modelName)
 	return false
+}
+
+// SupportsModel checks if the given model name is supported by Google
+func (g *GoogleProvider) SupportsModel(modelName string) bool {
+	return g.ValidateModel(modelName)
 }
 
 // Configure sets up the provider with necessary credentials
@@ -86,7 +90,7 @@ func (g *GoogleProvider) SendPrompt(modelName string, prompt string) (string, er
 		return "", fmt.Errorf("Google provider not configured: missing API key")
 	}
 
-	if !g.SupportsModel(modelName) {
+	if !g.ValidateModel(modelName) {
 		return "", fmt.Errorf("invalid Google model: %s", modelName)
 	}
 
@@ -139,7 +143,7 @@ func (g *GoogleProvider) SendPromptWithFile(modelName string, prompt string, fil
 		return "", fmt.Errorf("Google provider not configured: missing API key")
 	}
 
-	if !g.SupportsModel(modelName) {
+	if !g.ValidateModel(modelName) {
 		return "", fmt.Errorf("invalid Google model: %s", modelName)
 	}
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced a new function `getGoogleModels` to list supported Google models.
- Updated the configuration command to handle Google provider with a new model selection process.
- Replaced the `SupportsModel` function with `ValidateModel` in the Google provider for better model validation.
- Updated examples to include a note about the required configuration for using CSV input.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/configure.go`: Added a new function `getGoogleModels` to return a list of supported Google models. Updated the `configureCmd` to include a case for the Google provider, requiring an API key and using the new model selection process.
- `utils/models/google.go`: Renamed `SupportsModel` to `ValidateModel` for better clarity. The function now checks for exact matches of valid Google models. Updated `SendPrompt` and `SendPromptWithFile` methods to use `ValidateModel`.
- `examples/analyze-csv.yaml`: Added comments to specify that the example requires the OpenAI provider to be configured and the `gpt-4o-mini` model to be available.
</details>

___
## User Description:
- oops forgot to apply the same treatment to the google provider
