### PR TITLE
Add permission-mode flag for non-interactive agentic tool use

### DIFF
--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -279,6 +279,12 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 		args = append(args, "--add-dir", path)
 	}
 
+	// Enable bypass permissions for non-interactive agentic use
+	// Without this, Claude Code prompts for permission which blocks non-interactive execution
+	if len(allowedPaths) > 0 {
+		args = append(args, "--permission-mode", "bypassPermissions")
+	}
+
 	// Restrict tools if specified
 	if len(tools) > 0 {
 		args = append(args, "--tools", strings.Join(tools, ","))

--- a/utils/models/claudecode_test.go
+++ b/utils/models/claudecode_test.go
@@ -192,7 +192,7 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 			prompt:       "explore",
 			allowedPaths: []string{"./"},
 			tools:        nil,
-			contains:     []string{"--add-dir", "./", "--model", "claude-sonnet-4-5-20250929", "-p", "explore"},
+			contains:     []string{"--add-dir", "./", "--permission-mode", "bypassPermissions", "--model", "claude-sonnet-4-5-20250929", "-p", "explore"},
 			notContains:  []string{"--print"},
 		},
 		{
@@ -201,7 +201,7 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 			prompt:       "test",
 			allowedPaths: []string{"/tmp"},
 			tools:        []string{"Read", "Bash"},
-			contains:     []string{"--add-dir", "/tmp", "--tools", "Read,Bash", "-p", "test"},
+			contains:     []string{"--add-dir", "/tmp", "--permission-mode", "bypassPermissions", "--tools", "Read,Bash", "-p", "test"},
 			notContains:  []string{"--print", "--model"},
 		},
 		{
@@ -210,8 +210,17 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 			prompt:       "analyze",
 			allowedPaths: []string{"./src", "./tests"},
 			tools:        nil,
-			contains:     []string{"--add-dir", "./src", "--add-dir", "./tests", "-p", "analyze"},
+			contains:     []string{"--add-dir", "./src", "--add-dir", "./tests", "--permission-mode", "bypassPermissions", "-p", "analyze"},
 			notContains:  []string{"--print"},
+		},
+		{
+			name:         "no allowed paths skips permission mode",
+			model:        "claude-code",
+			prompt:       "query",
+			allowedPaths: []string{},
+			tools:        nil,
+			contains:     []string{"-p", "query"},
+			notContains:  []string{"--print", "--add-dir", "--permission-mode"},
 		},
 	}
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a `--permission-mode bypassPermissions` flag to enable non-interactive execution when `allowedPaths` are specified.
- Ensures that the flag is only added when paths are defined, maintaining the security model.
- Updates the agentic mode builder to include the new permission flag.
- Modifies existing tests to account for the new flag and adds a new test case for scenarios with no allowed paths.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/models/claudecode.go`: Added logic to append the `--permission-mode bypassPermissions` flag to the arguments list if `allowedPaths` is not empty. This change ensures that Claude Code does not prompt for permissions during non-interactive execution.
- `utils/models/claudecode_test.go`: Updated test cases to check for the presence of the `--permission-mode bypassPermissions` flag in scenarios where `allowedPaths` are specified. Added a new test case to verify that the flag is not included when `allowedPaths` is empty.
</details>

___
## User Description:
Enable truly non-interactive execution by adding the --permission-mode bypassPermissions flag when allowedPaths are specified. This prevents Claude Code from prompting for permissions during automated workflows.

The flag is only added when paths are defined, maintaining the security model where allowedPaths define the scope of access.

- Updated agentic mode builder to include permission flag
- Updated existing tests and added edge case test for empty allowedPaths
