### PR TITLE
feat: support for gpt-5

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -48,6 +48,9 @@ var primaryOpenAIModels = []string{
 	"o3-pro",            // Responses API only model
 	"o3",                // Base model
 	"chatgpt-4o-latest", // ChatGPT variant
+	"gpt-5",
+	"gpt-5-mini",
+	"gpt-5-nano",
 }
 
 // Patterns for unsupported model types that should be excluded from selection

--- a/examples/model-examples/gpt-5-example.yaml
+++ b/examples/model-examples/gpt-5-example.yaml
@@ -1,0 +1,32 @@
+gpt5_example:
+  type: openai-responses
+  input:
+    - examples/example_filename.txt
+  model: gpt-5
+  instructions: "You are a helpful assistant specialized in business analysis."
+  action:
+    - analyze these company names and identify which are in the HVAC industry
+  output:
+    - STDOUT
+
+gpt5_mini_example:
+  type: openai-responses
+  input:
+    - examples/example_filename.txt
+  model: gpt-5-mini
+  instructions: "You are a helpful assistant specialized in business analysis."
+  action:
+    - analyze these company names and identify which are in the HVAC industry
+  output:
+    - STDOUT
+
+gpt5_nano_example:
+  type: openai-responses
+  input:
+    - examples/example_filename.txt
+  model: gpt-5-nano
+  instructions: "You are a helpful assistant specialized in business analysis."
+  action:
+    - analyze these company names and identify which are in the HVAC industry
+  output:
+    - STDOUT

--- a/utils/models/openai.go
+++ b/utils/models/openai.go
@@ -57,6 +57,7 @@ func (o *OpenAIProvider) SupportsModel(modelName string) bool {
 	if len(registry.GetFamilies("openai")) == 0 {
 		registry.RegisterFamilies("openai", []string{
 			"gpt-",    // Standard GPT models
+			"gpt-5",   // New GPT-5 models
 			"o1",      // To cover o1, o1-pro, o1-mini
 			"o3",      // To cover o3, o3-pro, o3-mini
 			"o4-",     // Support for o4-mini series

--- a/utils/models/registry.go
+++ b/utils/models/registry.go
@@ -63,6 +63,9 @@ func (r *ModelRegistry) initializeDefaultModels() {
 		"o3-pro",
 		"o3",
 		"chatgpt-4o-latest",
+		"gpt-5",
+		"gpt-5-mini",
+		"gpt-5-nano",
 	})
 
 	// X.AI models

--- a/utils/processor/responses_handler.go
+++ b/utils/processor/responses_handler.go
@@ -418,7 +418,10 @@ func (p *Processor) processResponsesStep(step Step, isParallel bool, parallelID 
 	}
 
 	// Use the configured provider instance
-	configuredProvider := p.providers[provider.Name()]
+	configuredProvider, err := p.getProviderForModel(modelName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get provider for model %s: %w", modelName, err)
+	}
 	if configuredProvider == nil {
 		return "", fmt.Errorf("OpenAI provider not configured")
 	}
@@ -538,7 +541,6 @@ func (p *Processor) processResponsesStep(step Step, isParallel bool, parallelID 
 	})
 
 	var response string
-	var err error
 
 	// Check if streaming is enabled
 	if step.Config.Stream {
@@ -571,8 +573,8 @@ func (p *Processor) processResponsesStep(step Step, isParallel bool, parallelID 
 		}
 
 		// Extract and store the response ID for potential future use
-		responseID, err := p.extractResponseID(response)
-		if err == nil && responseID != "" {
+		responseID, extractErr := p.extractResponseID(response)
+		if extractErr == nil && responseID != "" {
 			// Store in variables map
 			p.variables[step.Name+".response_id"] = responseID
 			p.debugf("[%s] Stored response ID: %s", step.Name, responseID)


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Added support for new GPT-5 models, including gpt-5, gpt-5-mini, and gpt-5-nano.
- Enhanced the logic for selecting and initializing model providers.
- Updated examples to include new GPT-5 models.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/configure.go`: Added new GPT-5 models (gpt-5, gpt-5-mini, gpt-5-nano) to the list of primary OpenAI models.
- `utils/models/openai.go`: Registered the new GPT-5 model family in the OpenAIProvider.
- `utils/models/registry.go`: Added GPT-5 models to the default model initialization in the ModelRegistry.
- `utils/processor/dsl.go`: Enhanced the logic for selecting a provider for a model, including initializing providers if not already done.
- `utils/processor/responses_handler.go`: Updated the processResponsesStep function to use the new provider selection logic and handle errors more gracefully.
- `examples/model-examples/gpt-5-example.yaml`: Added examples for using the new GPT-5 models, including gpt-5, gpt-5-mini, and gpt-5-nano.
</details>

___
## User Description:
- added new models in the gpt-5 family
