### PR TITLE
fix: parallel processing

### DIFF
--- a/examples/parallel-processing/parallel-inference.yaml
+++ b/examples/parallel-processing/parallel-inference.yaml
@@ -2,7 +2,7 @@ parallel-process:
   step_one:
     input:
       - NA
-    model: gpt-4.5-preview
+    model: gpt-4o-mini
     action:
       - write a sonnet about network cables
     output:
@@ -12,7 +12,7 @@ parallel-process:
     input:
       - NA
     model:
-      - o1-mini
+      - gpt-4o-mini
     action:
       - write a sonnet about network cables
     output:


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Fixed a bug in the DSL processing related to parallel step groups.
- Enhanced the DSL configuration to better handle parallel processing by adding support for parallel step groups.
- Updated example YAML to reflect changes in model names.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/dsl.go`: - Introduced logic to handle parallel step groups in the DSL configuration.
- Added a new method `isParallelStepGroup` to identify if a YAML node represents a parallel step group.
- Modified the unmarshalling process to decode both standard and parallel step configurations.
- Enhanced error handling to provide more specific error messages when decoding fails.
- `examples/parallel-processing/parallel-inference.yaml`: - Updated model names from `gpt-4.5-preview` and `o1-mini` to `gpt-4o-mini` for consistency and clarity.
</details>

___
## User Description:
- updated dsl processing to fix a bug w/parallel processing
