### PR TITLE
feat: add --stream-log for real-time monitoring of agentic loops

### DIFF
--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -51,6 +51,7 @@ type Processor struct {
 	externalMemory       string             // External memory context (e.g., from OpenAI messages)
 	mu                   sync.Mutex         // Mutex for thread-safe debug logging
 	currentAgenticConfig *AgenticLoopConfig // Current agentic loop config (set during agentic loop execution)
+	streamLog            *StreamLogger      // Stream logger for real-time monitoring of long operations
 }
 
 // setAgenticConfig sets the current agentic config (thread-safe)
@@ -344,6 +345,27 @@ func NewProcessor(dslConfig *DSLConfig, envConfig *config.EnvConfig, serverConfi
 func (p *Processor) SetProgressWriter(w ProgressWriter) {
 	p.progress = w
 	p.spinner.SetProgressWriter(w)
+}
+
+// SetStreamLog sets up stream logging to a file for real-time monitoring
+func (p *Processor) SetStreamLog(path string) error {
+	if path == "" {
+		return nil
+	}
+	logger, err := NewStreamLogger(path)
+	if err != nil {
+		return err
+	}
+	p.streamLog = logger
+	p.debugf("Stream logging enabled: %s", path)
+	return nil
+}
+
+// CloseStreamLog closes the stream log file
+func (p *Processor) CloseStreamLog() {
+	if p.streamLog != nil {
+		p.streamLog.Close()
+	}
 }
 
 // SetLastOutput sets the last output value, useful for initializing with STDIN data

--- a/utils/processor/stream_log.go
+++ b/utils/processor/stream_log.go
@@ -56,7 +56,7 @@ func (s *StreamLogger) Log(format string, args ...interface{}) {
 	timestamp := time.Now().Format("15:04:05")
 	message := fmt.Sprintf(format, args...)
 	fmt.Fprintf(s.file, "[%s] %s\n", timestamp, message)
-	s.file.Sync() // Flush immediately for tail -f
+	_ = s.file.Sync() // Flush immediately for tail -f
 }
 
 // LogSection writes a section header to the stream log

--- a/utils/processor/stream_log.go
+++ b/utils/processor/stream_log.go
@@ -1,0 +1,147 @@
+package processor
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// StreamLogger handles real-time logging to a file for monitoring long-running operations
+type StreamLogger struct {
+	file    *os.File
+	mu      sync.Mutex
+	enabled bool
+}
+
+// NewStreamLogger creates a new stream logger that writes to the specified file
+func NewStreamLogger(path string) (*StreamLogger, error) {
+	if path == "" {
+		return &StreamLogger{enabled: false}, nil
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stream log file: %w", err)
+	}
+
+	return &StreamLogger{
+		file:    file,
+		enabled: true,
+	}, nil
+}
+
+// Close closes the stream log file
+func (s *StreamLogger) Close() error {
+	if s.file != nil {
+		return s.file.Close()
+	}
+	return nil
+}
+
+// IsEnabled returns whether stream logging is enabled
+func (s *StreamLogger) IsEnabled() bool {
+	return s.enabled
+}
+
+// Log writes a message to the stream log with timestamp
+func (s *StreamLogger) Log(format string, args ...interface{}) {
+	if !s.enabled || s.file == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	timestamp := time.Now().Format("15:04:05")
+	message := fmt.Sprintf(format, args...)
+	fmt.Fprintf(s.file, "[%s] %s\n", timestamp, message)
+	s.file.Sync() // Flush immediately for tail -f
+}
+
+// LogSection writes a section header to the stream log
+func (s *StreamLogger) LogSection(title string) {
+	if !s.enabled {
+		return
+	}
+	s.Log("═══════════════════════════════════════════════════════════════")
+	s.Log("  %s", title)
+	s.Log("═══════════════════════════════════════════════════════════════")
+}
+
+// LogIteration writes iteration start info
+func (s *StreamLogger) LogIteration(current, total int, loopName string) {
+	if !s.enabled {
+		return
+	}
+	s.Log("")
+	s.Log("───────────────────────────────────────────────────────────────")
+	s.Log("  ITERATION %d/%d - %s", current, total, loopName)
+	s.Log("───────────────────────────────────────────────────────────────")
+}
+
+// LogOutput writes the output from an iteration (truncated if too long)
+func (s *StreamLogger) LogOutput(output string, maxLines int) {
+	if !s.enabled {
+		return
+	}
+
+	lines := splitLines(output)
+	if len(lines) > maxLines {
+		s.Log("OUTPUT (%d lines, showing first %d):", len(lines), maxLines)
+		for i := 0; i < maxLines; i++ {
+			s.Log("  %s", lines[i])
+		}
+		s.Log("  ... (%d more lines)", len(lines)-maxLines)
+	} else {
+		s.Log("OUTPUT:")
+		for _, line := range lines {
+			s.Log("  %s", line)
+		}
+	}
+}
+
+// LogThinking writes model thinking/reasoning content
+func (s *StreamLogger) LogThinking(thinking string) {
+	if !s.enabled || thinking == "" {
+		return
+	}
+	s.Log("THINKING:")
+	lines := splitLines(thinking)
+	for _, line := range lines {
+		s.Log("  │ %s", line)
+	}
+}
+
+// LogExit writes exit reason
+func (s *StreamLogger) LogExit(reason string) {
+	if !s.enabled {
+		return
+	}
+	s.Log("")
+	s.Log("★ EXIT: %s", reason)
+}
+
+// LogError writes an error message
+func (s *StreamLogger) LogError(err error) {
+	if !s.enabled {
+		return
+	}
+	s.Log("✖ ERROR: %v", err)
+}
+
+// splitLines splits a string into lines
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}

