### PR TITLE
fix: expand tilde (~) and env vars in allowed_paths

### DIFF
--- a/utils/fileutil/path.go
+++ b/utils/fileutil/path.go
@@ -1,0 +1,52 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPath expands ~ and ~user to the user's home directory.
+// It also cleans the path and expands environment variables.
+func ExpandPath(path string) (string, error) {
+	if path == "" {
+		return path, nil
+	}
+
+	// Expand environment variables first (e.g., $HOME)
+	path = os.ExpandEnv(path)
+
+	// Handle tilde expansion
+	if strings.HasPrefix(path, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+
+		if path == "~" {
+			return homeDir, nil
+		}
+
+		if strings.HasPrefix(path, "~/") {
+			return filepath.Join(homeDir, path[2:]), nil
+		}
+
+		// ~user syntax is not supported, return as-is
+		// (would require looking up other users' home dirs)
+	}
+
+	return filepath.Clean(path), nil
+}
+
+// ExpandPaths expands a slice of paths using ExpandPath.
+func ExpandPaths(paths []string) ([]string, error) {
+	expanded := make([]string, len(paths))
+	for i, p := range paths {
+		exp, err := ExpandPath(p)
+		if err != nil {
+			return nil, err
+		}
+		expanded[i] = exp
+	}
+	return expanded, nil
+}

--- a/utils/fileutil/path_test.go
+++ b/utils/fileutil/path_test.go
@@ -1,0 +1,123 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Failed to get home dir: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "empty path",
+			input:    "",
+			expected: "",
+			wantErr:  false,
+		},
+		{
+			name:     "tilde only",
+			input:    "~",
+			expected: homeDir,
+			wantErr:  false,
+		},
+		{
+			name:     "tilde with subpath",
+			input:    "~/Documents",
+			expected: filepath.Join(homeDir, "Documents"),
+			wantErr:  false,
+		},
+		{
+			name:     "tilde with nested path",
+			input:    "~/projects/comanda/src",
+			expected: filepath.Join(homeDir, "projects/comanda/src"),
+			wantErr:  false,
+		},
+		{
+			name:     "absolute path unchanged",
+			input:    "/usr/local/bin",
+			expected: "/usr/local/bin",
+			wantErr:  false,
+		},
+		{
+			name:     "relative path cleaned",
+			input:    "./src/../lib",
+			expected: "lib",
+			wantErr:  false,
+		},
+		{
+			name:     "dot path",
+			input:    ".",
+			expected: ".",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandPath(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExpandPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("ExpandPath() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExpandPathWithEnvVar(t *testing.T) {
+	// Set a test environment variable
+	testPath := "/test/path"
+	os.Setenv("TEST_COMANDA_PATH", testPath)
+	defer os.Unsetenv("TEST_COMANDA_PATH")
+
+	got, err := ExpandPath("$TEST_COMANDA_PATH/subdir")
+	if err != nil {
+		t.Fatalf("ExpandPath() error = %v", err)
+	}
+
+	expected := filepath.Join(testPath, "subdir")
+	if got != expected {
+		t.Errorf("ExpandPath() = %v, want %v", got, expected)
+	}
+}
+
+func TestExpandPaths(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Failed to get home dir: %v", err)
+	}
+
+	input := []string{"~/foo", "~/bar", "."}
+	expected := []string{
+		filepath.Join(homeDir, "foo"),
+		filepath.Join(homeDir, "bar"),
+		".",
+	}
+
+	got, err := ExpandPaths(input)
+	if err != nil {
+		t.Fatalf("ExpandPaths() error = %v", err)
+	}
+
+	if len(got) != len(expected) {
+		t.Fatalf("ExpandPaths() returned %d paths, want %d", len(got), len(expected))
+	}
+
+	for i := range got {
+		if got[i] != expected[i] {
+			t.Errorf("ExpandPaths()[%d] = %v, want %v", i, got[i], expected[i])
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When using `allowed_paths` with tilde notation (e.g., `~/projects/myapp`), the path validation fails with:

```
allowed_path does not exist: ~/projects/myapp
```

This is because `os.Stat()` doesn't expand `~` to the user's home directory.

## Solution

Added path expansion in `SendPromptAgentic` before validation:

1. **New `fileutil.ExpandPath()`** - Expands:
   - `~` and `~/path` → user's home directory
   - Environment variables like `$HOME`
   - Cleans paths with `filepath.Clean()`

2. **New `fileutil.ExpandPaths()`** - Helper for expanding slices of paths

3. **Updated `claudecode.go`** - Expands paths before validation, uses expanded paths for the CLI call

4. **Improved error message** - Now shows both original and expanded path for easier debugging

## Testing

Added comprehensive unit tests for the new path expansion functions:
- Empty paths
- Tilde-only (`~`)  
- Tilde with subpaths (`~/Documents`)
- Nested paths (`~/projects/myapp/src`)
- Absolute paths (unchanged)
- Relative paths (cleaned)
- Environment variable expansion

All existing tests still pass.

## Example

Before:
```yaml
allowed_paths:
  - ~/projects/myapp  # ❌ fails
```

After:
```yaml
allowed_paths:
  - ~/projects/myapp  # ✅ works
  - $HOME/analysis   # ✅ also works
```