### PR TITLE
Scraping Use Case Updates

### DIFF
--- a/examples/web-scraping/scrape-example.yaml
+++ b/examples/web-scraping/scrape-example.yaml
@@ -1,15 +1,16 @@
 scrape_webpage:
-    input: https://example.com
-    model: gpt-4o-mini
+    input:
+        url: https://github.com
+        scrape_config:
+            allowed_domains:
+                - github.com
+            headers:
+                Accept: text/html,application/xhtml+xml
+                Accept-Language: en-US,en;q=0.9
+            extract:
+                - title
+                - text
+                - links
+    model: deepseek-r1:1.5b
     action: Analyze the scraped content and provide insights
     output: STDOUT
-    scrape_config:
-        allowed_domains:
-            - example.com
-        headers:
-            Accept: text/html,application/xhtml+xml
-            Accept-Language: en-US,en;q=0.9
-        extract:
-            - title
-            - text
-            - links

--- a/utils/models/deepseek.go
+++ b/utils/models/deepseek.go
@@ -45,7 +45,17 @@ func (d *DeepseekProvider) SupportsModel(modelName string) bool {
 	d.debugf("Checking if model is supported: %s", modelName)
 	modelName = strings.ToLower(modelName)
 
-	// Accept any model name that starts with deepseek-
+	// Special case for deepseek-r1: only support if API key is configured
+	if strings.HasPrefix(modelName, "deepseek-r1") {
+		if d.apiKey == "" {
+			d.debugf("Deepseek API key not configured; not claiming support for model %s", modelName)
+			return false
+		}
+		d.debugf("Deepseek API key configured; supporting model %s", modelName)
+		return true
+	}
+
+	// Accept any other model name that starts with deepseek-
 	if strings.HasPrefix(modelName, "deepseek-") {
 		d.debugf("Model %s is supported", modelName)
 		return true

--- a/utils/models/ollama.go
+++ b/utils/models/ollama.go
@@ -72,6 +72,7 @@ func (o *OllamaProvider) SupportsModel(modelName string) bool {
 		"yi",
 		"qwen",
 		"mixtral",
+		"deepseek-r1",
 	}
 
 	// Check if model starts with any known Ollama prefix

--- a/utils/models/provider.go
+++ b/utils/models/provider.go
@@ -49,7 +49,7 @@ func defaultDetectProvider(modelName string) Provider {
 	}
 
 	for _, provider := range providers {
-		log.Printf("[DEBUG][Provider] Checking if %s supports model %s", provider.Name(), modelName)
+		//log.Printf("[DEBUG][Provider] Checking if %s supports model %s", provider.Name(), modelName)
 		if provider.SupportsModel(modelName) {
 			log.Printf("[DEBUG][Provider] Found provider %s for model %s", provider.Name(), modelName)
 			return provider

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -262,7 +262,6 @@ func (p *Processor) Process() error {
 					p.emitError(err)
 					return fmt.Errorf("failed to process scraping input: %w", err)
 				}
-				inputs = []string{url}
 				p.spinner.Stop()
 			} else {
 				inputs = p.NormalizeStringSlice(step.Config.Input)

--- a/utils/scraper/scraper.go
+++ b/utils/scraper/scraper.go
@@ -1,7 +1,7 @@
 package scraper
 
 import (
-	"fmt"
+	"log"
 	"strings"
 
 	"github.com/gocolly/colly/v2"
@@ -101,11 +101,19 @@ func (s *Scraper) AllowedDomains(domains ...string) {
 				}
 			}
 			if !allowed {
-				fmt.Printf("[SCRAPER] Request aborted due to disallowed domain: %s\n", host)
-				r.Abort()
+				log.Printf("[SCRAPER] Request aborted due to disallowed domain: %s\n", host)
+				// Wrap the abort call to recover from any potential panic
+				func() {
+					defer func() {
+						if err := recover(); err != nil {
+							log.Printf("[SCRAPER] Error aborting request for disallowed domain %s: %v", host, err)
+						}
+					}()
+					r.Abort()
+				}()
 				return
 			}
 		}
 	})
-	fmt.Printf("[SCRAPER] Set allowed domains to: %v\n", domains)
+	log.Printf("[SCRAPER] Set allowed domains to: %v\n", domains)
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Added support for local deepseek-r1 model with API key validation.
- Enhanced the web scraping functionality by allowing domain restrictions.
- Updated the web scraping example YAML to reflect new configurations.
- Removed unnecessary verbose logging.
- Fixed bugs related to URL handling and domain restrictions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/models/deepseek.go`: Enhanced the SupportsModel function to include a special case for the "deepseek-r1" model, which now requires an API key to be configured for support.
- `utils/models/ollama.go`: Added "deepseek-r1" to the list of supported model prefixes for the OllamaProvider.
- `utils/models/provider.go`: Commented out a verbose debug log statement that was previously printing provider checks.
- `utils/processor/dsl.go`: Removed redundant assignment of the 'inputs' variable when processing scraping inputs.
- `utils/scraper/scraper.go`: Introduced domain restriction functionality in the Scraper by allowing only specified domains for scraping. Added logic to abort requests to disallowed domains.
- `examples/web-scraping/scrape-example.yaml`: Updated the YAML configuration to use a structured input format with URL and scrape configuration, including allowed domains and headers. Changed the model to "deepseek-r1:1.5b".
</details>

___
## User Description:
# Overview 
 - Restructured the web scraping example yaml file to match what is expected in the code
 - Allows running deepsekk-r1 locally with Ollama
 - Fixes a couple of bugs that came up while running the example workflow

<h2 dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold, 600); line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted)); color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Walkthrough</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The pull request updates the web scraping configuration and several provider and processing modules. The YAML example now uses a hierarchical input structure for scraping parameters and updates the model. Within the providers, the logic for supporting "deepseek-r1" has been refined with an API key check and additional model prefix support added. Logging in provider detection has been disabled, input processing in the DSL has been adjusted, and the scraper now enforces domain restrictions before processing requests.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold, 600); line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted)); color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
File(s) | Summary of Changes
-- | --
examples/web-scraping/scrape-example.yaml | Overhauled the scraping configuration: input structure is now nested (includes URL, scrape_config with allowed_domains, headers, extract) and model updated from gpt-4o-mini to deepseek-r1:1.5b.
utils/models/deepseek.go, utils/models/ollama.go | deepseek.go: Modified SupportsModel to require an API key for "deepseek-r1"; ollama.go: Added "deepseek-r1" prefix to supported models.
utils/models/provider.go | Commented out the debug log within defaultDetectProvider, disabling per-provider support logging.
utils/processor/dsl.go | Adjusted the Process method to remove the direct assignment of a URL string when handling map inputs with a "url" key.
utils/scraper/scraper.go | Added an allowedDomains field to the Scraper struct and updated the AllowedDomains method to enforce domain restrictions by aborting requests from disallowed domains with appropriate logging.

</markdown-accessiblity-table>

# Commits

- feat: support local deepseek

- refactor: remove verbose log statement

- fix: url not a path or an output

- fix: forbidden domain

- fix: scrape example yaml format