--- a/utils/processor/stream_log_test.go
+++ b/utils/processor/stream_log_test.go
@@ -1,0 +1,106 @@
+package processor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStreamLogger(t *testing.T) {
+	// Create temp file
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// Create logger
+	logger, err := NewStreamLogger(logPath)
+	if err != nil {
+		t.Fatalf("Failed to create stream logger: %v", err)
+	}
+	defer logger.Close()
+
+	// Test logging
+	logger.Log("Test message %d", 1)
+	logger.LogSection("Test Section")
+	logger.LogIteration(1, 10, "test-loop")
+	logger.LogOutput("Line 1\nLine 2\nLine 3", 10)
+	logger.LogExit("completed")
+
+	// Close to flush
+	logger.Close()
+
+	// Read and verify
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	logStr := string(content)
+
+	// Check for expected content
+	checks := []string{
+		"Test message 1",
+		"Test Section",
+		"ITERATION 1/10",
+		"test-loop",
+		"Line 1",
+		"Line 2",
+		"EXIT: completed",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(logStr, check) {
+			t.Errorf("Log should contain '%s', got:\n%s", check, logStr)
+		}
+	}
+}
+
+func TestStreamLoggerDisabled(t *testing.T) {
+	// Empty path should create disabled logger
+	logger, err := NewStreamLogger("")
+	if err != nil {
+		t.Fatalf("Failed to create disabled logger: %v", err)
+	}
+
+	if logger.IsEnabled() {
+		t.Error("Logger with empty path should be disabled")
+	}
+
+	// These should not panic
+	logger.Log("test")
+	logger.LogSection("test")
+	logger.LogIteration(1, 10, "test")
+	logger.Close()
+}
+
+func TestStreamLoggerOutputTruncation(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "truncate.log")
+
+	logger, err := NewStreamLogger(logPath)
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+
+	// Create output with many lines
+	var lines []string
+	for i := 0; i < 100; i++ {
+		lines = append(lines, "Line content here")
+	}
+	output := strings.Join(lines, "\n")
+
+	// Log with max 5 lines
+	logger.LogOutput(output, 5)
+	logger.Close()
+
+	content, _ := os.ReadFile(logPath)
+	logStr := string(content)
+
+	// Should mention truncation
+	if !strings.Contains(logStr, "100 lines") {
+		t.Errorf("Should mention total line count")
+	}
+	if !strings.Contains(logStr, "more lines") {
+		t.Errorf("Should mention truncation")
+	}
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a new `--stream-log <file>` flag to the `process` command for real-time logging of agentic loops.
- Implements a `StreamLogger` to handle logging to a specified file.
- Logs include iteration start/end, output (truncated for readability), exit conditions, and errors.
- Provides immediate visibility for long-running processes using `tail -f`.
- Includes comprehensive tests for the `StreamLogger`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/process.go`: Added a new command-line flag `--stream-log` for real-time logging. Integrated the setup and closure of the stream log within the process command execution.
- `utils/processor/agentic_loop.go`: Integrated stream logging into the agentic loop lifecycle, logging headers, iterations, errors, outputs, and exit conditions.
- `utils/processor/dsl.go`: Added `streamLog` field to the `Processor` struct and methods to set up and close the stream log.
- `utils/processor/stream_log.go`: Implemented the `StreamLogger` class for handling real-time logging to a file, including methods for logging sections, iterations, outputs, errors, and exits.
- `utils/processor/stream_log_test.go`: Added tests for the `StreamLogger`, covering basic logging, disabled logger behavior, and output truncation.
</details>

___
## User Description:
## Problem

Long-running agentic loops (10+ minutes) provide no visibility into progress. When a loop times out after 10 minutes, you have no idea what happened or where it got stuck.

## Solution

New `--stream-log <file>` flag that writes real-time progress to a file:

```bash
# Start the workflow
comanda process agentic.yaml --stream-log /tmp/progress.log

# In another terminal, watch progress
tail -f /tmp/progress.log
```

## Output Format

```
[22:45:01] ═══════════════════════════════════════════════════════════════
[22:45:01]   AGENTIC LOOP: beads-architecture-review
[22:45:01] ═══════════════════════════════════════════════════════════════
[22:45:01] Max iterations: 25
[22:45:01] Exit condition: llm_decides
[22:45:01] Allowed paths: [~/projects/myapp ~/analysis .]

[22:45:02] ───────────────────────────────────────────────────────────────
[22:45:02]   ITERATION 1/25 - beads-architecture-review
[22:45:02] ───────────────────────────────────────────────────────────────
[22:47:15] OUTPUT (127 lines, showing first 50):
[22:47:15]   ## Phase 1: Gathering Beads
[22:47:15]   ...

[22:47:16] ───────────────────────────────────────────────────────────────
[22:47:16]   ITERATION 2/25 - beads-architecture-review
[22:47:16] ───────────────────────────────────────────────────────────────
...
```

## Features

- Logs iteration start/end with timestamps
- Shows output (truncated to 50 lines to keep it readable)
- Logs exit conditions and errors
- Flushes after each write for immediate `tail -f` visibility
- Clean visual section headers

## Changes

- `utils/processor/stream_log.go` - StreamLogger implementation
- `utils/processor/stream_log_test.go` - Comprehensive tests
- `utils/processor/dsl.go` - Add streamLog field to Processor
- `utils/processor/agentic_loop.go` - Hook into iteration lifecycle
- `cmd/process.go` - Add `--stream-log` flag

## Testing

```bash
go test ./utils/processor/... -v -run StreamLog
```
