### PR TITLE
fix: updated ollama handling and sequencing

### DIFF
--- a/examples/model-examples/local-and-remote-gpt.yaml
+++ b/examples/model-examples/local-and-remote-gpt.yaml
@@ -1,0 +1,20 @@
+# Local vs Remote GPT Models
+# gpt-oss VIA local Ollama and gpt-4o VIA OpenAI API
+
+local_gpt_test:
+  input: NA
+  model: gpt-oss
+  action: "You are a local AI model running via Ollama. Please respond with exactly: 'I am running locally via Ollama as gpt-oss' and then explain in 2-3 sentences what makes local models useful."
+  output: local_response.txt
+
+remote_gpt_test:
+  input: NA  
+  model: gpt-4o
+  action: "You are GPT-4o running via OpenAI's API. Please respond with exactly: 'I am running remotely via OpenAI API as gpt-4o' and then explain in 2-3 sentences what makes cloud models useful."
+  output: remote_response.txt
+
+comparison:
+  input: [local_response.txt, remote_response.txt]
+  model: gpt-oss
+  action: "Compare these two responses and identify which one came from a local model vs a remote API model. Look for the identifying statements in each response and verify that different providers were used correctly."
+  output: STDOUT

--- a/utils/models/provider.go
+++ b/utils/models/provider.go
@@ -1,6 +1,12 @@
 package models
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/kris-hansen/comanda/utils/config"
 )
 
@@ -59,6 +65,79 @@ type ResponsesProvider interface {
 	SendPromptWithResponsesStream(config ResponsesConfig, handler ResponsesStreamHandler) error
 }
 
