### PR TITLE
feat: generate and process workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
             fi
             
             echo "Building for $GOOS/$GOARCH..."
-            GOOS=$GOOS GOARCH=$GOARCH go build -o "dist/$output_name" .
+            echo "Injecting version: ${{ env.NEW_VERSION }}"
+            GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-X 'github.com/kris-hansen/comanda/cmd.version=${{ env.NEW_VERSION }}'" -o "dist/$output_name" .
             if [ $? -ne 0 ]; then
               echo "Error building for $GOOS/$GOARCH"
               exit 1

--- a/README.md
+++ b/README.md
@@ -257,6 +257,28 @@ Enter new API key: sk-...
 Successfully updated API key for provider 'openai'
 ```
 
+### Setting Default Model for Generation
+
+You can set a default model for the `comanda generate` command, which creates YAML workflows from natural language prompts:
+
+```bash
+# Interactively set default model
+comanda configure --default
+
+# Or set directly
+comanda configure --set-default-generation-model gpt-4
+```
+
+Once set, you can use `comanda generate` without specifying a model:
+
+```bash
+# Uses the default model
+comanda generate my_workflow.yaml "Create a workflow to analyze CSV files"
+
+# Override the default with a specific model
+comanda generate my_workflow.yaml "Create a workflow to analyze CSV files" --model claude-3-opus
+```
+
 When configuring a model that already exists, you'll be prompted to update its mode. This allows you to change a model's capabilities without removing and re-adding it.
 
 Example configuration output:

--- a/cmd/configure_default_test.go
+++ b/cmd/configure_default_test.go
@@ -1,0 +1,235 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/spf13/cobra"
+)
+
+func TestConfigureDefaultFlag(t *testing.T) {
+	// Create a temporary directory for test
+	tempDir, err := os.MkdirTemp("", "comanda-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set up test environment
+	testEnvPath := filepath.Join(tempDir, ".env")
+	os.Setenv("COMANDA_ENV", testEnvPath)
+	defer os.Unsetenv("COMANDA_ENV")
+
+	// Create a test configuration with some models
+	testConfig := &config.EnvConfig{
+		Providers: map[string]*config.Provider{
+			"openai": {
+				APIKey: "test-key",
+				Models: []config.Model{
+					{Name: "gpt-4", Type: "external", Modes: []config.ModelMode{config.TextMode}},
+					{Name: "gpt-3.5-turbo", Type: "external", Modes: []config.ModelMode{config.TextMode}},
+				},
+			},
+			"anthropic": {
+				APIKey: "test-key",
+				Models: []config.Model{
+					{Name: "claude-3-opus", Type: "external", Modes: []config.ModelMode{config.TextMode}},
+				},
+			},
+		},
+	}
+
+	// Save the test configuration
+	if err := config.SaveEnvConfig(testEnvPath, testConfig); err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
+	}
+
+	// Test 1: Verify getAllConfiguredModelNames function
+	modelNames := getAllConfiguredModelNames(testConfig)
+	expectedModels := []string{"gpt-4", "gpt-3.5-turbo", "claude-3-opus"}
+
+	if len(modelNames) != len(expectedModels) {
+		t.Errorf("Expected %d models, got %d", len(expectedModels), len(modelNames))
+	}
+
+	// Check that all expected models are present
+	modelMap := make(map[string]bool)
+	for _, model := range modelNames {
+		modelMap[model] = true
+	}
+	for _, expected := range expectedModels {
+		if !modelMap[expected] {
+			t.Errorf("Expected model %s not found in configured models", expected)
+		}
+	}
+
+	// Test 2: Test the --default flag behavior with no configured models
+	emptyConfig := &config.EnvConfig{
+		Providers: map[string]*config.Provider{},
+	}
+	if err := config.SaveEnvConfig(testEnvPath, emptyConfig); err != nil {
+		t.Fatalf("Failed to save empty config: %v", err)
+	}
+
+	// Create a new command instance for testing
+	rootCmd := &cobra.Command{}
+	configureCmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Configure model settings",
+		Run: func(cmd *cobra.Command, args []string) {
+			// This would normally be the full configure command logic
+			// For testing, we'll just verify the flag is set
+			if defaultFlag {
+				envConfig, _ := config.LoadEnvConfig(testEnvPath)
+				models := getAllConfiguredModelNames(envConfig)
+				if len(models) == 0 {
+					// This is the expected behavior
+					return
+				}
+			}
+		},
+	}
+
+	configureCmd.Flags().BoolVar(&defaultFlag, "default", false, "Interactively set the default model for workflow generation")
+	rootCmd.AddCommand(configureCmd)
+
+	// Test with --default flag
+	defaultFlag = true
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"configure", "--default"})
+
+	// Execute should not error even with no models
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("Command execution failed: %v", err)
+	}
+
+	// Test 3: Verify that setting default model updates the configuration
+	testConfig.DefaultGenerationModel = "gpt-4"
+	if err := config.SaveEnvConfig(testEnvPath, testConfig); err != nil {
+		t.Fatalf("Failed to save config with default model: %v", err)
+	}
+
+	// Load and verify
+	loadedConfig, err := config.LoadEnvConfig(testEnvPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if loadedConfig.DefaultGenerationModel != "gpt-4" {
+		t.Errorf("Expected default model to be 'gpt-4', got '%s'", loadedConfig.DefaultGenerationModel)
+	}
+}
+
+func TestConfigureSetDefaultGenerationModelFlag(t *testing.T) {
+	// Create a temporary directory for test
+	tempDir, err := os.MkdirTemp("", "comanda-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set up test environment
+	testEnvPath := filepath.Join(tempDir, ".env")
+	os.Setenv("COMANDA_ENV", testEnvPath)
+	defer os.Unsetenv("COMANDA_ENV")
+
+	// Create a test configuration
+	testConfig := &config.EnvConfig{
+		Providers: map[string]*config.Provider{
+			"openai": {
+				APIKey: "test-key",
+				Models: []config.Model{
+					{Name: "gpt-4", Type: "external", Modes: []config.ModelMode{config.TextMode}},
+				},
+			},
+		},
+	}
+
+	if err := config.SaveEnvConfig(testEnvPath, testConfig); err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
+	}
+
+	// Test the --set-default-generation-model flag
+	setDefaultGenerationModelFlag = "gpt-4"
+
+	// Simulate the command logic
+	envConfig, err := config.LoadEnvConfig(testEnvPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	envConfig.DefaultGenerationModel = setDefaultGenerationModelFlag
+
+	if err := config.SaveEnvConfig(testEnvPath, envConfig); err != nil {
+		t.Fatalf("Failed to save updated config: %v", err)
+	}
+
+	// Verify the change
+	updatedConfig, err := config.LoadEnvConfig(testEnvPath)
+	if err != nil {
+		t.Fatalf("Failed to load updated config: %v", err)
+	}
+
+	if updatedConfig.DefaultGenerationModel != "gpt-4" {
+		t.Errorf("Expected default generation model to be 'gpt-4', got '%s'", updatedConfig.DefaultGenerationModel)
+	}
+}
+
+func TestListConfigurationWithDefaultModel(t *testing.T) {
+	// Create a temporary directory for test
+	tempDir, err := os.MkdirTemp("", "comanda-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set up test environment
+	testEnvPath := filepath.Join(tempDir, ".env")
+	os.Setenv("COMANDA_ENV", testEnvPath)
+	defer os.Unsetenv("COMANDA_ENV")
+
+	// Create a test configuration with default model
+	testConfig := &config.EnvConfig{
+		DefaultGenerationModel: "claude-3-opus",
+		Providers: map[string]*config.Provider{
+			"anthropic": {
+				APIKey: "test-key",
+				Models: []config.Model{
+					{Name: "claude-3-opus", Type: "external", Modes: []config.ModelMode{config.TextMode}},
+				},
+			},
+		},
+	}
+
+	if err := config.SaveEnvConfig(testEnvPath, testConfig); err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
+	}
+
+	// Capture output
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Call listConfiguration
+	listConfiguration()
+
+	// Restore stdout
+	w.Close()
+	os.Stdout = oldStdout
+
+	// Read captured output
+	buf := make([]byte, 1024)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	// Verify default model is displayed
+	if !strings.Contains(output, "Default Generation Model: claude-3-opus") {
+		t.Errorf("Expected output to contain default generation model, got: %s", output)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,12 +5,18 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/config"    // Required for input.Input
+	"github.com/kris-hansen/comanda/utils/models"    // Required for models.DetectProvider
+	"github.com/kris-hansen/comanda/utils/processor" // Required for EmbeddedLLMGuide
 	"github.com/spf13/cobra"
 )
 
+// version is a placeholder for the version string, which will be set at build time.
+var version string
+
 var verbose bool
 var debug bool
+var generateModelName string // Flag for specifying model in generateCmd
 
 var rootCmd = &cobra.Command{
 	Use:   "comanda",
@@ -26,9 +32,145 @@ for model interactions and executes the specified actions.`,
 	},
 }
 
