### PR TITLE
fix: resolve discrepencies on dsl parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/google/generative-ai-go v0.18.0
 	github.com/kbinani/screenshot v0.0.0-20240820160931-a8a2c5d0e191
+	github.com/lib/pq v1.10.9
 	github.com/sashabaranov/go-openai v1.32.3
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/image v0.21.0
 	golang.org/x/term v0.25.0
 	google.golang.org/api v0.205.0
@@ -26,6 +28,7 @@ require (
 	github.com/antchfx/htmlquery v1.2.3 // indirect
 	github.com/antchfx/xmlquery v1.3.1 // indirect
 	github.com/antchfx/xpath v1.1.10 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gen2brain/shm v0.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -41,8 +44,8 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/kennygrant/sanitize v1.2.4 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/temoto/robotstxt v1.1.1 // indirect

--- a/utils/server/handlers_test.go
+++ b/utils/server/handlers_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/processor"
+	"gopkg.in/yaml.v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYAMLParsingParity(t *testing.T) {
+	// Sample YAML that uses STDIN input (similar to stdin-example.yaml)
+	yamlContent := []byte(`
+analyze_text:
+  input: STDIN
+  model: gpt-4o
+  action: "Analyze the following text and provide key insights:"
+  output: STDOUT
+
+summarize:
+  input: STDIN
+  model: gpt-4o-mini
+  action: "Summarize the analysis in 3 bullet points:"
+  output: STDOUT
+`)
+
+	// CLI-style parsing (from cmd/process.go)
+	var cliRawConfig map[string]processor.StepConfig
+	err := yaml.Unmarshal(yamlContent, &cliRawConfig)
+	assert.NoError(t, err, "CLI parsing should not error")
+
+	var cliConfig processor.DSLConfig
+	for name, config := range cliRawConfig {
+		cliConfig.Steps = append(cliConfig.Steps, processor.Step{
+			Name:   name,
+			Config: config,
+		})
+	}
+
+	// Server-style parsing (from utils/server/handlers.go)
+	var serverRawConfig map[string]processor.StepConfig
+	err = yaml.Unmarshal(yamlContent, &serverRawConfig)
+	assert.NoError(t, err, "Server parsing should not error")
+
+	var serverConfig processor.DSLConfig
+	for name, config := range serverRawConfig {
+		serverConfig.Steps = append(serverConfig.Steps, processor.Step{
+			Name:   name,
+			Config: config,
+		})
+	}
+
+	// Verify both methods produce identical results
+	assert.Equal(t, len(cliConfig.Steps), len(serverConfig.Steps), 
+		"CLI and server should parse the same number of steps")
+
+	// Compare each step in detail
+	for i := 0; i < len(cliConfig.Steps); i++ {
+		cliStep := cliConfig.Steps[i]
+		serverStep := serverConfig.Steps[i]
+
+		assert.Equal(t, cliStep.Name, serverStep.Name, 
+			"Step names should match for step %d", i)
+		
+		// Compare StepConfig fields
+		assert.Equal(t, cliStep.Config.Input, serverStep.Config.Input, 
+			"Input should match for step %s", cliStep.Name)
+		assert.Equal(t, cliStep.Config.Model, serverStep.Config.Model, 
+			"Model should match for step %s", cliStep.Name)
+		assert.Equal(t, cliStep.Config.Action, serverStep.Config.Action, 
+			"Action should match for step %s", cliStep.Name)
+		assert.Equal(t, cliStep.Config.Output, serverStep.Config.Output, 
+			"Output should match for step %s", cliStep.Name)
+		assert.Equal(t, cliStep.Config.NextAction, serverStep.Config.NextAction, 
+			"NextAction should match for step %s", cliStep.Name)
+	}
+
+	// Verify both configs can be processed
+	cliProc := processor.NewProcessor(&cliConfig, nil, true)
+	assert.NotNil(t, cliProc, "CLI processor should be created successfully")
+
+	serverProc := processor.NewProcessor(&serverConfig, nil, true)
+	assert.NotNil(t, serverProc, "Server processor should be created successfully")
+}
+
+// Test that direct DSLConfig parsing fails for our YAML format
+func TestDirectDSLConfigParsing(t *testing.T) {
+	yamlContent := []byte(`
+analyze_text:
+  input: STDIN
+  model: gpt-4o
+  action: "Test action"
+  output: STDOUT
+`)
+
+	// Try parsing directly into DSLConfig (the old way that caused the bug)
+	var dslConfig processor.DSLConfig
+	err := yaml.Unmarshal(yamlContent, &dslConfig)
+	
+	// This should result in a DSLConfig with no steps
+	assert.NoError(t, err, "Parsing should not error")
+	assert.Empty(t, dslConfig.Steps, 
+		"Direct parsing into DSLConfig should result in no steps due to YAML structure mismatch")
+}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Adjusted YAML parsing in the server to match the CLI's approach.
- Introduced tests to ensure parsing consistency between server and CLI.
- Updated dependencies in `go.mod` to include necessary testing libraries.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/server/handlers.go`: Modified the YAML parsing logic to first unmarshal into a map to preserve step names, similar to the CLI. Then, converted the map into an ordered slice of steps for processing.
- `utils/server/handlers_test.go`: Added a new test suite to verify that YAML parsing results are consistent between the server and CLI. The tests ensure that both methods produce identical results and validate that direct parsing into `DSLConfig` fails as expected.
- `go.mod`: Updated to include new dependencies: `github.com/lib/pq`, `github.com/stretchr/testify`, and `github.com/davecgh/go-spew` for testing purposes.
</details>

___
## User Description:
- align parsing between server and cli
- tests to ensure this remains aligned for future builds