+// OllamaTagsResponse represents the response from Ollama's /api/tags endpoint
+type OllamaTagsResponse struct {
+	Models []OllamaModelTag `json:"models"`
+}
+
+// OllamaModelTag represents a single model tag from Ollama
+type OllamaModelTag struct {
+	Name string `json:"name"`
+}
+
+// isModelAvailableLocally checks if a model is available in the local Ollama instance
+func isModelAvailableLocally(modelName string) bool {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("http://localhost:11434/api/tags")
+	if err != nil {
+		config.DebugLog("[Provider] Failed to connect to Ollama: %v", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		config.DebugLog("[Provider] Ollama API returned status %d", resp.StatusCode)
+		return false
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		config.DebugLog("[Provider] Failed to read Ollama response: %v", err)
+		return false
+	}
+
+	var tagsResponse OllamaTagsResponse
+	if err := json.Unmarshal(body, &tagsResponse); err != nil {
+		config.DebugLog("[Provider] Failed to parse Ollama response: %v", err)
+		return false
+	}
+
+	modelNameLower := strings.ToLower(modelName)
+	for _, model := range tagsResponse.Models {
+		modelFullName := strings.ToLower(model.Name)
+		
+		// First check exact match
+		if modelFullName == modelNameLower {
+			config.DebugLog("[Provider] Found local model (exact match): %s", modelName)
+			return true
+		}
+		
+		// Then check if the requested model matches the base name (before :tag)
+		// e.g., "gpt-oss" should match "gpt-oss:latest"
+		if strings.Contains(modelFullName, ":") {
+			baseName := strings.Split(modelFullName, ":")[0]
+			if baseName == modelNameLower {
+				config.DebugLog("[Provider] Found local model (tag match): %s -> %s", modelName, model.Name)
+				return true
+			}
+		}
+		
+		// Also check if the full model name starts with the requested name
+		// e.g., "llama3" should match "llama3.2:latest" 
+		if strings.HasPrefix(modelFullName, modelNameLower) {
+			// Make sure we're not matching partial names unintentionally
+			nextChar := modelFullName[len(modelNameLower):]
+			if strings.HasPrefix(nextChar, ":") || strings.HasPrefix(nextChar, ".") {
+				config.DebugLog("[Provider] Found local model (prefix match): %s -> %s", modelName, model.Name)
+				return true
+			}
+		}
+	}
+
+	config.DebugLog("[Provider] Model %s not found locally", modelName)
+	return false
+}
+
 // DetectProviderFunc is the type for the provider detection function
 type DetectProviderFunc func(modelName string) Provider
 
@@ -69,7 +148,18 @@ var DetectProvider DetectProviderFunc = defaultDetectProvider
 func defaultDetectProvider(modelName string) Provider {
 	config.DebugLog("[Provider] Attempting to detect provider for model: %s", modelName)
 
-	// Order providers from most specific to most general
+	// First, check if the model is available locally via Ollama
+	// This prioritizes local models over third-party providers
+	ollamaProvider := NewOllamaProvider()
+	if ollamaProvider.SupportsModel(modelName) {
+		// Check if the model actually exists locally
+		if isModelAvailableLocally(modelName) {
+			config.DebugLog("[Provider] Found local Ollama provider for model %s", modelName)
+			return ollamaProvider
+		}
+	}
+
+	// Order third-party providers from most specific to most general
 	providers := []Provider{
 		NewGoogleProvider(),    // Handles gemini- models
 		NewAnthropicProvider(), // Handles claude- models
@@ -77,7 +167,6 @@ func defaultDetectProvider(modelName string) Provider {
 		NewDeepseekProvider(),  // Handles deepseek- models
 		NewMoonshotProvider(),  // Handles moonshot- models
 		NewOpenAIProvider(),    // Handles gpt- models
-		NewOllamaProvider(),    // Handles remaining models
 	}
 
 	for _, provider := range providers {
@@ -86,6 +175,8 @@ func defaultDetectProvider(modelName string) Provider {
 			return provider
 		}
 	}
-	config.DebugLog("[Provider] No provider found for model %s", modelName)
-	return nil
+
+	// If no third-party provider supports it, fall back to Ollama as a catch-all
+	config.DebugLog("[Provider] No third-party provider found, using Ollama as fallback for model %s", modelName)
+	return ollamaProvider
 }

--- a/utils/processor/model_handler.go
+++ b/utils/processor/model_handler.go
@@ -55,8 +55,30 @@ func checkOllamaModelExists(modelName string) (bool, error) {
 
 	modelNameLower := strings.ToLower(modelName)
 	for _, model := range tagsResponse.Models {
-		if strings.ToLower(model.Name) == modelNameLower {
-			return true, nil // Model found
+		modelFullName := strings.ToLower(model.Name)
+		
+		// First check exact match
+		if modelFullName == modelNameLower {
+			return true, nil // Model found (exact match)
+		}
+		
+		// Then check if the requested model matches the base name (before :tag)
+		// e.g., "gpt-oss" should match "gpt-oss:latest"
+		if strings.Contains(modelFullName, ":") {
+			baseName := strings.Split(modelFullName, ":")[0]
+			if baseName == modelNameLower {
+				return true, nil // Model found (tag match)
+			}
+		}
+		
+		// Also check if the full model name starts with the requested name
+		// e.g., "llama3" should match "llama3.2:latest" 
+		if strings.HasPrefix(modelFullName, modelNameLower) {
+			// Make sure we're not matching partial names unintentionally
+			nextChar := modelFullName[len(modelNameLower):]
+			if strings.HasPrefix(nextChar, ":") || strings.HasPrefix(nextChar, ".") {
+				return true, nil // Model found (prefix match)
+			}
 		}
 	}
 


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Enhanced the model configuration retrieval to handle exact and base name matches more effectively.
- Updated the Ollama provider to prioritize local models and improved model availability checks.
- Refined the OpenAI provider's model support logic to use specific patterns for validation.
- Adjusted the provider detection logic to prioritize local Ollama models before third-party providers.
- Added examples to demonstrate the handling of local vs remote GPT models.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/config/env.go`: Improved the `GetModelConfig` function to first check for an exact match of the model name. If no exact match is found, it checks for base name matches and handles ambiguity when multiple base matches exist.
- `utils/models/ollama.go`: Simplified the `SupportsModel` function for the OllamaProvider to accept any model name, relying on local availability checks to determine support.
- `utils/models/openai.go`: Refined the `SupportsModel` function for the OpenAIProvider to use specific patterns for model validation, ensuring more precise matching.
- `utils/models/provider.go`: Added functions to check local model availability in Ollama and adjusted the provider detection logic to prioritize local models over third-party providers.
- `utils/processor/model_handler.go`: Enhanced the `checkOllamaModelExists` function to perform more thorough checks for model availability, including exact, tag, and prefix matches.
- `examples/model-examples/local-and-remote-gpt.yaml`: Added examples to demonstrate the handling of local vs remote GPT models, comparing responses from a local Ollama model and a remote OpenAI API model.
</details>

___
## User Description:
- updated the ollama processing to sequence it in advance of other providers
- this fixes a bug where when a model name has the same prefix it is assumed to come from another provider
- we are now more dynamic with the lookup of ollama models and check these first before checking the other providers
