### PR TITLE
Inject output context into agent prompts

### DIFF
--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -1261,13 +1261,11 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 			}
 		}
 
-		// If output is a file path, inject context about where output will be saved.
+		// If output is a file path, inject context so agents know to output content directly.
 		// This helps agents (especially Claude Code in --print mode) understand that they
 		// should output content directly rather than attempting to write files themselves.
 		if outputPath := getFileOutputPath(step.Config.Output); outputPath != "" {
-			outputContext := fmt.Sprintf(
-				"[Output Handling]\nYour text output will be automatically saved to: %s\nDo not attempt to write files directly - simply output the content.\n\n",
-				outputPath)
+			outputContext := "[Output Handling]\nSimply output the content directly. Do not attempt to write files - your output will be captured automatically.\n\n"
 			substituted = outputContext + substituted
 			p.debugf("Injected output context into action (output path: %s)", outputPath)
 		}

--- a/utils/processor/dsl_test.go
+++ b/utils/processor/dsl_test.go
@@ -1078,3 +1078,81 @@ func TestFetchURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFileOutputPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   interface{}
+		expected string
+	}{
+		{
+			name:     "file path returns path",
+			output:   "/path/to/output.txt",
+			expected: "/path/to/output.txt",
+		},
+		{
+			name:     "relative file path returns path",
+			output:   "output.txt",
+			expected: "output.txt",
+		},
+		{
+			name:     "STDOUT returns empty",
+			output:   "STDOUT",
+			expected: "",
+		},
+		{
+			name:     "MEMORY returns empty",
+			output:   "MEMORY",
+			expected: "",
+		},
+		{
+			name:     "MEMORY section returns empty",
+			output:   "MEMORY:section_name",
+			expected: "",
+		},
+		{
+			name:     "tool output returns empty",
+			output:   "tool: jq '.data'",
+			expected: "",
+		},
+		{
+			name:     "pipe output returns empty",
+			output:   "STDOUT|grep pattern",
+			expected: "",
+		},
+		{
+			name:     "variable returns empty",
+			output:   "$MY_VAR",
+			expected: "",
+		},
+		{
+			name:     "empty string returns empty",
+			output:   "",
+			expected: "",
+		},
+		{
+			name:     "nil returns empty",
+			output:   nil,
+			expected: "",
+		},
+		{
+			name:     "non-string returns empty",
+			output:   123,
+			expected: "",
+		},
+		{
+			name:     "path with whitespace is trimmed",
+			output:   "  /path/to/file.txt  ",
+			expected: "/path/to/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getFileOutputPath(tt.output)
+			if result != tt.expected {
+				t.Errorf("getFileOutputPath(%v) = %q, want %q", tt.output, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a mechanism to inject context into agent prompts when a step has a file path as output.
- Adds a helper function `getFileOutputPath()` to determine if the output is a file path.
- Updates the processing logic to prepend a specific output handling message to prompts when the output is a file path.
- Provides comprehensive tests for the `getFileOutputPath()` function to ensure correct behavior across various output types.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/dsl.go`: - Added logic to inject an output handling context into agent prompts when the output is a file path. This context instructs agents to output content directly rather than attempting to write files themselves.
- Implemented the `getFileOutputPath()` function to identify file path outputs and return the path if applicable.
- `utils/processor/dsl_test.go`: - Added a new test suite `TestGetFileOutputPath` to validate the behavior of the `getFileOutputPath()` function.
- Included multiple test cases to cover different scenarios such as file paths, STDOUT, MEMORY, tool outputs, and invalid inputs.
</details>

___
## User Description:
## Summary
When a step has a file path as output, inject context into the prompt telling agents to output content directly rather than attempting to write files themselves.

## Why
Claude Code runs in `--print` mode (output-only), so agents couldn't write files directly. This context injection helps agents understand their role and avoids confusion about file write permissions.

## Changes
- Added `getFileOutputPath()` helper to detect file path outputs
- Injects `[Output Handling]` context before agent prompts
- Comprehensive tests for all output types (STDOUT, MEMORY, tool:, variables, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
