### PR TITLE
Chore: fix(go.mod): use 'go 1.23' and adjust/remove toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kris-hansen/comanda
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.23
 
 require (
 	github.com/gocolly/colly/v2 v2.2.0


### PR DESCRIPTION
- adjust to allow go install to operate normally