### PR TITLE
Fix Claude Code permission bypass for agentic workflows

### DIFF
--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -282,7 +282,7 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 	// Enable bypass permissions for non-interactive agentic use
 	// Without this, Claude Code prompts for permission which blocks non-interactive execution
 	if len(allowedPaths) > 0 {
-		args = append(args, "--permission-mode", "bypassPermissions")
+		args = append(args, "--dangerously-skip-permissions")
 	}
 
 	// Restrict tools if specified

--- a/utils/models/claudecode_test.go
+++ b/utils/models/claudecode_test.go
@@ -192,7 +192,7 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 			prompt:       "explore",
 			allowedPaths: []string{"./"},
 			tools:        nil,
-			contains:     []string{"--add-dir", "./", "--permission-mode", "bypassPermissions", "--model", "claude-sonnet-4-5-20250929", "-p", "explore"},
+			contains:     []string{"--add-dir", "./", "--dangerously-skip-permissions", "--model", "claude-sonnet-4-5-20250929", "-p", "explore"},
 			notContains:  []string{"--print"},
 		},
 		{
@@ -201,7 +201,7 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 			prompt:       "test",
 			allowedPaths: []string{"/tmp"},
 			tools:        []string{"Read", "Bash"},
-			contains:     []string{"--add-dir", "/tmp", "--permission-mode", "bypassPermissions", "--tools", "Read,Bash", "-p", "test"},
+			contains:     []string{"--add-dir", "/tmp", "--dangerously-skip-permissions", "--tools", "Read,Bash", "-p", "test"},
 			notContains:  []string{"--print", "--model"},
 		},
 		{
@@ -210,7 +210,7 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 			prompt:       "analyze",
 			allowedPaths: []string{"./src", "./tests"},
 			tools:        nil,
-			contains:     []string{"--add-dir", "./src", "--add-dir", "./tests", "--permission-mode", "bypassPermissions", "-p", "analyze"},
+			contains:     []string{"--add-dir", "./src", "--add-dir", "./tests", "--dangerously-skip-permissions", "-p", "analyze"},
 			notContains:  []string{"--print"},
 		},
 		{
@@ -220,7 +220,7 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 			allowedPaths: []string{},
 			tools:        nil,
 			contains:     []string{"-p", "query"},
-			notContains:  []string{"--print", "--add-dir", "--permission-mode"},
+			notContains:  []string{"--print", "--add-dir", "--dangerously-skip-permissions"},
 		},
 	}
 

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -329,7 +329,7 @@ agentic-loop:
   - ` + "`pattern_match`" + `: Exits when output matches ` + "`exit_pattern`" + ` regex
 - ` + "`exit_pattern`" + `: (string) Regex pattern for ` + "`pattern_match`" + ` condition.
 - ` + "`context_window`" + `: (int, default: 5) Number of past iterations to include in context.
-- ` + "`allowed_paths`" + `: (list, optional) Directories where Claude Code can use tools (Read, Write, Edit, Bash, etc.). Without this, Claude Code runs in print-only mode.
+- ` + "`allowed_paths`" + `: (list, **REQUIRED for file operations**) Directories where Claude Code can use tools (Read, Write, Edit, Bash, etc.). **Without this, Claude Code runs in print-only mode and CANNOT read/write files.** When generating workflows, infer paths from: the ` + "`codebase_index.root`" + ` if present, file paths mentioned in the action, or use ` + "`[.]`" + ` (current directory) as fallback.
 - ` + "`tools`" + `: (list, optional) Restrict available tools (e.g., ` + "`[Read, Glob, Grep]`" + ` for read-only access). If omitted, all tools are available.
 
 **Template Variables in Actions:**
@@ -361,6 +361,7 @@ implement:
     max_iterations: 3
     exit_condition: pattern_match
     exit_pattern: "SATISFIED"
+    allowed_paths: [.]  # Required for file operations
   input: STDIN
   model: claude-code
   action: |
@@ -378,6 +379,7 @@ agentic-loop:
   config:
     max_iterations: 5
     exit_condition: llm_decides
+    allowed_paths: [.]  # Required for file operations
 
   steps:
     plan:
@@ -395,6 +397,13 @@ agentic-loop:
       action: "Generate code based on the plan"
       output: STDOUT
 ` + "```" + `
