### PR TITLE
Fix spinner to print in place

### DIFF
--- a/utils/processor/spinner.go
+++ b/utils/processor/spinner.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"time"
 )
@@ -67,6 +66,7 @@ func (s *Spinner) Start(message string) {
 			select {
 			case <-s.stop:
 				s.mu.Lock()
+				defer s.mu.Unlock()
 				msg := fmt.Sprintf("%s... Done!", s.message)
 				if !s.disabled {
 					fmt.Printf("\r%s     \n", msg)
@@ -78,7 +78,6 @@ func (s *Spinner) Start(message string) {
 						Message: msg,
 					})
 				}
-				s.mu.Unlock()
 				return
 			default:
 				s.mu.Lock()

--- a/utils/processor/spinner.go
+++ b/utils/processor/spinner.go
@@ -66,14 +66,17 @@ func (s *Spinner) Start(message string) {
 			select {
 			case <-s.stop:
 				s.mu.Lock()
-				defer s.mu.Unlock()
 				msg := fmt.Sprintf("%s... Done!", s.message)
-				if !s.disabled {
+				disabled := s.disabled
+				progress := s.progress
+				s.mu.Unlock()
+
+				if !disabled {
 					fmt.Printf("\r%s     \n", msg)
 				}
 				// Send completion update
-				if s.progress != nil {
-					s.progress.WriteProgress(ProgressUpdate{
+				if progress != nil {
+					progress.WriteProgress(ProgressUpdate{
 						Type:    ProgressStep,
 						Message: msg,
 					})

--- a/utils/processor/spinner.go
+++ b/utils/processor/spinner.go
@@ -69,7 +69,7 @@ func (s *Spinner) Start(message string) {
 				s.mu.Lock()
 				msg := fmt.Sprintf("%s... Done!", s.message)
 				if !s.disabled {
-					log.Printf("\r%s     \n", msg)
+					fmt.Printf("\r%s     \n", msg)
 				}
 				// Send completion update
 				if s.progress != nil {
@@ -84,7 +84,7 @@ func (s *Spinner) Start(message string) {
 				s.mu.Lock()
 				if !s.disabled {
 					spinMsg := fmt.Sprintf("%s... %s", s.message, s.chars[s.index])
-					log.Printf("\r%s", spinMsg)
+					fmt.Printf("\r%s", spinMsg)
 					// Don't send spinner updates through progress writer
 					s.index = (s.index + 1) % len(s.chars)
 				}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Replaced `log.Printf` with `fmt.Printf` to ensure spinner animations remain on a single line.
- Ensured that spinner completion messages are preserved without introducing unintended newlines.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/spinner.go`: - Changed the output method from `log.Printf` to `fmt.Printf` for spinner messages.
- This change affects both the spinner's ongoing animation and its completion message, ensuring they print in place without extra newlines.
</details>

___
## User Description:
## Summary
- replace spinner log-based output with fmt.Printf to keep animations on a single line
- preserve spinner completion messaging while avoiding unintended newlines

## Testing
- `timeout 120 go test ./...` *(timed out/hung; interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e64c62b7c832b9d9f15781c43696a)