+var generateCmd = &cobra.Command{
+	Use:   "generate <output_filename.yaml> \"<prompt_for_workflow_generation>\"",
+	Short: "Generate a new Comanda workflow YAML file using an LLM",
+	Long: `Generates a new Comanda workflow YAML file based on a natural language prompt.
+The generated workflow is saved to the specified output filename.
+You can optionally specify a model to use for generation, otherwise the default_generation_model from your configuration will be used.`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return fmt.Errorf("requires exactly two arguments: <output_filename.yaml> and \"<prompt_for_workflow_generation>\"\nExample: comanda generate my_workflow.yaml \"Create a workflow to summarize a file and save it.\"")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outputFilename := args[0]
+		userPrompt := args[1]
+
+		configPath := config.GetEnvPath()
+		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
+		if err != nil {
+			return fmt.Errorf("error loading configuration: %w", err)
+		}
+
+		modelForGeneration := generateModelName // From flag
+		if modelForGeneration == "" {
+			modelForGeneration = envConfig.DefaultGenerationModel
+		}
+		if modelForGeneration == "" {
+			return fmt.Errorf("no model specified for generation and no default_generation_model configured. Use --model or configure a default")
+		}
+
+		fmt.Printf("Generating workflow using model: %s\n", modelForGeneration)
+		fmt.Printf("Output file: %s\n", outputFilename)
+
+		// Prepare the full prompt for the LLM
+		// Use the embedded guide instead of reading from file
+		dslGuide := processor.EmbeddedLLMGuide
+
+		fullPrompt := fmt.Sprintf(`SYSTEM: You are a YAML generator. You MUST output ONLY valid YAML content. No explanations, no markdown, no code blocks, no commentary - just raw YAML.
+
+--- BEGIN COMANDA DSL SPECIFICATION ---
+%s
+--- END COMANDA DSL SPECIFICATION ---
+
+User's request: %s
+
+CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.`,
+			dslGuide, userPrompt)
+
+		// Get the provider
+		// Note: This assumes models.DetectProvider and provider.Configure are correctly set up.
+		// The provider instance needs to be configured with an API key.
+		// This logic might need to be more robust, potentially calling a configure method on the provider.
+		provider := models.DetectProvider(modelForGeneration)
+		if provider == nil {
+			return fmt.Errorf("could not detect provider for model: %s", modelForGeneration)
+		}
+
+		// Attempt to configure the provider with API key from envConfig
+		providerConfig, err := envConfig.GetProviderConfig(provider.Name())
+		if err != nil {
+			// If provider is not in envConfig, it might be a public one like Ollama, or an error
+			fmt.Printf("Warning: Provider %s not found in env configuration. Assuming it does not require an API key or is pre-configured.\n", provider.Name())
+		} else {
+			if err := provider.Configure(providerConfig.APIKey); err != nil {
+				return fmt.Errorf("failed to configure provider %s: %w", provider.Name(), err)
+			}
+		}
+		provider.SetVerbose(verbose)
+
+		// Call the LLM
+		// The SendPrompt method is part of the models.Provider interface.
+		generatedResponse, err := provider.SendPrompt(modelForGeneration, fullPrompt)
+		if err != nil {
+			return fmt.Errorf("LLM execution failed for model '%s': %w", modelForGeneration, err)
+		}
+
+		// Extract YAML content from the response
+		yamlContent := generatedResponse
+
+		// Check if the response contains code blocks
+		if strings.Contains(generatedResponse, "```yaml") {
+			// Extract content between ```yaml and ```
+			startMarker := "```yaml"
+			endMarker := "```"
+
+			startIdx := strings.Index(generatedResponse, startMarker)
+			if startIdx != -1 {
+				startIdx += len(startMarker)
+				// Find the next ``` after the start marker
+				remaining := generatedResponse[startIdx:]
+				endIdx := strings.Index(remaining, endMarker)
+				if endIdx != -1 {
+					yamlContent = strings.TrimSpace(remaining[:endIdx])
+				}
+			}
+		} else if strings.Contains(generatedResponse, "```") {
+			// Try generic code block
+			parts := strings.Split(generatedResponse, "```")
+			if len(parts) >= 3 {
+				// Take the content of the first code block
+				yamlContent = strings.TrimSpace(parts[1])
+				// Remove language identifier if present (e.g., "yaml" at the start)
+				lines := strings.Split(yamlContent, "\n")
+				if len(lines) > 0 && !strings.Contains(lines[0], ":") {
+					yamlContent = strings.Join(lines[1:], "\n")
+				}
+			}
+		}
+
+		// Save the generated YAML to the output file
+		if err := os.WriteFile(outputFilename, []byte(yamlContent), 0644); err != nil {
+			return fmt.Errorf("failed to write generated workflow to '%s': %w", outputFilename, err)
+		}
+
+		fmt.Printf("\n%s Workflow successfully generated and saved to %s\n", "\u2705", outputFilename)
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging")
+	generateCmd.Flags().StringVarP(&generateModelName, "model", "m", "", "Model to use for workflow generation (optional, uses default if not set)")
+	rootCmd.AddCommand(generateCmd)
+	rootCmd.AddCommand(versionCmd) // Add the version command
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of Comanda",
+	Long:  `All software has versions. This is Comanda's.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if version == "" {
+			fmt.Println("Comanda version: unknown (not set at build time)")
+		} else {
+			fmt.Printf("Comanda version: %s\n", version)
+		}
+	},
 }
 
 func Execute() {
@@ -39,8 +181,13 @@ func Execute() {
 	if err != nil {
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "unknown command") {
-			cmd := strings.Trim(strings.TrimPrefix(errMsg, "unknown command"), `"`+` for "comanda"`)
-			fmt.Printf("To process a file, use the 'process' command:\n\n   comanda process %s\n\n", cmd)
+			cmdPath := strings.Trim(strings.TrimPrefix(errMsg, "unknown command"), `"`+` for "comanda"`)
+			// Check if the unknown command might be a filename intended for 'process'
+			if _, statErr := os.Stat(cmdPath); statErr == nil || os.IsNotExist(statErr) { // if it exists or looks like a path
+				fmt.Printf("To process a file, use the 'process' command:\n\n   comanda process %s\n\n", cmdPath)
+			} else {
+				fmt.Fprintln(os.Stderr, err) // Default error for other unknown commands
+			}
 		} else {
 			fmt.Fprintln(os.Stderr, err)
 		}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,7 +20,6 @@ components:
       properties:
         success:
           type: boolean
-          enum: [true]
         message:
           type: string
       required:
@@ -31,7 +30,6 @@ components:
       properties:
         success:
           type: boolean
-          enum: [false]
         error:
           type: string
       required:
@@ -66,7 +64,6 @@ components:
       properties:
         success:
           type: boolean
-          enum: [true]
         providers:
           type: array
           items:
@@ -118,7 +115,6 @@ components:
       properties:
         success:
           type: boolean
-          enum: [true]
         models:
           type: array
           items:
@@ -131,7 +127,6 @@ components:
       properties:
         success:
           type: boolean
-          enum: [true]
         models:
           type: array
           items:
@@ -218,7 +213,6 @@ components:
       properties:
         success:
           type: boolean
-          enum: [true]
         files:
           type: array
           items:
@@ -242,9 +236,9 @@ components:
       properties:
         files:
           type: array
+          description: List of file paths to delete
           items:
             type: string
-          description: List of file paths to delete
       required:
         - files
 
@@ -1148,6 +1142,96 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /generate:
+    post:
+      summary: Generate Workflow YAML
+      description: |
+        Generate a new Comanda workflow YAML file using an LLM based on a natural language prompt.
+        The endpoint uses the specified model or falls back to the default_generation_model from configuration.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                prompt:
+                  type: string
+                  description: Natural language description of the workflow to create
+                model:
+                  type: string
+                  description: Optional model to use for generation (uses default_generation_model if not specified)
+              required:
+                - prompt
+            example:
+              prompt: "Create a workflow to read a CSV file and summarize its contents"
+              model: "gpt-4o-mini"
+      responses:
+        '200':
+          description: Workflow generated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  yaml:
+                    type: string
+                    description: Generated YAML workflow content
+                  model:
+                    type: string
+                    description: Model used for generation
+                required:
+                  - success
+                  - yaml
+                  - model
+              example:
+                success: true
+                yaml: |
+                  step_one:
+                    model: gpt-4o-mini
+                    input: FILE
+                    action: Read the CSV file and analyze its structure
+                    output: STDOUT
+                  
+                  step_two:
+                    model: gpt-4o-mini
+                    input: LAST_OUTPUT
+                    action: Summarize the CSV data
+                    output: STDOUT
+                model: "gpt-4o-mini"
+        '400':
+          description: Bad request (e.g., missing prompt or no model configured)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_prompt:
+                  value:
+                    success: false
+                    error: "Prompt is required"
+                no_model:
+                  value:
+                    success: false
+                    error: "No model specified and no default_generation_model configured"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error (e.g., LLM execution failed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                success: false
+                error: "LLM execution failed: connection timeout"
 
   /process:
     post:

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -371,6 +371,45 @@ data: Processing step 2...
 data: Processing complete
 ```
 
+### Generate Endpoint
+
+The generate endpoint allows you to generate Comanda workflow YAML files using an LLM based on natural language prompts.
+
+#### Generate Workflow
+```http
+POST /generate
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "prompt": "Create a workflow to summarize a file and save it",
+  "model": "gpt-4o-mini"  # Optional, uses default_generation_model if not specified
+}
+```
+
+Generates a new Comanda workflow YAML file based on the provided prompt.
+
+Request parameters:
+- `prompt` (required): Natural language description of the workflow you want to create
+- `model` (optional): Specific model to use for generation. If not provided, uses the `default_generation_model` from configuration
+
+Response:
+```json
+{
+  "success": true,
+  "yaml": "step_one:\n  model: gpt-4o-mini\n  input: FILE\n  ...",
+  "model": "gpt-4o-mini"
+}
+```
+
+Error response:
+```json
+{
+  "success": false,
+  "error": "No model specified and no default_generation_model configured"
+}
+```
+
 ### Process Endpoint
 
 The process endpoint handles YAML file processing via POST requests only, supporting both regular and streaming responses.
@@ -543,6 +582,22 @@ curl -H "Authorization: Bearer your-token" \
      --output downloaded_file.pdf
 ```
 
