### PR TITLE
fix: agentic loop validation and chart rendering

### DIFF
--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -697,15 +697,15 @@ func (p *Processor) Process() error {
 	}
 
 	// Check if we have any steps to process
-	if len(p.config.Steps) == 0 && len(p.config.ParallelSteps) == 0 {
+	if len(p.config.Steps) == 0 && len(p.config.ParallelSteps) == 0 && len(p.config.AgenticLoops) == 0 {
 		err := fmt.Errorf("no steps defined in DSL configuration")
 		p.debugf("Validation error: %v", err)
 		p.emitError(err)
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	p.debugf("Initial validation passed: found %d sequential steps and %d parallel step groups",
-		len(p.config.Steps), len(p.config.ParallelSteps))
+	p.debugf("Initial validation passed: found %d sequential steps, %d parallel step groups, and %d agentic loops",
+		len(p.config.Steps), len(p.config.ParallelSteps), len(p.config.AgenticLoops))
 
 	// First validate all steps before processing
 	p.spinner.Start("Validating DSL configuration")


### PR DESCRIPTION
## Summary

Fixes two bugs with standalone `agentic-loop:` YAML workflows (the block syntax using `config:` + `steps:`).

### Bug 1: "no steps defined in DSL configuration" error (`dsl.go`)

`Process()` validates that steps exist before execution, but only checked `Steps` and `ParallelSteps` — not `AgenticLoops`. A YAML file containing only a standalone `agentic-loop:` block would fail validation before reaching the agentic loop executor.

**Fix:** Added `len(p.config.AgenticLoops) == 0` to the early validation guard.

### Bug 2: Chart command doesn't render standalone agentic-loop blocks (`chart.go`)

`buildWorkflowChart()` had an early return for multi-loop orchestration (`config.Loops`), but standalone `agentic-loop:` blocks populate `config.AgenticLoops` — which was not handled. The chart showed `(no steps defined)`.

**Fix:** Added `processAgenticLoopBlocks()` and `renderAgenticLoopBox()`:
- Detects standalone agentic-loop blocks via `config.AgenticLoops`
- Renders a bordered container with loop config (name, max iterations, exit condition, stateful flag, context window, timeout)
- Shows sub-steps inside the container with a loop-back indicator
- Statistics box counts agentic loop steps correctly

### Re: Preston's default values comment
`MaxIterations` and `TimeoutSeconds` defaults are already handled at runtime in `agentic_loop.go` (lines 15-16, 44-52). Go zero values work correctly here since the runtime applies `DefaultMaxIterations=10` and `DefaultTimeoutSeconds=0` (unlimited) when the fields are 0.

## Testing
- All tests pass (`go test ./...`)
- Chart verified with standalone `agentic-loop:` YAML, `code-improvement.yaml`, and `simple-multi-loop.yaml`
- Rebased cleanly on main (v0.0.103)