+
+**CRITICAL: When generating agentic_loop workflows with Claude Code:**
+- **ALWAYS include ` + "`allowed_paths`" + `** - Claude Code CANNOT read/write files without it
+- If the workflow uses ` + "`codebase_index`" + `, use the same ` + "`root`" + ` directory in ` + "`allowed_paths`" + `
+- If the action mentions specific file paths or directories, include those directories
+- When in doubt, use ` + "`allowed_paths: [.]`" + ` for current directory access
+- Forgetting ` + "`allowed_paths`" + ` is a common error that causes "permission denied" failures
 
 ## 5. Codebase Index Step Definition (` + "`codebase_index`" + `)
 
@@ -896,7 +905,7 @@ agentic-loop:
   - ` + "`pattern_match`" + `: Exits when output matches ` + "`exit_pattern`" + ` regex
 - ` + "`exit_pattern`" + `: (string) Regex pattern for ` + "`pattern_match`" + ` condition.
 - ` + "`context_window`" + `: (int, default: 5) Number of past iterations to include in context.
-- ` + "`allowed_paths`" + `: (list, optional) Directories where Claude Code can use tools (Read, Write, Edit, Bash, etc.). Without this, Claude Code runs in print-only mode.
+- ` + "`allowed_paths`" + `: (list, **REQUIRED for file operations**) Directories where Claude Code can use tools (Read, Write, Edit, Bash, etc.). **Without this, Claude Code runs in print-only mode and CANNOT read/write files.** When generating workflows, infer paths from: the ` + "`codebase_index.root`" + ` if present, file paths mentioned in the action, or use ` + "`[.]`" + ` (current directory) as fallback.
 - ` + "`tools`" + `: (list, optional) Restrict available tools (e.g., ` + "`[Read, Glob, Grep]`" + ` for read-only access). If omitted, all tools are available.
 
 **Template Variables in Actions:**
@@ -928,6 +937,7 @@ implement:
     max_iterations: 3
     exit_condition: pattern_match
     exit_pattern: "SATISFIED"
+    allowed_paths: [.]  # Required for file operations
   input: STDIN
   model: claude-code
   action: |
@@ -945,6 +955,7 @@ agentic-loop:
   config:
     max_iterations: 5
     exit_condition: llm_decides
+    allowed_paths: [.]  # Required for file operations
 
   steps:
     plan:
@@ -962,6 +973,13 @@ agentic-loop:
       action: "Generate code based on the plan"
       output: STDOUT
 ` + "```" + `
+
+**CRITICAL: When generating agentic_loop workflows with Claude Code:**
+- **ALWAYS include ` + "`allowed_paths`" + `** - Claude Code CANNOT read/write files without it
+- If the workflow uses ` + "`codebase_index`" + `, use the same ` + "`root`" + ` directory in ` + "`allowed_paths`" + `
+- If the action mentions specific file paths or directories, include those directories
+- When in doubt, use ` + "`allowed_paths: [.]`" + ` for current directory access
+- Forgetting ` + "`allowed_paths`" + ` is a common error that causes "permission denied" failures
 
 ## 5. Codebase Index Step Definition (` + "`codebase_index`" + `)
 


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Replaces the `--permission-mode bypassPermissions` flag with `--dangerously-skip-permissions` to correctly bypass permission checks in non-interactive agentic workflows.
- Updates the embedded DSL guide to emphasize that `allowed_paths` is required for file operations, preventing permission denied errors.
- Provides examples in the DSL guide to demonstrate proper usage of `allowed_paths`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/models/claudecode.go`: The `buildArgsAgentic` function now uses the `--dangerously-skip-permissions` flag instead of `--permission-mode bypassPermissions` to ensure permissions are bypassed correctly for non-interactive agentic workflows.
- `utils/models/claudecode_test.go`: Updated test cases to reflect the change from `--permission-mode bypassPermissions` to `--dangerously-skip-permissions` in the `contains` and `notContains` arrays, ensuring tests align with the new permission handling logic.
- `utils/processor/embedded_guide.go`: Revised the DSL guide to clarify that `allowed_paths` is required for file operations. Added examples and critical notes to emphasize the importance of including `allowed_paths` to avoid permission denied errors in generated workflows.
</details>

___
## User Description:
Use `--dangerously-skip-permissions` instead of `--permission-mode bypassPermissions`. The previous flag was not actually bypassing permission checks.

Also updates the embedded DSL guide to clarify that `allowed_paths` is REQUIRED for file operations in agentic loops, and adds examples showing proper usage. This prevents generated workflows from failing with permission denied errors.

Fixes agentic workflows created by `comanda generate` that include Claude Code but miss write permissions.