+9. Generate Workflow:
+```bash
+curl -X POST \
+     -H "Authorization: Bearer your-token" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt":"Create a workflow to read a CSV file and summarize its contents"}' \
+     http://localhost:8080/generate
+
+# With specific model
+curl -X POST \
+     -H "Authorization: Bearer your-token" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt":"Create a workflow to analyze sentiment from user input","model":"gpt-4o"}' \
+     http://localhost:8080/generate
+```
+
 ### Using JavaScript
 
 ```javascript
@@ -701,6 +756,21 @@ async function downloadFile(path) {
   return await response.blob();
 }
 
+// Generate workflow
+async function generateWorkflow(prompt, model = null) {
+  const body = { prompt };
+  if (model) {
+    body.model = model;
+  }
+  
+  const response = await fetch(`${API_URL}/generate`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+  return await response.json();
+}
+
 // Example usage
 async function example() {
   try {
@@ -731,6 +801,19 @@ async function example() {
     // Create a file
     const createResult = await createFile('example.yaml', 'file content');
     console.log('Create result:', createResult);
+
+    // Generate a workflow
+    const generateResult = await generateWorkflow(
+      'Create a workflow to read a CSV file and summarize its contents'
+    );
+    console.log('Generated YAML:', generateResult.yaml);
+
+    // Generate with specific model
+    const generateWithModel = await generateWorkflow(
+      'Create a workflow to analyze sentiment from user input',
+      'gpt-4o'
+    );
+    console.log('Generated with model:', generateWithModel.model);
   } catch (error) {
     console.error('Error:', error);
   }

--- a/examples/generate-process-advanced-example.yaml
+++ b/examples/generate-process-advanced-example.yaml
@@ -1,0 +1,35 @@
+# Advanced example demonstrating generate and process tags with data passing
+# This workflow generates a YAML file that creates multiple haikus, then processes it
+
+set_haiku_theme:
+  input: NA
+  model: gpt-4o-mini
+  action: "Choose a random theme for haikus from: nature, technology, seasons, or emotions. Just output the single word theme."
+  output: STDOUT as $theme
+
+generate_haiku_collection_workflow:
+  input: $theme
+  generate:
+    model: gpt-4o-mini
+    action: |
+      Create a Comanda workflow YAML file that:
+      1. Has three steps: 'haiku_one', 'haiku_two', and 'haiku_three'
+      2. Each step should:
+         - Use input: NA
+         - Use model: gpt-4o-mini
+         - Have an action that creates a haiku about the theme provided in the input (which will be passed as $parent.theme)
+         - Output to STDOUT
+      3. Include a fourth step 'combine_haikus' that:
+         - Uses input: STDIN (to get the previous haiku)
+         - Uses model: gpt-4o-mini
+         - Action: "Take the previous haiku and add a title 'Haiku Collection: [theme]' at the top, where [theme] is $parent.theme"
+         - Outputs to: haiku_collection.txt
+      Make sure to reference $parent.theme in the actions.
+    output: generated_haiku_collection.yaml
+
+execute_haiku_collection:
+  input: NA
+  process:
+    workflow_file: generated_haiku_collection.yaml
+    inputs: 
+      theme: $theme

--- a/examples/generate-process-example.yaml
+++ b/examples/generate-process-example.yaml
@@ -1,0 +1,20 @@
+# Example demonstrating generate and process tags
+# This workflow generates a YAML file with a haiku, then processes it
+
+generate_haiku_workflow:
+  input: NA
+  generate:
+    model: gpt-4o-mini
+    action: |
+      Create a Comanda workflow YAML file that:
+      1. Has a single step called 'create_haiku'
+      2. Uses gpt-4o-mini model
+      3. The action should be to write a beautiful haiku about coding
+      4. Outputs to STDOUT
+      Make it simple and elegant.
+    output: generated_haiku_workflow.yaml
+
+execute_haiku_workflow:
+  input: NA
+  process:
+    workflow_file: generated_haiku_workflow.yaml

--- a/examples/generate-process-examples-README.md
+++ b/examples/generate-process-examples-README.md
@@ -1,0 +1,88 @@
+# Generate and Process Examples
+
+This directory contains examples demonstrating Comanda's meta-processing capabilities using the `generate` and `process` tags.
+
+## Overview
+
+Comanda supports dynamic workflow generation where:
+- The `generate` tag uses an LLM to create a new Comanda workflow YAML file
+- The `process` tag executes another Comanda workflow file (either static or dynamically generated)
+
+## Examples
+
+### 1. Basic Example: `generate-process-example.yaml`
+
+This simple example demonstrates:
+- **Step 1**: Uses the `generate` tag to create a workflow that generates a haiku
+- **Step 2**: Uses the `process` tag to execute the generated workflow
+
+To run:
+```bash
+comanda process examples/generate-process-example.yaml
+```
+
+Expected behavior:
+1. First, it generates a file called `generated_haiku_workflow.yaml` containing a simple workflow
+2. Then it executes that workflow, which outputs a haiku about coding to the console
+
+### 2. Advanced Example: `generate-process-advanced-example.yaml`
+
+This more complex example demonstrates:
+- **Step 1**: Selects a random theme for haikus
+- **Step 2**: Uses the `generate` tag to create a workflow that:
+  - Creates three haikus based on the theme
+  - Combines them into a collection with a title
+- **Step 3**: Uses the `process` tag to execute the generated workflow, passing the theme as a parameter
+
+To run:
+```bash
+comanda process examples/generate-process-advanced-example.yaml
+```
+
+Expected behavior:
+1. Randomly selects a theme (nature, technology, seasons, or emotions)
+2. Generates a file called `generated_haiku_collection.yaml` with a multi-step workflow
+3. Executes that workflow, which creates three haikus and saves them to `haiku_collection.txt`
+
+Note: The generated `haiku_collection.txt` file can be viewed after the workflow completes.
+
+## Key Concepts
+
+### Generate Tag Structure
+```yaml
+step_name:
+  input: [optional context]
+  generate:
+    model: [LLM to use for generation]
+    action: [prompt describing the workflow to generate]
+    output: [filename for the generated YAML]
+```
+
+### Process Tag Structure
+```yaml
+step_name:
+  input: [optional input for the sub-workflow]
+  process:
+    workflow_file: [path to YAML file to execute]
+    inputs: [optional key-value pairs to pass to sub-workflow]
+```
+
+### Variable Passing
+- Parent workflow variables can be passed to child workflows using the `inputs` field
+- In the child workflow, these are accessed as `$parent.variable_name`
+
+## Use Cases
+
+This meta-processing capability is useful for:
+- Creating adaptive workflows based on input data
+- Generating specialized processing pipelines on demand
+- Building workflow templates that can be customized dynamically
+- Creating self-modifying or self-improving workflows
+
+## Clean Up
+
+After running these examples, you may want to clean up the generated files:
+```bash
+rm generated_haiku_workflow.yaml
+rm generated_haiku_collection.yaml
+rm haiku_collection.txt

--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -59,9 +59,10 @@ type Provider struct {
 
 // EnvConfig represents the complete environment configuration
 type EnvConfig struct {
-	Providers map[string]*Provider      `yaml:"providers"` // Changed to store pointers to Provider
-	Server    *ServerConfig             `yaml:"server,omitempty"`
-	Databases map[string]DatabaseConfig `yaml:"databases,omitempty"` // Added database configurations
+	Providers              map[string]*Provider      `yaml:"providers"` // Changed to store pointers to Provider
+	Server                 *ServerConfig             `yaml:"server,omitempty"`
+	Databases              map[string]DatabaseConfig `yaml:"databases,omitempty"` // Added database configurations
+	DefaultGenerationModel string                    `yaml:"default_generation_model,omitempty"`
 }
 
 // Verbose indicates whether verbose logging is enabled
@@ -537,4 +538,24 @@ func (c *DatabaseConfig) GetConnectionString() string {
 	default:
 		return ""
 	}
+}
+
+// GetAllConfiguredModels returns a list of all configured models across all providers
+func (c *EnvConfig) GetAllConfiguredModels() []string {
+	var models []string
+
+	if c.Providers == nil {
+		return models
+	}
+
+	for _, provider := range c.Providers {
+		if provider == nil {
+			continue
+		}
+		for _, model := range provider.Models {
+			models = append(models, model.Name)
+		}
+	}
+
+	return models
 }

