### PR TITLE
feat: update google models

### DIFF
--- a/examples/model-examples/gemini-2.5-pro-example.yaml
+++ b/examples/model-examples/gemini-2.5-pro-example.yaml
@@ -1,10 +1,11 @@
-# Example using Gemini 2.5 Pro Experimental model
-# This demonstrates a basic text generation task.
+# This example demonstrates how to use the new Gemini 2.5 Pro model with a prompt.
+#
+# To run this example, execute the following command from the project root:
+# comanda process -f examples/model-examples/gemini-2.5-pro-example.yaml
 
-generate_story_idea:
-  input: NA # No file input needed, as this is a generative prompt
-  model: gemini-2.5-pro-preview-05-06
-  action: |
-    Generate a short, compelling story idea based on the following theme:
-    "A world where gravity occasionally reverses for brief, unpredictable moments."
-  output: STDOUT # Output the generated story idea to the console
+gemini_2_5_pro_example:
+  input: NA
+  model: gemini-2.5-pro
+  action:
+    - "What are the key features of the Gemini 2.5 Pro model?"
+  output: STDOUT

--- a/utils/models/registry.go
+++ b/utils/models/registry.go
@@ -83,22 +83,17 @@ func (r *ModelRegistry) initializeDefaultModels() {
 
 	// Google models
 	r.RegisterModels("google", []string{
-		"gemini-2.5-pro-exp-03-25",
-		"gemini-2.0-flash",
-		"gemini-2.0-flash-lite",
+		"gemini-2.5-pro",
+		"gemini-2.5-flash",
+		"gemini-2.5-flash-lite",
 		"gemini-1.5-flash",
-		"gemini-1.5-flash-8b",
 		"gemini-1.5-pro",
-		"gemini-2.5-pro-preview-03-25",
-		"gemini-2.5-pro-preview-05-06",
-		"gemini-embedding-exp",
 		"gemini-1.0-pro",
-		"gemini-2.0-flash-exp",
-		"gemini-2.0-flash-001",
-		"gemini-2.0-pro-exp-02-05",
-		"gemini-2.0-flash-lite-preview-02-05",
-		"gemini-2.0-flash-thinking-exp-01-21",
 		"aqa",
+	})
+	r.RegisterFamilies("google", []string{
+		"gemini-1.5",
+		"gemini-2.5",
 	})
 
 	// Moonshot models


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Updated the list of Google Gemini models in the model registry.
- Removed outdated experimental and preview models.
- Standardized the Gemini 1.5 and 2.5 family of models.
- Updated the example YAML file to reflect the changes in the Gemini 2.5 Pro model.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/models/registry.go`: The Google models list was updated by removing several experimental and preview models, such as "gemini-2.5-pro-exp-03-25" and "gemini-2.0-flash-exp". The new list includes "gemini-2.5-pro", "gemini-2.5-flash", and "gemini-2.5-flash-lite". Additionally, model families for "gemini-1.5" and "gemini-2.5" were registered.
- `examples/model-examples/gemini-2.5-pro-example.yaml`: The example YAML file was updated to demonstrate the use of the "gemini-2.5-pro" model instead of the previous experimental version. The example now includes a prompt to list key features of the Gemini 2.5 Pro model, and instructions for running the example were added.
</details>

___
## User Description:
- clean up beta models
- standardize the 1.5 and 2.5 family of pro/flash models
