### PR TITLE
fix: env file applied consistently

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -24,21 +24,11 @@ var processCmd = &cobra.Command{
 	Long:  `Process one or more workflow files and execute the specified actions.`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// Get environment file path
-		envPath := config.GetEnvPath()
-
-		// Load environment configuration
-		if verbose {
-			fmt.Printf("[DEBUG] Loading environment configuration from %s\n", envPath)
-		}
-
-		envConfig, err := config.LoadEnvConfigWithPassword(envPath)
-		if err != nil {
-			log.Fatalf("Error loading environment configuration: %v", err)
-		}
+		// The environment configuration is already loaded in rootCmd's PersistentPreRunE
+		// and available in the package-level envConfig variable
 
 		if verbose {
-			fmt.Println("[DEBUG] Environment configuration loaded successfully")
+			fmt.Println("[DEBUG] Using centralized environment configuration")
 		}
 
 		// Check if there's data on STDIN

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -19,12 +19,7 @@ var serverCmd = &cobra.Command{
 	Long:  `Start the HTTP server for processing YAML files, or manage server configuration`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Default behavior (no subcommand) is to start the server
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
 
 		if err := server.Run(envConfig); err != nil {
 			fmt.Printf("Server failed to start: %v\n", err)
@@ -38,12 +33,8 @@ var configureServerCmd = &cobra.Command{
 	Short: "Configure server settings",
 	Long:  `Configure server settings including port, data directory, and authentication`,
 	Run: func(cmd *cobra.Command, args []string) {
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
+		configPath := config.GetEnvPath() // Only needed for display purposes
 
 		reader := bufio.NewReader(os.Stdin)
 		if err := configureServer(reader, envConfig); err != nil {
@@ -65,12 +56,7 @@ var showServerCmd = &cobra.Command{
 	Short: "Show current server configuration",
 	Long:  `Display the current server configuration settings`,
 	Run: func(cmd *cobra.Command, args []string) {
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
 
 		server := envConfig.GetServerConfig()
 		fmt.Println("\nServer Configuration:")
@@ -106,12 +92,8 @@ var updatePortCmd = &cobra.Command{
 			return
 		}
 
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
+		configPath := config.GetEnvPath() // Only needed for saving
 
 		serverConfig := envConfig.GetServerConfig()
 		serverConfig.Port = port
@@ -172,12 +154,8 @@ var updateDataDirCmd = &cobra.Command{
 		}
 		os.Remove(testFile) // Clean up test file
 
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
+		configPath := config.GetEnvPath() // Only needed for saving
 
 		serverConfig := envConfig.GetServerConfig()
 		serverConfig.DataDir = absPath
@@ -204,12 +182,8 @@ var toggleAuthCmd = &cobra.Command{
 			return
 		}
 
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
+		configPath := config.GetEnvPath() // Only needed for saving
 
 		serverConfig := envConfig.GetServerConfig()
 		serverConfig.Enabled = enable == "on"
@@ -241,12 +215,8 @@ var newTokenCmd = &cobra.Command{
 	Short: "Generate new bearer token",
 	Long:  `Generate a new bearer token for server authentication`,
 	Run: func(cmd *cobra.Command, args []string) {
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
+		configPath := config.GetEnvPath() // Only needed for saving
 
 		serverConfig := envConfig.GetServerConfig()
 		token, err := config.GenerateBearerToken()
@@ -327,12 +297,8 @@ var corsCmd = &cobra.Command{
 	Short: "Configure CORS settings",
 	Long:  `Configure Cross-Origin Resource Sharing (CORS) settings for the server`,
 	Run: func(cmd *cobra.Command, args []string) {
-		configPath := config.GetEnvPath()
-		envConfig, err := config.LoadEnvConfigWithPassword(configPath)
-		if err != nil {
-			fmt.Printf("Error loading configuration: %v\n", err)
-			return
-		}
+		// Use the centralized configuration that was loaded in rootCmd's PersistentPreRunE
+		configPath := config.GetEnvPath() // Only needed for saving
 
 		reader := bufio.NewReader(os.Stdin)
 		if err := configureCORS(reader, envConfig); err != nil {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Centralized the loading of environment configuration to improve consistency and reduce redundancy.
- Removed repeated loading of environment configuration across multiple command files.
- Introduced a package-level variable `envConfig` to hold the loaded configuration, making it accessible to all commands.
- Updated command implementations to use the centralized configuration.
- Improved error handling and debug logging for configuration loading.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/configure.go`: Removed redundant loading of environment configuration by utilizing the package-level `envConfig` variable. Updated the `listConfiguration` function to handle cases where it is called directly from tests.
- `cmd/process.go`: Eliminated repeated loading of environment configuration by using the centralized `envConfig` variable. Updated debug logging to reflect the use of centralized configuration.
- `cmd/root.go`: Introduced a package-level `envConfig` variable to store the loaded environment configuration. Modified `PersistentPreRunE` to load the configuration once and set global flags. Removed redundant configuration loading in command execution.
- `cmd/server.go`: Removed repeated loading of environment configuration across server-related commands by using the centralized `envConfig` variable. Updated commands to rely on the configuration loaded in `rootCmd`'s `PersistentPreRunE`.
</details>

___
## User Description:
- centralized the logic for env variable checking
- ensured it was applied consistently
