### PR TITLE
Add agentic tool use mode with refactoring and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ implement:
 echo "Write a binary search function with tests" | comanda process implement.yaml
 ```
 
+### Agentic Tool Use
+
+Enable Claude Code's full tool capabilities (Read, Write, Edit, Bash) within agentic loops:
+
+```yaml
+explore:
+  agentic_loop:
+    max_iterations: 3
+    exit_condition: llm_decides
+    allowed_paths: [./src, ./tests]  # Enable tool access to these directories
+    tools: [Read, Glob, Grep]        # Restrict to read-only tools
+  input: STDIN
+  model: claude-code
+  action: |
+    Explore the codebase and answer: {{ loop.previous_output }}
+    Say DONE when you have the answer.
+  output: STDOUT
+```
+
+Without `allowed_paths`, Claude Code runs in print-only mode. The `tools` option restricts available tools for safety.
+
 ### Server Mode
 
 Turn any workflow into an HTTP API:

--- a/examples/agentic-explore.yaml
+++ b/examples/agentic-explore.yaml
@@ -1,0 +1,31 @@
+# Agentic Exploration Example
+# This workflow uses Claude Code's full tool capabilities to explore the codebase
+#
+# The key configuration is in agentic_loop:
+#   - allowed_paths: Directories where tools can operate
+#   - tools: Optional whitelist of allowed tools (default: all)
+#
+# Without allowed_paths, Claude Code runs in --print mode (output only)
+# With allowed_paths, Claude Code can use Read, Write, Edit, Bash, Glob, Grep tools
+
+explore_codebase:
+  input: NA
+  model: claude-code-sonnet
+  agentic_loop:
+    max_iterations: 3
+    exit_condition: llm_decides
+    allowed_paths:
+      - ./
+    # tools:  # Optional - uncomment to restrict tools
+    #   - Read
+    #   - Bash
+    #   - Glob
+    #   - Grep
+  action: |
+    Explore this codebase and provide a brief summary. Use your tools to:
+    1. List the top-level directory structure
+    2. Read the main entry point (main.go or similar)
+    3. Summarize what this project does
+
+    When you have enough information, output "DONE" to exit the loop.
+  output: STDOUT

--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -65,12 +65,18 @@ type ToolConfig struct {
 	Timeout   int      `yaml:"timeout,omitempty"`   // Default timeout in seconds (0 = use system default of 30)
 }
 
+// SecurityConfig represents global security settings
+type SecurityConfig struct {
+	AllowAgenticTools bool `yaml:"allow_agentic_tools"` // Allow agentic tool use in loops (default true)
+}
+
 // EnvConfig represents the complete environment configuration
 type EnvConfig struct {
 	Providers              map[string]*Provider      `yaml:"providers"` // Changed to store pointers to Provider
 	Server                 *ServerConfig             `yaml:"server,omitempty"`
 	Databases              map[string]DatabaseConfig `yaml:"databases,omitempty"` // Added database configurations
 	Tool                   *ToolConfig               `yaml:"tool,omitempty"`      // Global tool execution settings
+	Security               *SecurityConfig           `yaml:"security,omitempty"`  // Global security settings
 	DefaultGenerationModel string                    `yaml:"default_generation_model,omitempty"`
 	MemoryFile             string                    `yaml:"memory_file,omitempty"`          // Path to COMANDA.md memory file
 	IndexEncryptionKey     string                    `yaml:"index_encryption_key,omitempty"` // Key for encrypting codebase indexes
@@ -646,6 +652,14 @@ func (c *EnvConfig) GetToolConfig() *ToolConfig {
 // SetToolConfig sets the global tool configuration
 func (c *EnvConfig) SetToolConfig(tool *ToolConfig) {
 	c.Tool = tool
+}
+
+// IsAgenticToolsAllowed returns whether agentic tool use is allowed globally
+func (c *EnvConfig) IsAgenticToolsAllowed() bool {
+	if c.Security == nil {
+		return true // default enabled
+	}
+	return c.Security.AllowAgenticTools
 }
 
 // GetAllConfiguredModels returns a list of all configured models across all providers

--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -654,10 +654,12 @@ func (c *EnvConfig) SetToolConfig(tool *ToolConfig) {
 	c.Tool = tool
 }
 
-// IsAgenticToolsAllowed returns whether agentic tool use is allowed globally
+// IsAgenticToolsAllowed returns whether agentic tool use is allowed globally.
+// When enabled (the default), agents can execute shell commands and write files
+// within allowed_paths. Set security.allow_agentic_tools: false to disable.
 func (c *EnvConfig) IsAgenticToolsAllowed() bool {
 	if c.Security == nil {
-		return true // default enabled
+		return true // default enabled for dev convenience
 	}
 	return c.Security.AllowAgenticTools
 }

--- a/utils/config/env_test.go
+++ b/utils/config/env_test.go
@@ -242,3 +242,36 @@ func TestLoadEnvConfigWithPassword(t *testing.T) {
 		t.Error("Loading invalid YAML should fail")
 	}
 }
+
+func TestIsAgenticToolsAllowed(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *EnvConfig
+		expected bool
+	}{
+		{
+			name:     "nil security config defaults to true",
+			config:   &EnvConfig{Security: nil},
+			expected: true,
+		},
+		{
+			name:     "explicitly enabled",
+			config:   &EnvConfig{Security: &SecurityConfig{AllowAgenticTools: true}},
+			expected: true,
+		},
+		{
+			name:     "explicitly disabled",
+			config:   &EnvConfig{Security: &SecurityConfig{AllowAgenticTools: false}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.config.IsAgenticToolsAllowed()
+			if result != tt.expected {
+				t.Errorf("IsAgenticToolsAllowed() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -194,16 +194,16 @@ func (c *ClaudeCodeProvider) SendPromptAgentic(modelName string, prompt string, 
 	c.debugf("Preparing to send agentic prompt via Claude Code")
 	c.debugf("Prompt length: %d characters, allowed paths: %v, tools: %v", len(prompt), allowedPaths, tools)
 
-	if c.binaryPath == "" {
-		if err := c.Configure("LOCAL"); err != nil {
-			return "", err
-		}
-	}
-
-	// Validate all allowed paths exist
+	// Validate all allowed paths exist (do this first to fail fast on bad config)
 	for _, path := range allowedPaths {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			return "", fmt.Errorf("allowed_path does not exist: %s", path)
+		}
+	}
+
+	if c.binaryPath == "" {
+		if err := c.Configure("LOCAL"); err != nil {
+			return "", err
 		}
 	}
 

--- a/utils/models/claudecode_test.go
+++ b/utils/models/claudecode_test.go
@@ -247,9 +247,9 @@ func TestClaudeCodeSendPromptAgenticPathValidation(t *testing.T) {
 	provider := NewClaudeCodeProvider()
 
 	tests := []struct {
-		name         string
-		allowedPaths []string
-		expectError  bool
+		name          string
+		allowedPaths  []string
+		expectError   bool
 		errorContains string
 	}{
 		{

--- a/utils/models/claudecode_test.go
+++ b/utils/models/claudecode_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -144,4 +145,143 @@ func TestIsClaudeCodeAvailable(t *testing.T) {
 	// The actual result depends on whether claude is installed
 	available := IsClaudeCodeAvailable()
 	t.Logf("Claude Code binary available: %v", available)
+}
+
+func TestClaudeCodeGetModelFlag(t *testing.T) {
+	provider := NewClaudeCodeProvider()
+
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		{"base claude-code", "claude-code", ""},
+		{"opus", "claude-code-opus", "claude-opus-4-5-20251101"},
+		{"sonnet", "claude-code-sonnet", "claude-sonnet-4-5-20250929"},
+		{"haiku", "claude-code-haiku", "claude-haiku-4-5-20251001"},
+		{"custom full model name", "claude-code-custom-model-123", "custom-model-123"},
+		{"single word variant", "claude-code-test", ""},
+		{"not claude-code model", "gpt-4", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.getModelFlag(tt.model)
+			if result != tt.expected {
+				t.Errorf("getModelFlag(%q) = %q, want %q", tt.model, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
+	provider := NewClaudeCodeProvider()
+
+	tests := []struct {
+		name         string
+		model        string
+		prompt       string
+		allowedPaths []string
+		tools        []string
+		contains     []string
+		notContains  []string
+	}{
+		{
+			name:         "basic agentic call",
+			model:        "claude-code-sonnet",
+			prompt:       "explore",
+			allowedPaths: []string{"./"},
+			tools:        nil,
+			contains:     []string{"--add-dir", "./", "--model", "claude-sonnet-4-5-20250929", "-p", "explore"},
+			notContains:  []string{"--print"},
+		},
+		{
+			name:         "with tool restrictions",
+			model:        "claude-code",
+			prompt:       "test",
+			allowedPaths: []string{"/tmp"},
+			tools:        []string{"Read", "Bash"},
+			contains:     []string{"--add-dir", "/tmp", "--tools", "Read,Bash", "-p", "test"},
+			notContains:  []string{"--print", "--model"},
+		},
+		{
+			name:         "multiple paths",
+			model:        "claude-code-opus",
+			prompt:       "analyze",
+			allowedPaths: []string{"./src", "./tests"},
+			tools:        nil,
+			contains:     []string{"--add-dir", "./src", "--add-dir", "./tests", "-p", "analyze"},
+			notContains:  []string{"--print"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := provider.buildArgsAgentic(tt.model, tt.prompt, tt.allowedPaths, tt.tools)
+
+			for _, expected := range tt.contains {
+				found := false
+				for _, arg := range args {
+					if arg == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("buildArgsAgentic() missing expected arg %q, got: %v", expected, args)
+				}
+			}
+
+			for _, notExpected := range tt.notContains {
+				for _, arg := range args {
+					if arg == notExpected {
+						t.Errorf("buildArgsAgentic() should not contain %q, got: %v", notExpected, args)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestClaudeCodeSendPromptAgenticPathValidation(t *testing.T) {
+	provider := NewClaudeCodeProvider()
+
+	tests := []struct {
+		name         string
+		allowedPaths []string
+		expectError  bool
+		errorContains string
+	}{
+		{
+			name:         "valid path",
+			allowedPaths: []string{"."},
+			expectError:  false,
+		},
+		{
+			name:          "invalid path",
+			allowedPaths:  []string{"/nonexistent/path/that/does/not/exist"},
+			expectError:   true,
+			errorContains: "allowed_path does not exist",
+		},
+		{
+			name:          "mixed valid and invalid",
+			allowedPaths:  []string{".", "/nonexistent/path"},
+			expectError:   true,
+			errorContains: "allowed_path does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := provider.SendPromptAgentic("claude-code", "test", tt.allowedPaths, nil, "")
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("SendPromptAgentic() expected error, got nil")
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("SendPromptAgentic() error = %v, want error containing %q", err, tt.errorContains)
+				}
+			}
+			// Note: valid paths may still fail if claude binary not found, that's ok
+		})
+	}
 }

--- a/utils/processor/action_handler.go
+++ b/utils/processor/action_handler.go
@@ -74,7 +74,8 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 	p.debugf("Processing %d action(s)", len(actions))
 
 	// Check if we're in agentic mode (have allowed paths set in agentic loop)
-	isAgenticMode := p.currentAgenticConfig != nil && len(p.currentAgenticConfig.AllowedPaths) > 0
+	agenticConfig := p.getAgenticConfig()
+	isAgenticMode := agenticConfig != nil && len(agenticConfig.AllowedPaths) > 0
 
 	for i, action := range actions {
 		p.debugf("Processing action %d/%d: %s", i+1, len(actions), action)
@@ -96,9 +97,9 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 			if isAgenticMode {
 				if claudeCode, ok := configuredProvider.(*models.ClaudeCodeProvider); ok {
 					p.debugf("Using agentic mode with Claude Code (paths: %v, tools: %v)",
-						p.currentAgenticConfig.AllowedPaths, p.currentAgenticConfig.Tools)
+						agenticConfig.AllowedPaths, agenticConfig.Tools)
 					result, err := claudeCode.SendPromptAgentic(modelName, action,
-						p.currentAgenticConfig.AllowedPaths, p.currentAgenticConfig.Tools, p.runtimeDir)
+						agenticConfig.AllowedPaths, agenticConfig.Tools, p.runtimeDir)
 					if err != nil {
 						return nil, err
 					}
@@ -264,7 +265,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 				if claudeCode, ok := configuredProvider.(*models.ClaudeCodeProvider); ok {
 					p.debugf("Using agentic mode with Claude Code for non-file inputs")
 					result, err := claudeCode.SendPromptAgentic(modelName, combinedPrompt,
-						p.currentAgenticConfig.AllowedPaths, p.currentAgenticConfig.Tools, p.runtimeDir)
+						agenticConfig.AllowedPaths, agenticConfig.Tools, p.runtimeDir)
 					if err != nil {
 						return nil, err
 					}

--- a/utils/processor/action_handler.go
+++ b/utils/processor/action_handler.go
@@ -73,6 +73,9 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 	p.debugf("Using model %s with provider %s", modelName, configuredProvider.Name())
 	p.debugf("Processing %d action(s)", len(actions))
 
+	// Check if we're in agentic mode (have allowed paths set in agentic loop)
+	isAgenticMode := p.currentAgenticConfig != nil && len(p.currentAgenticConfig.AllowedPaths) > 0
+
 	for i, action := range actions {
 		p.debugf("Processing action %d/%d: %s", i+1, len(actions), action)
 
@@ -89,6 +92,22 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 		inputs := p.handler.GetInputs()
 		if len(inputs) == 0 {
 			// If there are no inputs, just send the action directly
+			// Check for agentic mode with Claude Code
+			if isAgenticMode {
+				if claudeCode, ok := configuredProvider.(*models.ClaudeCodeProvider); ok {
+					p.debugf("Using agentic mode with Claude Code (paths: %v, tools: %v)",
+						p.currentAgenticConfig.AllowedPaths, p.currentAgenticConfig.Tools)
+					result, err := claudeCode.SendPromptAgentic(modelName, action,
+						p.currentAgenticConfig.AllowedPaths, p.currentAgenticConfig.Tools, p.runtimeDir)
+					if err != nil {
+						return nil, err
+					}
+					return &ActionResult{
+						CombinedResult:       result,
+						HasIndividualResults: false,
+					}, nil
+				}
+			}
 			result, err := configuredProvider.SendPrompt(modelName, action)
 			if err != nil {
 				return nil, err
@@ -238,7 +257,25 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 		// If we have non-file inputs, combine them and use SendPrompt
 		if len(nonFileInputs) > 0 {
 			combinedInput := strings.Join(nonFileInputs, "\n\n")
-			result, err := configuredProvider.SendPrompt(modelName, fmt.Sprintf("Input:\n%s\n\nAction: %s", combinedInput, action))
+			combinedPrompt := fmt.Sprintf("Input:\n%s\n\nAction: %s", combinedInput, action)
+
+			// Check for agentic mode with Claude Code
+			if isAgenticMode {
+				if claudeCode, ok := configuredProvider.(*models.ClaudeCodeProvider); ok {
+					p.debugf("Using agentic mode with Claude Code for non-file inputs")
+					result, err := claudeCode.SendPromptAgentic(modelName, combinedPrompt,
+						p.currentAgenticConfig.AllowedPaths, p.currentAgenticConfig.Tools, p.runtimeDir)
+					if err != nil {
+						return nil, err
+					}
+					return &ActionResult{
+						CombinedResult:       result,
+						HasIndividualResults: false,
+					}, nil
+				}
+			}
+
+			result, err := configuredProvider.SendPrompt(modelName, combinedPrompt)
 			if err != nil {
 				return nil, err
 			}

--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -28,9 +28,9 @@ func (p *Processor) processAgenticLoop(loopName string, config *AgenticLoopConfi
 	}
 
 	// Set the current agentic config (used by action handler)
-	p.currentAgenticConfig = config
+	p.setAgenticConfig(config)
 	defer func() {
-		p.currentAgenticConfig = nil
+		p.setAgenticConfig(nil)
 	}()
 
 	// Apply defaults

--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -19,6 +19,20 @@ const (
 func (p *Processor) processAgenticLoop(loopName string, config *AgenticLoopConfig, initialInput string) (string, error) {
 	p.debugf("Starting agentic loop: %s", loopName)
 
+	// Check if agentic tools are enabled and we have allowed paths
+	if len(config.AllowedPaths) > 0 {
+		if p.envConfig != nil && !p.envConfig.IsAgenticToolsAllowed() {
+			return "", fmt.Errorf("agentic tool use is disabled in global config (security.allow_agentic_tools: false)")
+		}
+		p.debugf("Agentic tools enabled with allowed paths: %v, tools: %v", config.AllowedPaths, config.Tools)
+	}
+
+	// Set the current agentic config (used by action handler)
+	p.currentAgenticConfig = config
+	defer func() {
+		p.currentAgenticConfig = nil
+	}()
+
 	// Apply defaults
 	maxIterations := config.MaxIterations
 	if maxIterations <= 0 {

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -34,22 +34,22 @@ type ProcessStepConfig struct {
 
 // Processor handles the DSL processing pipeline
 type Processor struct {
-	config              *DSLConfig
-	envConfig           *config.EnvConfig
-	serverConfig        *config.ServerConfig   // Add server config
-	handler             *input.Handler
-	validator           *input.Validator
-	providers           map[string]models.Provider
-	verbose             bool
-	lastOutput          string
-	spinner             *Spinner
-	variables           map[string]string // Store variables from STDIN
-	cliVariables        map[string]string // CLI-provided variables for {{var}} substitution
-	progress            ProgressWriter    // Progress writer for streaming updates
-	runtimeDir          string            // Runtime directory for file operations
-	memory              *MemoryManager    // Memory manager for COMANDA.md file
-	externalMemory      string            // External memory context (e.g., from OpenAI messages)
-	mu                  sync.Mutex        // Mutex for thread-safe debug logging
+	config               *DSLConfig
+	envConfig            *config.EnvConfig
+	serverConfig         *config.ServerConfig // Add server config
+	handler              *input.Handler
+	validator            *input.Validator
+	providers            map[string]models.Provider
+	verbose              bool
+	lastOutput           string
+	spinner              *Spinner
+	variables            map[string]string  // Store variables from STDIN
+	cliVariables         map[string]string  // CLI-provided variables for {{var}} substitution
+	progress             ProgressWriter     // Progress writer for streaming updates
+	runtimeDir           string             // Runtime directory for file operations
+	memory               *MemoryManager     // Memory manager for COMANDA.md file
+	externalMemory       string             // External memory context (e.g., from OpenAI messages)
+	mu                   sync.Mutex         // Mutex for thread-safe debug logging
 	currentAgenticConfig *AgenticLoopConfig // Current agentic loop config (set during agentic loop execution)
 }
 

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -329,12 +329,30 @@ agentic-loop:
   - ` + "`pattern_match`" + `: Exits when output matches ` + "`exit_pattern`" + ` regex
 - ` + "`exit_pattern`" + `: (string) Regex pattern for ` + "`pattern_match`" + ` condition.
 - ` + "`context_window`" + `: (int, default: 5) Number of past iterations to include in context.
+- ` + "`allowed_paths`" + `: (list, optional) Directories where Claude Code can use tools (Read, Write, Edit, Bash, etc.). Without this, Claude Code runs in print-only mode.
+- ` + "`tools`" + `: (list, optional) Restrict available tools (e.g., ` + "`[Read, Glob, Grep]`" + ` for read-only access). If omitted, all tools are available.
 
 **Template Variables in Actions:**
 - ` + "`{{ loop.iteration }}`" + `: Current iteration number (1-based)
 - ` + "`{{ loop.previous_output }}`" + `: Output from previous iteration
 - ` + "`{{ loop.total_iterations }}`" + `: Maximum allowed iterations
 - ` + "`{{ loop.elapsed_seconds }}`" + `: Seconds since loop started
+
+**Example: Agentic Code Exploration**
+` + "```yaml" + `
+explore_codebase:
+  agentic_loop:
+    max_iterations: 3
+    exit_condition: llm_decides
+    allowed_paths: [./src, ./tests]
+    tools: [Read, Glob, Grep]  # Read-only access
+  input: STDIN
+  model: claude-code
+  action: |
+    Explore the codebase and answer: {{ loop.previous_output }}
+    Say DONE when you have the answer.
+  output: STDOUT
+` + "```" + `
 
 **Example: Iterative Code Implementation**
 ` + "```yaml" + `
@@ -878,12 +896,30 @@ agentic-loop:
   - ` + "`pattern_match`" + `: Exits when output matches ` + "`exit_pattern`" + ` regex
 - ` + "`exit_pattern`" + `: (string) Regex pattern for ` + "`pattern_match`" + ` condition.
 - ` + "`context_window`" + `: (int, default: 5) Number of past iterations to include in context.
+- ` + "`allowed_paths`" + `: (list, optional) Directories where Claude Code can use tools (Read, Write, Edit, Bash, etc.). Without this, Claude Code runs in print-only mode.
+- ` + "`tools`" + `: (list, optional) Restrict available tools (e.g., ` + "`[Read, Glob, Grep]`" + ` for read-only access). If omitted, all tools are available.
 
 **Template Variables in Actions:**
 - ` + "`{{ loop.iteration }}`" + `: Current iteration number (1-based)
 - ` + "`{{ loop.previous_output }}`" + `: Output from previous iteration
 - ` + "`{{ loop.total_iterations }}`" + `: Maximum allowed iterations
 - ` + "`{{ loop.elapsed_seconds }}`" + `: Seconds since loop started
+
+**Example: Agentic Code Exploration**
+` + "```yaml" + `
+explore_codebase:
+  agentic_loop:
+    max_iterations: 3
+    exit_condition: llm_decides
+    allowed_paths: [./src, ./tests]
+    tools: [Read, Glob, Grep]  # Read-only access
+  input: STDIN
+  model: claude-code
+  action: |
+    Explore the codebase and answer: {{ loop.previous_output }}
+    Say DONE when you have the answer.
+  output: STDOUT
+` + "```" + `
 
 **Example: Iterative Code Implementation**
 ` + "```yaml" + `

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -4,12 +4,12 @@ import "time"
 
 // AgenticLoopConfig represents the configuration for an agentic loop
 type AgenticLoopConfig struct {
-	MaxIterations  int      `yaml:"max_iterations"`        // Maximum iterations before stopping (default: 10)
-	TimeoutSeconds int      `yaml:"timeout_seconds"`       // Total timeout in seconds (default: 300)
-	ExitCondition  string   `yaml:"exit_condition"`        // Exit condition: llm_decides, pattern_match
-	ExitPattern    string   `yaml:"exit_pattern"`          // Regex pattern for pattern_match exit condition
-	ContextWindow  int      `yaml:"context_window"`        // Number of past iterations to include in context (default: 5)
-	Steps          []Step   `yaml:"steps,omitempty"`       // Sub-steps to execute within each iteration
+	MaxIterations  int      `yaml:"max_iterations"`          // Maximum iterations before stopping (default: 10)
+	TimeoutSeconds int      `yaml:"timeout_seconds"`         // Total timeout in seconds (default: 300)
+	ExitCondition  string   `yaml:"exit_condition"`          // Exit condition: llm_decides, pattern_match
+	ExitPattern    string   `yaml:"exit_pattern"`            // Regex pattern for pattern_match exit condition
+	ContextWindow  int      `yaml:"context_window"`          // Number of past iterations to include in context (default: 5)
+	Steps          []Step   `yaml:"steps,omitempty"`         // Sub-steps to execute within each iteration
 	AllowedPaths   []string `yaml:"allowed_paths,omitempty"` // Directories for agentic tool access
 	Tools          []string `yaml:"tools,omitempty"`         // Optional tool whitelist (Read, Write, Edit, Bash, etc.)
 }

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -4,12 +4,14 @@ import "time"
 
 // AgenticLoopConfig represents the configuration for an agentic loop
 type AgenticLoopConfig struct {
-	MaxIterations  int    `yaml:"max_iterations"`  // Maximum iterations before stopping (default: 10)
-	TimeoutSeconds int    `yaml:"timeout_seconds"` // Total timeout in seconds (default: 300)
-	ExitCondition  string `yaml:"exit_condition"`  // Exit condition: llm_decides, pattern_match
-	ExitPattern    string `yaml:"exit_pattern"`    // Regex pattern for pattern_match exit condition
-	ContextWindow  int    `yaml:"context_window"`  // Number of past iterations to include in context (default: 5)
-	Steps          []Step `yaml:"steps,omitempty"` // Sub-steps to execute within each iteration
+	MaxIterations  int      `yaml:"max_iterations"`        // Maximum iterations before stopping (default: 10)
+	TimeoutSeconds int      `yaml:"timeout_seconds"`       // Total timeout in seconds (default: 300)
+	ExitCondition  string   `yaml:"exit_condition"`        // Exit condition: llm_decides, pattern_match
+	ExitPattern    string   `yaml:"exit_pattern"`          // Regex pattern for pattern_match exit condition
+	ContextWindow  int      `yaml:"context_window"`        // Number of past iterations to include in context (default: 5)
+	Steps          []Step   `yaml:"steps,omitempty"`       // Sub-steps to execute within each iteration
+	AllowedPaths   []string `yaml:"allowed_paths,omitempty"` // Directories for agentic tool access
+	Tools          []string `yaml:"tools,omitempty"`         // Optional tool whitelist (Read, Write, Edit, Bash, etc.)
 }
 
 // LoopContext holds runtime state for an agentic loop


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces agentic tool use mode, allowing full tool access in loops.
- Adds a new `SecurityConfig` to manage global security settings, including the ability to enable or disable agentic tools.
- Implements path validation for `allowed_paths` to ensure paths exist before execution.
- Refactors model mapping logic into a helper function `getModelFlag()` to reduce duplication.
- Provides comprehensive test coverage for new functionalities, including agentic mode, path validation, and model flag retrieval.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/config/env.go`: Added `SecurityConfig` to manage global security settings, including a flag to allow agentic tools. Introduced `IsAgenticToolsAllowed` method to check if agentic tools are enabled.
- `utils/config/env_test.go`: Added tests for `IsAgenticToolsAllowed` to ensure correct behavior when security settings are nil, enabled, or disabled.
- `utils/models/claudecode.go`: Introduced `SendPromptAgentic` for sending prompts with full tool access. Added `getModelFlag` to retrieve model flags based on model names. Refactored argument building for agentic mode.
- `utils/models/claudecode_test.go`: Added tests for `getModelFlag` and `buildArgsAgentic` to verify correct argument construction and model flag retrieval. Included path validation tests for `SendPromptAgentic`.
- `utils/processor/action_handler.go`: Integrated agentic mode checks and execution within the action processing logic, allowing for tool use when agentic mode is enabled.
- `utils/processor/agentic_loop.go`: Added checks to ensure agentic tools are enabled before proceeding with agentic loops. Set current agentic configuration for use in action handling.
- `utils/processor/dsl.go`: Updated `Processor` struct to include `currentAgenticConfig`. Modified output handling to skip context injection when in agentic mode.
- `utils/processor/types.go`: Extended `AgenticLoopConfig` to include `AllowedPaths` and `Tools` for specifying directories and tools available in agentic mode.
- `examples/agentic-explore.yaml`: Added an example YAML configuration demonstrating the use of agentic mode with Claude Code, including allowed paths and optional tool restrictions.
</details>

___
## User Description:
## Summary
- Enables Claude Code agentic mode with full tool access (Read, Write, Edit, Bash, etc.)
- Refactored model mapping to eliminate duplication via `getModelFlag()` helper
- Added path validation for `allowed_paths` with fail-fast error handling
- Comprehensive test coverage for new functionality

## Test plan
- All 17 new tests pass (getModelFlag, buildArgsAgentic, pathValidation, security config)
- Full test suite passes without regressions
- Build succeeds with no errors

🤖 Generated with Claude Code
