### PR TITLE
Improve setup instructions and remote install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ go install github.com/kris-hansen/comanda@latest
 # Or download from GitHub Releases
 ```
 
+Ensure the Go install location is on your `PATH` (often `$(go env GOPATH)/bin` or `$(go env GOBIN)`), then verify:
+
+```bash
+comanda --version
+```
+
 ### Configure
 
 ```bash
@@ -259,6 +265,16 @@ brew install kris-hansen/comanda/comanda
 ```bash
 go install github.com/kris-hansen/comanda@latest
 ```
+
+### Remote Install (Go)
+Install directly on a remote host over SSH:
+
+```bash
+ssh user@host 'GOBIN=$HOME/bin go install github.com/kris-hansen/comanda@latest'
+ssh user@host 'export PATH="$HOME/bin:$PATH"; comanda --version'
+```
+
+If you already manage Go on the remote host, you can omit `GOBIN` and rely on the default `$(go env GOPATH)/bin` in your `PATH`.
 
 ### Pre-built Binaries
 Download from [GitHub Releases](https://github.com/kris-hansen/comanda/releases) for Windows, macOS, and Linux.


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
- Updated the `README.md` to provide clearer instructions on ensuring the Go install location is on the `PATH`.
- Added verification steps using `comanda --version`.
- Introduced a new section for remote installation over SSH using Go, including setting `GOBIN` and updating `PATH`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `README.md`: - Added instructions to ensure the Go install location is on the `PATH` and verify the installation with `comanda --version`.
- Introduced a new "Remote Install (Go)" section with commands to install `comanda` on a remote host over SSH, including setting `GOBIN` and updating `PATH`.
</details>

___
## User Description:
### Motivation
- Clarify installation and verification steps and document how to perform a remote `go install` over SSH so users can confirm `comanda` is on their `PATH` and install on remote hosts.

### Description
- Update `README.md` to add guidance to ensure the Go install location is on the `PATH` and verify with `comanda --version`, and add a new "Remote Install (Go)" section showing `ssh user@host 'GOBIN=$HOME/bin go install github.com/kris-hansen/comanda@latest'` and a `PATH` note about `GOBIN`/`GOPATH`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967bbc515b0832b9406bfeb5faaaf9e)
