### PR TITLE
Add --vars flag for CLI variable substitution

### DIFF
--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import "testing"
+
+func TestParseVarsFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		flags     []string
+		stdinData string
+		expected  map[string]string
+	}{
+		{
+			name:      "empty flags",
+			flags:     []string{},
+			stdinData: "",
+			expected:  map[string]string{},
+		},
+		{
+			name:      "single variable",
+			flags:     []string{"filename=/path/to/file.txt"},
+			stdinData: "",
+			expected:  map[string]string{"filename": "/path/to/file.txt"},
+		},
+		{
+			name:      "multiple variables",
+			flags:     []string{"key1=value1", "key2=value2"},
+			stdinData: "",
+			expected:  map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:      "STDIN variable",
+			flags:     []string{"data=STDIN"},
+			stdinData: "hello world",
+			expected:  map[string]string{"data": "hello world"},
+		},
+		{
+			name:      "mixed STDIN and regular variables",
+			flags:     []string{"filename=/path/to/file.txt", "content=STDIN"},
+			stdinData: "stdin content here",
+			expected:  map[string]string{"filename": "/path/to/file.txt", "content": "stdin content here"},
+		},
+		{
+			name:      "value with equals sign",
+			flags:     []string{"query=SELECT * FROM users WHERE id=1"},
+			stdinData: "",
+			expected:  map[string]string{"query": "SELECT * FROM users WHERE id=1"},
+		},
+		{
+			name:      "invalid format without equals",
+			flags:     []string{"invalid"},
+			stdinData: "",
+			expected:  map[string]string{},
+		},
+		{
+			name:      "empty value",
+			flags:     []string{"empty="},
+			stdinData: "",
+			expected:  map[string]string{"empty": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseVarsFlags(tt.flags, tt.stdinData)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("parseVarsFlags() returned %d items, want %d", len(result), len(tt.expected))
+			}
+
+			for key, expectedValue := range tt.expected {
+				if actualValue, ok := result[key]; !ok {
+					t.Errorf("parseVarsFlags() missing key %q", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("parseVarsFlags()[%q] = %q, want %q", key, actualValue, expectedValue)
+				}
+			}
+		})
+	}
+}

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -730,6 +730,40 @@ step_name:
 - Reference: ` + "`action: \"Compare this analysis with $initial_data\"`" + `
 - Scope: Variables are typically scoped to the workflow. For ` + "`process`" + ` steps, parent variables are not directly accessible by default; use the ` + "`process.inputs`" + ` map to pass data.
 
+## CLI Variables (Runtime Substitution)
+
+CLI variables allow runtime value injection using ` + "`--vars key=value`" + ` flags when running workflows:
+
+**Usage:**
+` + "```bash" + `
+# Single variable
+comanda process workflow.yaml --vars filename=/path/to/file.txt
+
+# Multiple variables
+comanda process workflow.yaml --vars key1=value1 --vars key2=value2
+
+# Map STDIN to a variable
+cat data.txt | comanda process workflow.yaml --vars data=STDIN
+` + "```" + `
+
+**In workflows, reference CLI variables with ` + "`{{varname}}`" + ` syntax:**
+` + "```yaml" + `
+step_name:
+  input: "tool: grep -E 'error' {{filename}}"
+  model: gpt-4o-mini
+  action: "Analyze {{project_name}} logs"
+  output: "{{output_dir}}/results.txt"
+` + "```" + `
+
+**Key differences from workflow variables (` + "`$varname`" + `):**
+- ` + "`{{varname}}`" + `: CLI-provided at runtime via ` + "`--vars`" + ` flag, substituted before processing
+- ` + "`$varname`" + `: Defined in workflow with ` + "`as $varname`" + ` syntax, scoped to workflow execution
+
+**When to use CLI variables:**
+- When the same workflow should work with different input files or parameters
+- When values need to be provided dynamically at runtime
+- When building reusable workflow templates
+
 ## Validation Rules Summary (for LLM)
 
 1.  When specifying a model name, you **must** use one of the supported models listed in the "Supported Models" section. Do not use model names that are not explicitly listed as supported.

--- a/utils/processor/output_handler.go
+++ b/utils/processor/output_handler.go
@@ -24,6 +24,12 @@ func (p *Processor) handleOutput(modelName string, response string, outputs []st
 // handleOutputWithToolConfig processes the model's response with optional tool configuration
 func (p *Processor) handleOutputWithToolConfig(modelName string, response string, outputs []string, metrics *PerformanceMetrics, toolConfig *ToolListConfig) error {
 	p.debugf("[%s] Handling %d output(s)", modelName, len(outputs))
+
+	// Apply CLI variable substitution to outputs
+	for i, output := range outputs {
+		outputs[i] = p.SubstituteCLIVariables(output)
+	}
+
 	for _, output := range outputs {
 		p.debugf("[%s] Processing output: %s", modelName, output)
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a new `--vars` flag for the `process` command to allow CLI variable substitution.
- Supports mapping of `STDIN` to a variable for dynamic input handling.
- Implements substitution of `{{varname}}` in inputs, actions, and outputs within workflows.
- Updates the embedded guide to include usage instructions for the new feature.
- Adds comprehensive tests for the new functionality, ensuring correct parsing and substitution of variables.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/process.go`: Added a new `--vars` flag to the `process` command for variable substitution. Implemented parsing of these flags into a map, handling `STDIN` as a special value. Updated the `processCmd` to include examples of using the new flag.
- `cmd/process_test.go`: Added tests for the `parseVarsFlags` function to ensure correct parsing of CLI variables, including handling of `STDIN` and various edge cases.
- `utils/processor/dsl.go`: Enhanced the `Processor` struct to include `cliVariables` for storing CLI-provided variables. Implemented `SubstituteCLIVariables` to replace `{{varname}}` with CLI values in workflow steps. Modified `NewProcessor` to accept CLI variables.
- `utils/processor/dsl_test.go`: Added tests for `SubstituteCLIVariables` to verify correct substitution of CLI variables in text. Tested `NewProcessor` initialization with and without CLI variables.
- `utils/processor/embedded_guide.go`: Updated the embedded guide to include a section on CLI variables, explaining usage, syntax, and differences from workflow variables.
- `utils/processor/output_handler.go`: Modified `handleOutputWithToolConfig` to apply CLI variable substitution to outputs, ensuring consistent variable handling across inputs, actions, and outputs.
</details>

___
## User Description:
## Summary
- Add `--vars key=value` flag to process command (repeatable)
- Support `STDIN` as value to map piped input to a variable
- Substitute `{{varname}}` in inputs, actions, and outputs
- Update embedded guide for generate awareness

## Usage
```bash
comanda process workflow.yaml --vars filename=/path/to/file.txt
cat data.txt | comanda process workflow.yaml --vars data=STDIN
```
