### PR TITLE
Claude update

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,11 @@ anthropic:
     Modes: text, vision, multi, file
   - claude-opus-4-20250514 (external)
     Modes: text, vision, multi, file
+  - claude-opus-4-1-20250805 (external)
+    Modes: text, vision, multi, file
   - claude-sonnet-4-20250514 (external)
+    Modes: text, vision, multi, file
+  - claude-sonnet-4-5-20250929 (external)
     Modes: text, vision, multi, file
 
 Users updating an existing comanda installation may need to run `comanda configure` to select and enable these new models.

--- a/examples/model-examples/claude-4-models-example.yaml
+++ b/examples/model-examples/claude-4-models-example.yaml
@@ -5,8 +5,20 @@ claude_opus_example:
   action: Write a short poem about the beauty of a sunset.
   output: STDOUT
 
+claude_opus_4_1_example:
+  input: NA
+  model: claude-opus-4-1-20250805
+  action: Analyze the themes in Shakespeare's Hamlet in 3 paragraphs.
+  output: STDOUT
+
 claude_sonnet_example:
   input: NA
   model: claude-sonnet-4-20250514
   action: Summarize the key events of the French Revolution in 5 sentences.
+  output: STDOUT
+
+claude_sonnet_4_5_example:
+  input: NA
+  model: claude-sonnet-4-5-20250929
+  action: Explain the concept of recursion in programming with a simple example.
   output: STDOUT

--- a/utils/models/anthropic.go
+++ b/utils/models/anthropic.go
@@ -84,8 +84,8 @@ type anthropicRequest struct {
 	Model       string             `json:"model"`
 	Messages    []anthropicMessage `json:"messages"`
 	MaxTokens   int                `json:"max_tokens"`
-	Temperature float64            `json:"temperature"`
-	TopP        float64            `json:"top_p"`
+	Temperature float64            `json:"temperature,omitempty"`
+	TopP        float64            `json:"top_p,omitempty"`
 }
 
 type anthropicResponse struct {
@@ -128,10 +128,12 @@ func (a *AnthropicProvider) SendPrompt(modelName string, prompt string) (string,
 				},
 			},
 		},
-		MaxTokens:   a.config.MaxTokens,
-		Temperature: a.config.Temperature,
-		TopP:        a.config.TopP,
+		MaxTokens: a.config.MaxTokens,
 	}
+
+	// Claude 4+ models only support either temperature OR top_p, not both
+	// Prefer temperature over top_p
+	reqBody.Temperature = a.config.Temperature
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
@@ -281,10 +283,12 @@ func (a *AnthropicProvider) SendPromptWithFile(modelName string, prompt string, 
 				Content: content,
 			},
 		},
-		MaxTokens:   a.config.MaxTokens,
-		Temperature: a.config.Temperature,
-		TopP:        a.config.TopP,
+		MaxTokens: a.config.MaxTokens,
 	}
+
+	// Claude 4+ models only support either temperature OR top_p, not both
+	// Prefer temperature over top_p
+	reqBody.Temperature = a.config.Temperature
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {

--- a/utils/models/registry.go
+++ b/utils/models/registry.go
@@ -41,14 +41,18 @@ func (r *ModelRegistry) initializeDefaultModels() {
 		"claude-3-7-sonnet-latest",
 		"claude-3-5-haiku-20241022",
 		"claude-opus-4-20250514",
+		"claude-opus-4-1-20250805",
 		"claude-sonnet-4-20250514",
+		"claude-sonnet-4-5-20250929",
 	})
 	r.RegisterFamilies("anthropic", []string{
 		"claude-3-5-sonnet",
 		"claude-3-5-haiku",
 		"claude-3-7-sonnet",
 		"claude-opus-4",
+		"claude-opus-4-1",
 		"claude-sonnet-4",
+		"claude-sonnet-4-5",
 	})
 
 	// OpenAI models - primary models only, the full list is fetched from the API


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Added support for new Claude models: claude-opus-4-1 and claude-sonnet-4-5.
- Updated the handling of temperature and top_p parameters for Claude 4+ models to prefer temperature over top_p.
- Updated documentation and examples to include new models.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/models/anthropic.go`: Modified the `anthropicRequest` struct to make `Temperature` and `TopP` fields optional. Updated the `SendPrompt` and `SendPromptWithFile` methods to prefer `Temperature` over `TopP` for Claude 4+ models, as they only support one of these parameters.
- `utils/models/registry.go`: Registered new Claude models: claude-opus-4-1-20250805 and claude-sonnet-4-5-20250929 in the model registry.
- `README.md`: Updated the list of supported models to include claude-opus-4-1-20250805 and claude-sonnet-4-5-20250929.
- `examples/model-examples/claude-4-models-example.yaml`: Added examples for the new models claude-opus-4-1 and claude-sonnet-4-5, demonstrating their usage with specific actions and expected outputs.
</details>

___
## User Description:
- add claude sonnet 4.5 and latest opus 4.1