--- a/utils/models/openai.go
+++ b/utils/models/openai.go
@@ -87,8 +87,8 @@ func (o *OpenAIProvider) Configure(apiKey string) error {
 // isNewModelSeries checks if the model is part of the newer series (4o, o1, o3, o4)
 func (o *OpenAIProvider) isNewModelSeries(modelName string) bool {
 	modelName = strings.ToLower(modelName)
-	return strings.Contains(modelName, "4o") || 
-		strings.HasPrefix(modelName, "o1-") || 
+	return strings.Contains(modelName, "4o") ||
+		strings.HasPrefix(modelName, "o1-") ||
 		strings.HasPrefix(modelName, "o3-") ||
 		strings.HasPrefix(modelName, "o4-") // Support for o4-mini series
 }

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -11,7 +11,23 @@ import (
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/input"
 	"github.com/kris-hansen/comanda/utils/models"
+	"gopkg.in/yaml.v3"
 )
+
+// GenerateStepConfig defines the configuration for a generate step
+type GenerateStepConfig struct {
+	Model        interface{} `yaml:"model"`
+	Action       interface{} `yaml:"action"`
+	Output       string      `yaml:"output"`
+	ContextFiles []string    `yaml:"context_files"`
+}
+
+// ProcessStepConfig defines the configuration for a process step
+type ProcessStepConfig struct {
+	WorkflowFile   string                 `yaml:"workflow_file"`
+	Inputs         map[string]interface{} `yaml:"inputs"`
+	CaptureOutputs []string               `yaml:"capture_outputs"`
+}
 
 // Processor handles the DSL processing pipeline
 type Processor struct {
@@ -50,9 +66,9 @@ func NewProcessor(config *DSLConfig, envConfig *config.EnvConfig, serverConfig *
 		validator:    input.NewValidator(nil),
 		providers:    make(map[string]models.Provider),
 		verbose:      verbose,
-		spinner:    NewSpinner(),
-		variables:  make(map[string]string),
-		runtimeDir: rd, // Store runtime directory
+		spinner:      NewSpinner(),
+		variables:    make(map[string]string),
+		runtimeDir:   rd, // Store runtime directory
 	}
 
 	// Store runtime directory as-is (relative or empty)
@@ -184,27 +200,76 @@ func (p *Processor) substituteVariables(text string) string {
 func (p *Processor) validateStepConfig(stepName string, config StepConfig) error {
 	var errors []string
 
-	// Check input field exists (can be empty or NA, but must be present)
-	if config.Input == nil {
-		errors = append(errors, "input tag is required (can be NA or empty, but the tag must be present)")
+	isGenerateStep := config.Generate != nil
+	isProcessStep := config.Process != nil
+	isStandardStep := !isGenerateStep && !isProcessStep && config.Type != "openai-responses" // Standard steps are not generate, process, or openai-responses
+	isOpenAIResponsesStep := config.Type == "openai-responses"
+
+	// Ensure a step is of one type only
+	typeCount := 0
+	if isStandardStep {
+		typeCount++
+	}
+	if isGenerateStep {
+		typeCount++
+	}
+	if isProcessStep {
+		typeCount++
+	}
+	if isOpenAIResponsesStep { // This is a specific type of standard step, handled slightly differently
+		// No increment here as it's a specialization of standard
 	}
 
-	// Check model field
-	modelNames := p.NormalizeStringSlice(config.Model)
-	if len(modelNames) == 0 {
-		errors = append(errors, "model is required (can be NA or a valid model name)")
+	if typeCount > 1 {
+		errors = append(errors, "a step can only be one type: standard, generate, or process")
+	}
+	if isGenerateStep && (config.Input != nil || config.Model != nil || config.Action != nil || config.Output != nil) {
+		// Allow Input: NA for generate steps if they don't need prior step's output
+		if val, ok := config.Input.(string); !ok || val != "NA" {
+			// errors = append(errors, "a 'generate' step should not contain 'input', 'model', 'action', or 'output' fields at the top level, unless Input is 'NA'")
+		}
+	}
+	if isProcessStep && (config.Input != nil || config.Model != nil || config.Action != nil || config.Output != nil) {
+		// Allow Input: NA for process steps
+		if val, ok := config.Input.(string); !ok || val != "NA" {
+			// errors = append(errors, "a 'process' step should not contain 'input', 'model', 'action', or 'output' fields at the top level, unless Input is 'NA'")
+		}
 	}
 
-	// Check action field
-	actions := p.NormalizeStringSlice(config.Action)
-	if len(actions) == 0 {
-		errors = append(errors, "action is required")
-	}
-
-	// Check output field
-	outputs := p.NormalizeStringSlice(config.Output)
-	if len(outputs) == 0 {
-		errors = append(errors, "output is required (can be STDOUT for console output)")
+	if isStandardStep {
+		if config.Input == nil {
+			errors = append(errors, "input tag is required for standard steps (can be NA or empty, but the tag must be present)")
+		}
+		modelNames := p.NormalizeStringSlice(config.Model)
+		if len(modelNames) == 0 {
+			errors = append(errors, "model is required for standard steps (can be NA or a valid model name)")
+		}
+		actions := p.NormalizeStringSlice(config.Action)
+		if len(actions) == 0 {
+			errors = append(errors, "action is required for standard steps")
+		}
+		outputs := p.NormalizeStringSlice(config.Output)
+		if len(outputs) == 0 {
+			errors = append(errors, "output is required for standard steps (can be STDOUT for console output)")
+		}
+	} else if isOpenAIResponsesStep {
+		// Validation specific to openai-responses type
+		// For example, 'instructions' might be required instead of 'action'
+		if config.Instructions == "" {
+			// errors = append(errors, "'instructions' is required for 'openai-responses' type steps")
+		}
+		// Other openai-responses specific validations...
+	} else if isGenerateStep {
+		if config.Generate.Action == nil {
+			errors = append(errors, "'action' is required within the 'generate' configuration")
+		}
+		if config.Generate.Output == "" {
+			errors = append(errors, "'output' (filename) is required within the 'generate' configuration")
+		}
+	} else if isProcessStep {
+		if config.Process.WorkflowFile == "" {
+			errors = append(errors, "'workflow_file' is required within the 'process' configuration")
+		}
 	}
 
 	if len(errors) > 0 {
@@ -358,12 +423,14 @@ func (p *Processor) Process() error {
 			return fmt.Errorf("validation error: %w", err)
 		}
 
-		// Validate model names
-		modelNames := p.NormalizeStringSlice(step.Config.Model)
-		p.debugf("Normalized model names for step %s: %v", step.Name, modelNames)
-		if err := p.validateModel(modelNames, []string{"STDIN"}); err != nil {
-			p.debugf("Model validation failed for step %s: %v", step.Name, err)
-			return fmt.Errorf("model validation failed for step %s: %w", step.Name, err)
+		// Validate model names only for standard or relevant steps
+		if step.Config.Generate == nil && step.Config.Process == nil && step.Config.Type != "openai-responses" {
+			modelNames := p.NormalizeStringSlice(step.Config.Model)
+			p.debugf("Normalized model names for step %s: %v", step.Name, modelNames)
+			if err := p.validateModel(modelNames, []string{"STDIN"}); err != nil { // STDIN is a placeholder here
+				p.debugf("Model validation failed for step %s: %v", step.Name, err)
+				return fmt.Errorf("model validation failed for step %s: %w", step.Name, err)
+			}
 		}
 
 		p.debugf("Successfully validated step: %s", step.Name)
@@ -385,14 +452,15 @@ func (p *Processor) Process() error {
 				return fmt.Errorf("validation error: %w", err)
 			}
 
-			// Validate model names
-			modelNames := p.NormalizeStringSlice(step.Config.Model)
-			p.debugf("Normalized model names for parallel step %s: %v", step.Name, modelNames)
-			if err := p.validateModel(modelNames, []string{"STDIN"}); err != nil {
-				p.debugf("Model validation failed for parallel step %s: %v", step.Name, err)
-				return fmt.Errorf("model validation failed for parallel step %s: %w", step.Name, err)
+			// Validate model names only for standard or relevant steps
+			if step.Config.Generate == nil && step.Config.Process == nil && step.Config.Type != "openai-responses" {
+				modelNames := p.NormalizeStringSlice(step.Config.Model)
+				p.debugf("Normalized model names for parallel step %s: %v", step.Name, modelNames)
+				if err := p.validateModel(modelNames, []string{"STDIN"}); err != nil { // STDIN is a placeholder
+					p.debugf("Model validation failed for parallel step %s: %v", step.Name, err)
+					return fmt.Errorf("model validation failed for parallel step %s: %w", step.Name, err)
+				}
 			}
-
 			p.debugf("Successfully validated parallel step: %s", step.Name)
 		}
 	}
@@ -499,6 +567,13 @@ func (p *Processor) Process() error {
 			Model:  fmt.Sprintf("%v", step.Config.Model),
 			Action: fmt.Sprintf("%v", step.Config.Action),
 		}
+		if step.Config.Generate != nil {
+			stepInfo.Model = fmt.Sprintf("%v", step.Config.Generate.Model)
+			stepInfo.Action = fmt.Sprintf("%v", step.Config.Generate.Action)
+		} else if step.Config.Process != nil {
+			stepInfo.Action = fmt.Sprintf("Process workflow: %s", step.Config.Process.WorkflowFile)
+			stepInfo.Model = "N/A"
+		}
 
 		stepMsg := fmt.Sprintf("Processing step %d/%d: %s", stepIndex+1, len(p.config.Steps), step.Name)
 		p.emitProgress(stepMsg, stepInfo)
@@ -537,6 +612,16 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 	// Check if this is an openai-responses step
 	if step.Config.Type == "openai-responses" {
 		return p.processResponsesStep(step, isParallel, parallelID)
+	}
+
+	// Handle generate step
+	if step.Config.Generate != nil {
+		return p.processGenerateStep(step, isParallel, parallelID, metrics, startTime)
+	}
+
+	// Handle process step
+	if step.Config.Process != nil {
+		return p.processProcessStep(step, isParallel, parallelID, metrics, startTime)
 	}
 
 	// Create a new handler for this step to avoid conflicts in parallel processing
@@ -812,6 +897,276 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 	return response, nil
 }
 
+// processGenerateStep handles the logic for a 'generate' step
+func (p *Processor) processGenerateStep(step Step, isParallel bool, parallelID string, metrics *PerformanceMetrics, startTime time.Time) (string, error) {
+	stepInfo := &StepInfo{
+		Name:   step.Name,
+		Model:  fmt.Sprintf("%v", step.Config.Generate.Model),
+		Action: fmt.Sprintf("%v", step.Config.Generate.Action),
+	}
+	p.debugf("Processing generate step: %s", step.Name)
+	// Emit progress
+	if isParallel {
+		p.emitParallelProgress(fmt.Sprintf("Generating workflow: %s", step.Name), stepInfo, parallelID)
+	} else {
+		p.emitProgress(fmt.Sprintf("Generating workflow: %s", step.Name), stepInfo)
+	}
+
+	// 1. Determine model for generation
+	var genModelName string
+	if step.Config.Generate.Model != nil {
+		modelNames := p.NormalizeStringSlice(step.Config.Generate.Model)
+		if len(modelNames) > 0 {
+			genModelName = modelNames[0] // Use the first model specified
+		}
+	}
+	if genModelName == "" {
+		genModelName = p.envConfig.DefaultGenerationModel // Use default from env config
+		if genModelName == "" {
+			return "", fmt.Errorf("no model specified for generate step '%s' and no default_generation_model configured", step.Name)
+		}
+	}
+	p.debugf("Using model '%s' for workflow generation in step '%s'", genModelName, step.Name)
+
+	// 2. Prepare the prompt for the LLM
+	//    This includes the Comanda DSL guide and the user's action.
+	// Use the embedded guide instead of reading from file
+	dslGuide := []byte(EmbeddedLLMGuide)
+
+	userAction := ""
+	if actions := p.NormalizeStringSlice(step.Config.Generate.Action); len(actions) > 0 {
+		userAction = actions[0] // Assuming single action for generation prompt
+	}
+	if userAction == "" {
+		return "", fmt.Errorf("action for generate step '%s' is empty", step.Name)
+	}
+
+	// Handle input for generate step (e.g., from STDIN or context_files)
+	var contextInput string
+	if step.Config.Input != nil {
+		inputValStr := fmt.Sprintf("%v", step.Config.Input)
+		if inputValStr == "STDIN" {
+			contextInput = p.lastOutput
+			p.debugf("Generate step '%s' using STDIN content as part of prompt context.", step.Name)
+		} else if inputValStr != "NA" && inputValStr != "" {
+			// If Input is a file path or direct string
+			inputs := p.NormalizeStringSlice(step.Config.Input)
+			if len(inputs) > 0 {
+				// For simplicity, concatenate all inputs if multiple are provided.
+				// A more sophisticated approach might handle them differently.
+				var sb strings.Builder
+				for _, inputPath := range inputs {
+					content, err := os.ReadFile(inputPath)
+					if err != nil {
+						p.debugf("Warning: could not read input file %s for generate step %s: %v", inputPath, step.Name, err)
+						continue // Or handle error more strictly
+					}
+					sb.Write(content)
+					sb.WriteString("\n\n")
+				}
+				contextInput = sb.String()
+				p.debugf("Generate step '%s' using content from specified input files as part of prompt context.", step.Name)
+			}
+		}
+	}
+
+	// Add content from context_files
+	var contextFilesContent strings.Builder
+	for _, filePath := range step.Config.Generate.ContextFiles {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			p.debugf("Warning: could not read context_file %s for generate step %s: %v", filePath, step.Name, err)
+			continue
+		}
+		contextFilesContent.Write(content)
+		contextFilesContent.WriteString("\n\n")
+	}
+
+	// Get list of configured models
+	configuredModels := p.envConfig.GetAllConfiguredModels()
+	var modelsList string
+	if len(configuredModels) > 0 {
+		modelsList = fmt.Sprintf("\n--- CONFIGURED MODELS ---\nThe following models are configured and available for use:\n%s\n--- END CONFIGURED MODELS ---\n", strings.Join(configuredModels, "\n"))
+	} else {
+		modelsList = "\n--- CONFIGURED MODELS ---\nNo models are currently configured. Use 'NA' for model fields.\n--- END CONFIGURED MODELS ---\n"
+	}
+
+	// Create a more forceful prompt that emphasizes YAML-only output
+	fullPrompt := fmt.Sprintf(`SYSTEM: You are a YAML generator. You MUST output ONLY valid YAML content. No explanations, no markdown, no code blocks, no commentary - just raw YAML.
+
+--- BEGIN COMANDA DSL SPECIFICATION ---
+%s
+--- END COMANDA DSL SPECIFICATION ---
+%s
+User's request: %s
+
+Additional Context (if any):
+%s
+%s
+
+CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.
+
+IMPORTANT: When specifying models in the generated YAML, you MUST use one of the configured models listed above, or use 'NA' if no model is needed for a step.`,
+		string(dslGuide), modelsList, userAction, contextInput, contextFilesContent.String())
+
+	// 3. Call the LLM
+	provider, err := p.getProviderForModel(genModelName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get provider for model '%s' in generate step '%s': %w", genModelName, step.Name, err)
+	}
+
+	// Create a temporary input.Input for the LLM call
+	// tempLLMInput := &input.Input{ // Not needed if SendPrompt takes a string
+	// 	Contents: []byte(fullPrompt),
+	// 	Path:     "generate-prompt", // Placeholder path
+	// 	Type:     input.StdinInput,  // Assign a type, StdinInput seems appropriate for a string prompt
+	// 	MimeType: "text/plain",
+	// }
+
+	// Assuming provider is already configured via configureProviders() or similar mechanism
+	generatedResponse, err := provider.SendPrompt(genModelName, fullPrompt)
+	if err != nil {
+		return "", fmt.Errorf("LLM execution failed for generate step '%s' with model '%s': %w", step.Name, genModelName, err)
+	}
+
+	// Extract YAML content from the response
+	yamlContent := generatedResponse
+
+	// Check if the response contains code blocks
+	if strings.Contains(generatedResponse, "```yaml") {
+		// Extract content between ```yaml and ```
+		startMarker := "```yaml"
+		endMarker := "```"
+
+		startIdx := strings.Index(generatedResponse, startMarker)
+		if startIdx != -1 {
+			startIdx += len(startMarker)
+			// Find the next ``` after the start marker
+			remaining := generatedResponse[startIdx:]
+			endIdx := strings.Index(remaining, endMarker)
+			if endIdx != -1 {
+				yamlContent = strings.TrimSpace(remaining[:endIdx])
+			}
+		}
+	} else if strings.Contains(generatedResponse, "```") {
+		// Try generic code block
+		parts := strings.Split(generatedResponse, "```")
+		if len(parts) >= 3 {
+			// Take the content of the first code block
+			yamlContent = strings.TrimSpace(parts[1])
+			// Remove language identifier if present (e.g., "yaml" at the start)
+			lines := strings.Split(yamlContent, "\n")
+			if len(lines) > 0 && !strings.Contains(lines[0], ":") {
+				yamlContent = strings.Join(lines[1:], "\n")
+			}
+		}
+	}
+
+	// 4. Validate the generated YAML before saving
+	if err := p.validateGeneratedWorkflow(yamlContent); err != nil {
+		return "", fmt.Errorf("generated workflow validation failed for step '%s': %w", step.Name, err)
+	}
+
+	// 5. Save the generated YAML to the output file
+	outputFilePath := step.Config.Generate.Output
+	if err := os.WriteFile(outputFilePath, []byte(yamlContent), 0644); err != nil {
+		return "", fmt.Errorf("failed to write generated workflow to '%s' in generate step '%s': %w", outputFilePath, step.Name, err)
+	}
+
+	p.debugf("Generated workflow saved to %s", outputFilePath)
+
+	// Record metrics
+	metrics.TotalProcessingTime = time.Since(startTime).Milliseconds()
+	if isParallel {
+		p.emitParallelProgressWithMetrics(fmt.Sprintf("Completed generate step: %s", step.Name), stepInfo, parallelID, metrics)
+	} else {
+		p.emitProgressWithMetrics(fmt.Sprintf("Completed generate step: %s", step.Name), stepInfo, metrics)
+	}
+
+	return fmt.Sprintf("Generated workflow saved to %s", outputFilePath), nil
+}
+
+// processProcessStep handles the logic for a 'process' step
+func (p *Processor) processProcessStep(step Step, isParallel bool, parallelID string, metrics *PerformanceMetrics, startTime time.Time) (string, error) {
+	stepInfo := &StepInfo{
+		Name:   step.Name,
+		Action: fmt.Sprintf("Process workflow: %s", step.Config.Process.WorkflowFile),
+		Model:  "N/A",
+	}
+	p.debugf("Processing process step: %s, workflow_file: %s", step.Name, step.Config.Process.WorkflowFile)
+	// Emit progress
+	if isParallel {
+		p.emitParallelProgress(fmt.Sprintf("Processing sub-workflow: %s (%s)", step.Name, step.Config.Process.WorkflowFile), stepInfo, parallelID)
+	} else {
+		p.emitProgress(fmt.Sprintf("Processing sub-workflow: %s (%s)", step.Name, step.Config.Process.WorkflowFile), stepInfo)
+	}
+
+	// 1. Read the sub-workflow YAML file
+	subWorkflowPath := step.Config.Process.WorkflowFile
+	yamlFile, err := os.ReadFile(subWorkflowPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read sub-workflow file '%s' for process step '%s': %w", subWorkflowPath, step.Name, err)
+	}
+
+	var subDSLConfig DSLConfig
+	if err := yaml.Unmarshal(yamlFile, &subDSLConfig); err != nil {
+		return "", fmt.Errorf("failed to unmarshal sub-workflow YAML '%s' for process step '%s': %w", subWorkflowPath, step.Name, err)
+	}
+
+	// 2. Create a new Processor for the sub-workflow
+	//    It inherits verbose settings and envConfig, but has its own DSLConfig and variables.
+	//    The runtimeDir for the sub-processor could be the directory of the sub-workflow file or inherited.
+	//    For now, let's assume it inherits the parent's runtimeDir.
+	subProcessor := NewProcessor(&subDSLConfig, p.envConfig, p.serverConfig, p.verbose, p.runtimeDir)
+	if p.progress != nil { // Propagate progress writer if available
+		subProcessor.SetProgressWriter(p.progress)
+	}
+
+	// 3. Handle inputs for the sub-workflow (optional)
+	if step.Config.Process.Inputs != nil {
+		for key, value := range step.Config.Process.Inputs {
+			// How these inputs are made available to the sub-workflow needs careful design.
+			// Option 1: Set them as initial variables in the sub-processor.
+			subProcessor.variables[key] = fmt.Sprintf("%v", value) // Convert value to string
+			p.debugf("Passing input '%s' (value: '%v') to sub-workflow '%s'", key, value, subWorkflowPath)
+
+			// Option 2: If the first step of sub-workflow expects STDIN and is named,
+			// we could set p.lastOutput. This is more complex.
+			// For now, using variables is simpler.
+		}
+	}
+
+	// If the parent 'process' step received STDIN, pass it to the sub-processor's lastOutput
+	if inputValStr := fmt.Sprintf("%v", step.Config.Input); inputValStr == "STDIN" {
+		subProcessor.SetLastOutput(p.lastOutput)
+		p.debugf("Passing STDIN from parent step '%s' to sub-workflow '%s'", step.Name, subWorkflowPath)
+	}
+
+	// 4. Execute the sub-workflow
+	if err := subProcessor.Process(); err != nil {
+		return "", fmt.Errorf("error processing sub-workflow '%s' in step '%s': %w", subWorkflowPath, step.Name, err)
+	}
+
+	// 5. Handle output capture (optional)
+	//    This is a placeholder for now. Capturing specific outputs from a sub-workflow
+	//    and making them available to the parent requires more design (e.g., sub-workflow
+	//    explicitly "exports" variables or files).
+	//    For now, the main output of the sub-processor (lastOutput) could be returned.
+
+	resultMessage := fmt.Sprintf("Successfully processed sub-workflow %s", subWorkflowPath)
+	p.debugf(resultMessage)
+
+	// Record metrics
+	metrics.TotalProcessingTime = time.Since(startTime).Milliseconds()
+	if isParallel {
+		p.emitParallelProgressWithMetrics(fmt.Sprintf("Completed process step: %s", step.Name), stepInfo, parallelID, metrics)
+	} else {
+		p.emitProgressWithMetrics(fmt.Sprintf("Completed process step: %s", step.Name), stepInfo, metrics)
+	}
+
+	return subProcessor.LastOutput(), nil // Return the last output of the sub-workflow
+}
+
 // getCurrentStepConfig returns the configuration for the current step being processed
 func (p *Processor) getCurrentStepConfig() StepConfig {
 	// If we're not processing a step yet, return an empty config with default values
@@ -843,4 +1198,144 @@ func (p *Processor) getCurrentStepConfig() StepConfig {
 // GetProcessedInputs returns all processed input contents
 func (p *Processor) GetProcessedInputs() []*input.Input {
 	return p.handler.GetInputs()
+}
+
+// validateGeneratedWorkflow validates that the generated YAML contains valid model references
+func (p *Processor) validateGeneratedWorkflow(yamlContent string) error {
+	p.debugf("Validating generated workflow YAML")
+
+	// Parse the YAML to check for model validity
+	var generatedConfig DSLConfig
+	if err := yaml.Unmarshal([]byte(yamlContent), &generatedConfig); err != nil {
+		return fmt.Errorf("generated YAML is invalid: %w", err)
+	}
+
+	// Collect all models referenced in the generated workflow
+	var referencedModels []string
+
+	// Check models in sequential steps
+	for _, step := range generatedConfig.Steps {
+		// Skip generate and process steps as they don't use models directly
+		if step.Config.Generate != nil || step.Config.Process != nil {
+			continue
+		}
+
+		// Check models in standard steps
+		modelNames := p.NormalizeStringSlice(step.Config.Model)
+		for _, modelName := range modelNames {
+			if modelName != "NA" && modelName != "" {
+				referencedModels = append(referencedModels, modelName)
+			}
+		}
+
+		// Check models in generate steps
+		if step.Config.Generate != nil && step.Config.Generate.Model != nil {
+			genModelNames := p.NormalizeStringSlice(step.Config.Generate.Model)
+			for _, modelName := range genModelNames {
+				if modelName != "" {
+					referencedModels = append(referencedModels, modelName)
+				}
+			}
+		}
+	}
+
+	// Check models in parallel steps
+	for _, steps := range generatedConfig.ParallelSteps {
+		for _, step := range steps {
+			// Skip generate and process steps
+			if step.Config.Generate != nil || step.Config.Process != nil {
+				continue
+			}
+
+			modelNames := p.NormalizeStringSlice(step.Config.Model)
+			for _, modelName := range modelNames {
+				if modelName != "NA" && modelName != "" {
+					referencedModels = append(referencedModels, modelName)
+				}
+			}
+
+			// Check models in generate steps
+			if step.Config.Generate != nil && step.Config.Generate.Model != nil {
+				genModelNames := p.NormalizeStringSlice(step.Config.Generate.Model)
+				for _, modelName := range genModelNames {
+					if modelName != "" {
+						referencedModels = append(referencedModels, modelName)
+					}
+				}
+			}
+		}
+	}
+
+	// Validate each referenced model
+	invalidModels := []string{}
+	for _, modelName := range referencedModels {
+		p.debugf("Checking if model '%s' in generated workflow is valid", modelName)
+
+		// Check if provider exists for this model
+		provider := models.DetectProvider(modelName)
+		if provider == nil {
+			invalidModels = append(invalidModels, fmt.Sprintf("%s (no provider found)", modelName))
+			continue
+		}
+
+		// Check if provider supports this model
+		if !provider.SupportsModel(modelName) {
+			invalidModels = append(invalidModels, fmt.Sprintf("%s (not supported by %s)", modelName, provider.Name()))
+			continue
+		}
+
+		// Check if model is configured
+		_, err := p.envConfig.GetModelConfig(provider.Name(), modelName)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found for provider") {
+				invalidModels = append(invalidModels, fmt.Sprintf("%s (not configured - run 'comanda configure' to add it)", modelName))
+			} else {
+				invalidModels = append(invalidModels, fmt.Sprintf("%s (configuration error: %v)", modelName, err))
+			}
+		}
+	}
+
+	if len(invalidModels) > 0 {
+		return fmt.Errorf("generated workflow contains invalid or unconfigured models:\n  - %s", strings.Join(invalidModels, "\n  - "))
+	}
+
+	p.debugf("Generated workflow validation successful - all %d model references are valid", len(referencedModels))
+	return nil
+}
+
+// getProviderForModel retrieves a model provider based on the model name
+// TODO: Implement actual logic to select provider based on model name and envConfig
+func (p *Processor) getProviderForModel(modelName string) (models.Provider, error) {
+	// For now, return the first configured provider or an error if none exist
+	// This is a placeholder and needs to be replaced with actual provider selection logic
+	for _, provider := range p.providers {
+		// This simple logic just returns the first provider.
+		// A real implementation would look up the provider that supports `modelName`.
+		return provider, nil
+	}
+	// Fallback or more sophisticated lookup if p.providers is not populated yet
+	// or if a specific provider for modelName is needed.
+	// This might involve looking into p.envConfig.Providers.
+
+	// Placeholder: Attempt to find a provider that lists this model.
+	// This is a simplified lookup. A more robust system would map model names to provider types.
+	for providerName, providerConfig := range p.envConfig.Providers {
+		for _, model := range providerConfig.Models {
+			if model.Name == modelName {
+				// Found a provider that lists this model. Now get/initialize this provider.
+				// This part depends on how providers are initialized and stored in p.providers.
+				// If p.providers is already populated by configureProviders(), this might not be needed here.
+				// For now, let's assume p.providers is populated.
+				if prov, ok := p.providers[providerName]; ok {
+					return prov, nil
+				}
+				// If not in p.providers, we might need to initialize it.
+				// This is complex and depends on the overall provider management strategy.
+				// For this stub, we'll return an error if not found in the initialized map.
+				return nil, fmt.Errorf("provider '%s' for model '%s' not initialized in p.providers", providerName, modelName)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no provider configured or found for model %s", modelName)
 }

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -1,0 +1,183 @@
+package processor
+
+// EmbeddedLLMGuide contains the Comanda YAML DSL Guide for LLM consumption
+// This is embedded directly in the binary to avoid file path issues
+const EmbeddedLLMGuide = `# Comanda YAML DSL Guide (for LLM Consumption)
+
+This guide specifies the YAML-based Domain Specific Language (DSL) for Comanda workflows, enabling LLMs to generate valid workflow files.
+
+## Overview
+
+Comanda workflows consist of one or more named steps. Each step performs an operation. There are three main types of steps:
+1.  **Standard Processing Step:** Involves LLMs, file processing, data operations.
+2.  **Generate Step:** Uses an LLM to dynamically create a new Comanda workflow YAML file.
+3.  **Process Step:** Executes another Comanda workflow file (static or dynamically generated).
+
+## Core Workflow Structure
+
+A Comanda workflow is a YAML map where each key is a ` + "`step_name`" + ` (string, user-defined), mapping to a dictionary defining the step.
+
+` + "```yaml" + `
+# Example of a workflow structure
+workflow_step_1:
+  # ... step definition ...
+another_step_name:
+  # ... step definition ...
+` + "```" + `
+
+## 1. Standard Processing Step Definition
+
+This is the most common step type.
+
+**Basic Structure:**
+` + "```yaml" + `
+step_name:
+  input: [input source]
+  model: [model name]
+  action: [action to perform / prompt provided]
+  output: [output destination]
+  type: [optional, e.g., "openai-responses"] # Specifies specialized handling
+  batch_mode: [individual|combined] # Optional, for multi-file inputs
+  skip_errors: [true|false] # Optional, for multi-file inputs
+  # ... other type-specific fields for "openai-responses" like 'instructions', 'tools', etc.
+` + "```" + `
+
+**Key Elements:**
+- ` + "`input`" + `: (Required for most, can be ` + "`NA`" + `) Source of data. See "Input Types".
+- ` + "`model`" + `: (Required, can be ` + "`NA`" + `) LLM model to use. See "Models".
+- ` + "`action`" + `: (Required for most) Instructions or operations. See "Actions".
+- ` + "`output`" + `: (Required) Destination for results. See "Outputs".
+- ` + "`type`" + `: (Optional) Specifies a specialized handler for the step, e.g., ` + "`openai-responses`" + `. If omitted, it's a general-purpose LLM or NA step.
+- ` + "`batch_mode`" + `: (Optional, default: ` + "`combined`" + `) For steps with multiple file inputs, defines if files are processed ` + "`combined`" + ` into one LLM call or ` + "`individual`" + `ly.
+- ` + "`skip_errors`" + `: (Optional, default: ` + "`false`" + `) If ` + "`batch_mode: individual`" + `, determines if processing continues if one file fails.
+
+**OpenAI Responses API Specific Fields (used when ` + "`type: openai-responses`" + `):**
+- ` + "`instructions`" + `: (string) System message for the LLM.
+- ` + "`tools`" + `: (list of maps) Configuration for tools/functions the LLM can call.
+- ` + "`previous_response_id`" + `: (string) ID of a previous response for maintaining conversation state.
+- ` + "`max_output_tokens`" + `: (int) Token limit for the LLM response.
+- ` + "`temperature`" + `: (float) Sampling temperature.
+- ` + "`top_p`" + `: (float) Nucleus sampling (top-p).
+- ` + "`stream`" + `: (bool) Whether to stream the response.
+- ` + "`response_format`" + `: (map) Specifies response format, e.g., ` + "`{ type: \"json_object\" }`" + `.
+
+
+## 2. Generate Step Definition (` + "`generate`" + `)
+
+This step uses an LLM to dynamically create a new Comanda workflow YAML file.
+
+**Structure:**
+` + "```yaml" + `
+step_name_for_generation:
+  input: [optional_input_source_for_context, or NA] # e.g., STDIN, a file with requirements
+  generate:
+    model: [llm_model_for_generation, optional] # e.g., gpt-4o-mini. Uses default if omitted.
+    action: [prompt_for_workflow_generation] # Natural language instruction for the LLM.
+    output: [filename_for_generated_yaml] # e.g., new_workflow.yaml
+    context_files: [list_of_files_for_additional_context, optional] # e.g., [schema.txt, examples.yaml]
+` + "```" + `
+**` + "`generate`" + ` Block Attributes:**
+- ` + "`model`" + `: (string, optional) Specifies the LLM to use for generation. If omitted, uses the ` + "`default_generation_model`" + ` configured in Comanda. You can set or update this default model by running ` + "`comanda configure`" + ` and following the prompts for setting a default generation model.
+- ` + "`action`" + `: (string, required) The natural language instruction given to the LLM to guide the workflow generation.
+- ` + "`output`" + `: (string, required) The filename where the generated Comanda workflow YAML file will be saved.
+- ` + "`context_files`" + `: (list of strings, optional) A list of file paths to provide as additional context to the LLM, beyond the standard Comanda DSL guide (which is implicitly included).
+- **Note:** The ` + "`input`" + ` field for a ` + "`generate`" + ` step is optional. If provided (e.g., ` + "`STDIN`" + ` or a file path), its content will be added to the context for the LLM generating the workflow. If not needed, use ` + "`input: NA`" + `.
+
+## 3. Process Step Definition (` + "`process`" + `)
+
+This step executes another Comanda workflow file.
+
+**Structure:**
+` + "```yaml" + `
+step_name_for_processing:
+  input: [optional_input_source_for_sub_workflow, or NA] # e.g., STDIN to pass data to the sub-workflow
+  process:
+    workflow_file: [path_to_comanda_yaml_to_execute] # e.g., generated_workflow.yaml or existing_flow.yaml
+    inputs: {key1: value1, key2: value2, optional} # Map of inputs to pass to the sub-workflow.
+    # capture_outputs: [list_of_outputs_to_capture, optional] # Future: Define how to capture specific outputs.
+` + "```" + `
+**` + "`process`" + ` Block Attributes:**
+- ` + "`workflow_file`" + `: (string, required) The path to the Comanda workflow YAML file to be executed. This can be a statically defined path or the output of a ` + "`generate`" + ` step.
+- ` + "`inputs`" + `: (map, optional) A map of key-value pairs to pass as initial variables to the sub-workflow. These can be accessed within the sub-workflow (e.g., as ` + "`$parent.key1`" + `).
+- **Note:** The ` + "`input`" + ` field for a ` + "`process`" + ` step is optional. If ` + "`input: STDIN`" + ` is used, the output of the previous step in the parent workflow will be available as the initial ` + "`STDIN`" + ` for the *first* step of the sub-workflow if that first step expects ` + "`STDIN`" + `.
+
+## Common Elements (for Standard Steps)
+
+### Input Types
+- File path: ` + "`input: path/to/file.txt`" + `
+- Previous step output: ` + "`input: STDIN`" + `
+- Multiple file paths: ` + "`input: [file1.txt, file2.txt]`" + `
+- Web scraping: ` + "`input: { url: \"https://example.com\" }`" + ` (Further scrape config under ` + "`scrape_config`" + ` map if needed)
+- Database query: ` + "`input: { database: { type: \"postgres\", query: \"SELECT * FROM users\" } }`" + `
+- No input: ` + "`input: NA`" + `
+- Input with alias for variable: ` + "`input: path/to/file.txt as $my_var`" + `
+- List with aliases: ` + "`input: [file1.txt as $file1_content, file2.txt as $file2_content]`" + `
+
+### Models
+- Single model: ` + "`model: gpt-4o-mini`" + `
+- No model (for non-LLM operations): ` + "`model: NA`" + `
+- Multiple models (for comparison): ` + "`model: [gpt-4o-mini, claude-3-opus-20240229]`" + `
+
+### Actions
+- Single instruction: ` + "`action: \"Summarize this text.\"`" + `
+- Multiple sequential instructions: ` + "`action: [\"Action 1\", \"Action 2\"]`" + `
+- Reference variable: ` + "`action: \"Compare with $previous_data.\"`" + `
+- Reference markdown file: ` + "`action: path/to/prompt.md`" + `
+
+### Outputs
+- Console: ` + "`output: STDOUT`" + `
+- File: ` + "`output: results.txt`" + `
+- Database: ` + "`output: { database: { type: \"postgres\", table: \"results_table\" } }`" + `
+- Output with alias (if supported for variable creation from output): ` + "`output: STDOUT as $step_output_var`" + `
+
+## Variables
+- Definition: ` + "`input: data.txt as $initial_data`" + `
+- Reference: ` + "`action: \"Compare this analysis with $initial_data\"`" + `
+- Scope: Variables are typically scoped to the workflow. For ` + "`process`" + ` steps, parent variables are not directly accessible by default; use the ` + "`process.inputs`" + ` map to pass data.
+
+## Validation Rules Summary (for LLM)
+
+1.  A step definition must clearly be one of: Standard, Generate, or Process.
+    *   A step cannot mix top-level keys from different types (e.g., a ` + "`generate`" + ` step should not have a top-level ` + "`model`" + ` or ` + "`output`" + ` key; these belong inside the ` + "`generate`" + ` block).
+2.  **Standard Step:**
+    *   Must contain ` + "`input`" + `, ` + "`model`" + `, ` + "`action`" + `, ` + "`output`" + ` (unless ` + "`type: openai-responses`" + `, where ` + "`action`" + ` might be replaced by ` + "`instructions`" + `).
+    *   ` + "`input`" + ` can be ` + "`NA`" + `. ` + "`model`" + ` can be ` + "`NA`" + `.
+3.  **Generate Step:**
+    *   Must contain a ` + "`generate`" + ` block.
+    *   ` + "`generate`" + ` block must contain ` + "`action`" + ` (string prompt) and ` + "`output`" + ` (string filename).
+    *   ` + "`generate.model`" + ` is optional (uses default if omitted).
+    *   Top-level ` + "`input`" + ` for the step is optional (can be ` + "`NA`" + ` or provide context).
+4.  **Process Step:**
+    *   Must contain a ` + "`process`" + ` block.
+    *   ` + "`process`" + ` block must contain ` + "`workflow_file`" + ` (string path).
+    *   ` + "`process.inputs`" + ` is optional.
+    *   Top-level ` + "`input`" + ` for the step is optional (can be ` + "`NA`" + ` or ` + "`STDIN`" + ` to pipe to sub-workflow).
+
+## Chaining and Examples
+
+(Existing Chaining Workflow Steps and Common Patterns sections can remain largely as-is, but ensure examples are consistent with the three step types if showcasing meta-processing.)
+
+**Meta-Processing Example:**
+` + "```yaml" + `
+gather_requirements:
+  input: requirements_document.txt
+  model: claude-3-opus-20240229
+  action: "Based on the input document, define the core tasks for a data processing workflow. Output as a concise list."
+  output: STDOUT as $task_list
+
+generate_data_workflow:
+  input: $task_list # Using output from previous step as context
+  generate:
+    model: gpt-4o-mini # LLM to generate the workflow
+    action: "Generate a Comanda workflow YAML to perform the tasks described in the input. The workflow should read 'raw_data.csv', perform transformations, and save to 'processed_data.csv'."
+    output: dynamic_data_processor.yaml # Filename for the generated workflow
+
+execute_data_workflow:
+  input: NA # Or potentially STDIN if dynamic_data_processor.yaml's first step expects it
+  process:
+    workflow_file: dynamic_data_processor.yaml # Execute the generated workflow
+    # inputs: { source_file: "override_data.csv" } # Optional: override inputs for the sub-workflow
+  output: STDOUT # Log output of the process step itself (e.g., success/failure)
+` + "```" + `
+
+This guide covers the core concepts and syntax of Comanda's YAML DSL, including meta-processing capabilities. LLMs should use this structure to generate valid workflow files.`

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -20,6 +20,10 @@ type StepConfig struct {
 	TopP               float64                  `yaml:"top_p"`                // Top-p sampling
 	Stream             bool                     `yaml:"stream"`               // Whether to stream the response
 	ResponseFormat     map[string]interface{}   `yaml:"response_format"`      // Format specification (e.g., JSON)
+
+	// Meta-processing fields
+	Generate *GenerateStepConfig `yaml:"generate,omitempty"` // Configuration for generating a workflow
+	Process  *ProcessStepConfig  `yaml:"process,omitempty"`  // Configuration for processing a sub-workflow
 }
 
 // Step represents a named step in the DSL

--- a/utils/server/generate_handler.go
+++ b/utils/server/generate_handler.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/models"
+	"github.com/kris-hansen/comanda/utils/processor"
+)
+
+// GenerateRequest represents the request body for the generate endpoint
+type GenerateRequest struct {
+	Prompt string `json:"prompt"`
+	Model  string `json:"model,omitempty"`
+}
+
+// GenerateResponse represents the response for the generate endpoint
+type GenerateResponse struct {
+	Success bool   `json:"success"`
+	YAML    string `json:"yaml,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Model   string `json:"model,omitempty"`
+}
+
+// handleGenerate handles the generation of Comanda workflow YAML files using an LLM
+func (s *Server) handleGenerate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(GenerateResponse{
+			Success: false,
+			Error:   "Method not allowed. Use POST.",
+		})
+		return
+	}
+
+	var req GenerateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(GenerateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	// Validate prompt
+	if req.Prompt == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(GenerateResponse{
+			Success: false,
+			Error:   "Prompt is required",
+		})
+		return
+	}
+
+	// Determine which model to use
+	modelForGeneration := req.Model
+	if modelForGeneration == "" {
+		modelForGeneration = s.envConfig.DefaultGenerationModel
+	}
+	if modelForGeneration == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(GenerateResponse{
+			Success: false,
+			Error:   "No model specified and no default_generation_model configured",
+		})
+		return
+	}
+
+	config.VerboseLog("Generating workflow using model: %s", modelForGeneration)
+	config.DebugLog("Generate request: prompt_length=%d, model=%s", len(req.Prompt), modelForGeneration)
+
+	// Prepare the full prompt for the LLM
+	dslGuide := processor.EmbeddedLLMGuide
+
+	fullPrompt := fmt.Sprintf(`SYSTEM: You are a YAML generator. You MUST output ONLY valid YAML content. No explanations, no markdown, no code blocks, no commentary - just raw YAML.
+
+--- BEGIN COMANDA DSL SPECIFICATION ---
+%s
+--- END COMANDA DSL SPECIFICATION ---
+
+User's request: %s
+
+CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.`,
+		dslGuide, req.Prompt)
+
+	// Get the provider
+	provider := models.DetectProvider(modelForGeneration)
+	if provider == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(GenerateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Could not detect provider for model: %s", modelForGeneration),
+		})
+		return
+	}
+
+	// Attempt to configure the provider with API key from envConfig
+	providerConfig, err := s.envConfig.GetProviderConfig(provider.Name())
+	if err != nil {
+		// If provider is not in envConfig, it might be a public one like Ollama
+		config.VerboseLog("Provider %s not found in env configuration. Assuming it does not require an API key.", provider.Name())
+	} else {
+		if err := provider.Configure(providerConfig.APIKey); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(GenerateResponse{
+				Success: false,
+				Error:   fmt.Sprintf("Failed to configure provider %s: %v", provider.Name(), err),
+			})
+			return
+		}
+	}
+	provider.SetVerbose(config.Verbose)
+
+	// Call the LLM
+	config.DebugLog("Sending prompt to LLM: model=%s, prompt_length=%d", modelForGeneration, len(fullPrompt))
+	generatedResponse, err := provider.SendPrompt(modelForGeneration, fullPrompt)
+	if err != nil {
+		config.VerboseLog("LLM execution failed: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(GenerateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("LLM execution failed: %v", err),
+		})
+		return
+	}
+
+	// Extract YAML content from the response
+	yamlContent := generatedResponse
+
+	// Check if the response contains code blocks
+	if strings.Contains(generatedResponse, "```yaml") {
+		// Extract content between ```yaml and ```
+		startMarker := "```yaml"
+		endMarker := "```"
+
+		startIdx := strings.Index(generatedResponse, startMarker)
+		if startIdx != -1 {
+			startIdx += len(startMarker)
+			// Find the next ``` after the start marker
+			remaining := generatedResponse[startIdx:]
+			endIdx := strings.Index(remaining, endMarker)
+			if endIdx != -1 {
+				yamlContent = strings.TrimSpace(remaining[:endIdx])
+			}
+		}
+	} else if strings.Contains(generatedResponse, "```") {
+		// Try generic code block
+		parts := strings.Split(generatedResponse, "```")
+		if len(parts) >= 3 {
+			// Take the content of the first code block
+			yamlContent = strings.TrimSpace(parts[1])
+			// Remove language identifier if present (e.g., "yaml" at the start)
+			lines := strings.Split(yamlContent, "\n")
+			if len(lines) > 0 && !strings.Contains(lines[0], ":") {
+				yamlContent = strings.Join(lines[1:], "\n")
+			}
+		}
+	}
+
+	config.VerboseLog("Successfully generated workflow YAML")
+	config.DebugLog("Generated YAML length: %d bytes", len(yamlContent))
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(GenerateResponse{
+		Success: true,
+		YAML:    yamlContent,
+		Model:   modelForGeneration,
+	})
+}

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -378,6 +378,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/process", s.combinedMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		handleProcess(w, r, s.config, s.envConfig)
 	}))
+
+	// Generate endpoint - requires auth
+	s.mux.HandleFunc("/generate", s.combinedMiddleware(s.handleGenerate))
 }
 
 // Run creates and starts the HTTP server with the given configuration


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced the ability to generate new workflows using LLMs with a `generate` command.
- Added a `process` command to execute generated or existing workflows.
- Implemented interactive and command-line options to set a default model for workflow generation.
- Enhanced the configuration to include a default generation model.
- Updated documentation and examples to reflect new features.
- Added comprehensive tests for new functionalities.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/configure.go`: Added flags and logic to set a default generation model. Implemented functions to retrieve and list configured models. Enhanced the `configure` command to support setting a default model interactively or via command-line flag.
- `cmd/configure_default_test.go`: Added tests for the new default model configuration functionality, including setting and verifying default models.
- `cmd/root.go`: Introduced a `generate` command to create workflows using LLMs. Added a `version` command to display the software version. Enhanced error handling for unknown commands.
- `examples/examples_test.go`: Updated test logic to validate new `generate` and `process` steps in workflow examples.
- `utils/config/env.go`: Added a `DefaultGenerationModel` field to the `EnvConfig` struct to store the default model for generation.
- `utils/processor/dsl.go`: Defined new structs for `GenerateStepConfig` and `ProcessStepConfig`. Enhanced the `Processor` to handle `generate` and `process` steps, including validation and execution logic.
- `utils/processor/embedded_guide.go`: Added an embedded guide for the Comanda YAML DSL to assist LLMs in generating valid workflow files.
- `utils/server/generate_handler.go`: Implemented an HTTP handler for generating workflows via a REST API endpoint, using LLMs based on provided prompts.
- `docs/comanda-llm-guide.md`: Updated the guide to include detailed instructions on using `generate` and `process` steps, along with examples and validation rules.
- `docs/openapi.yaml`: Added a new endpoint for generating workflows, including request and response schemas for the OpenAPI specification.
</details>

___
## User Description:
- supports a generate tag to create new workflows with a workflow
- process workflows from within a workflow
- generate new workflows from the command line
- generate new workflows from the server
- set a default model for the generation CLI command
- examples and documentation
