### PR TITLE
fix: expand ~ in codebase_index paths + output file guidance

### DIFF
--- a/utils/processor/codebase_index_handler.go
+++ b/utils/processor/codebase_index_handler.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/kris-hansen/comanda/utils/codebaseindex"
+	"github.com/kris-hansen/comanda/utils/fileutil"
 )
 
 // processCodebaseIndexStep handles the codebase-index step type
@@ -63,12 +64,26 @@ func (p *Processor) buildCodebaseIndexConfig(stepConfig StepConfig) *codebaseind
 		ci := stepConfig.CodebaseIndex
 
 		if ci.Root != "" {
-			config.Root = ci.Root
+			// Expand ~ in root path
+			expandedRoot, err := fileutil.ExpandPath(ci.Root)
+			if err != nil {
+				p.debugf("Warning: failed to expand root path %s: %v", ci.Root, err)
+				config.Root = ci.Root // Fall back to unexpanded path
+			} else {
+				config.Root = expandedRoot
+			}
 		}
 
 		if ci.Output != nil {
 			if ci.Output.Path != "" {
-				config.OutputPath = ci.Output.Path
+				// Expand ~ in output path
+				expandedOutput, err := fileutil.ExpandPath(ci.Output.Path)
+				if err != nil {
+					p.debugf("Warning: failed to expand output path %s: %v", ci.Output.Path, err)
+					config.OutputPath = ci.Output.Path // Fall back to unexpanded path
+				} else {
+					config.OutputPath = expandedOutput
+				}
 			}
 			if ci.Output.Store != "" {
 				switch ci.Output.Store {

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -975,9 +975,30 @@ consolidate_results:
 
 ### Outputs
 - Console: ` + "`output: STDOUT`" + `
-- File: ` + "`output: results.txt`" + `
+- File: ` + "`output: results.txt`" + ` or ` + "`output: ./path/to/output.md`" + `
 - Database: ` + "`output: { database: { type: \"postgres\", table: \"results_table\" } }`" + `
 - Output with alias (if supported for variable creation from output): ` + "`output: STDOUT as $step_output_var`" + `
+
+**⚠️ IMPORTANT: Writing to files**
+When the result should be saved to a file, use the ` + "`output:`" + ` field directly. Do NOT instruct the LLM to "write to a file" in the action.
+
+✅ **CORRECT** - Use ` + "`output:`" + ` for file writing:
+` + "```yaml" + `
+summarize_document:
+  input: report.txt
+  model: claude-sonnet-4-20250514
+  action: "Summarize this document"
+  output: ./summary.md
+` + "```" + `
+
+❌ **WRONG** - Do NOT tell the LLM to write the file:
+` + "```yaml" + `
+summarize_document:
+  input: report.txt
+  model: claude-sonnet-4-20250514
+  action: "Summarize this document and write it to ./summary.md"
+  output: STDOUT
+` + "```" + `
 
 ## Variables
 - Definition: ` + "`input: data.txt as $initial_data`" + `
@@ -2058,9 +2079,30 @@ generate_haiku:
 
 ### Outputs
 - Console: ` + "`output: STDOUT`" + `
-- File: ` + "`output: results.txt`" + `
+- File: ` + "`output: results.txt`" + ` or ` + "`output: ./path/to/output.md`" + `
 - Database: ` + "`output: { database: { type: \"postgres\", table: \"results_table\" } }`" + `
 - Output with alias (if supported for variable creation from output): ` + "`output: STDOUT as $step_output_var`" + `
+
+**⚠️ IMPORTANT: Writing to files**
+When the result should be saved to a file, use the ` + "`output:`" + ` field directly. Do NOT instruct the LLM to "write to a file" in the action.
+
+✅ **CORRECT** - Use ` + "`output:`" + ` for file writing:
+` + "```yaml" + `
+summarize_document:
+  input: report.txt
+  model: claude-sonnet-4-20250514
+  action: "Summarize this document"
+  output: ./summary.md
+` + "```" + `
+
+❌ **WRONG** - Do NOT tell the LLM to write the file:
+` + "```yaml" + `
+summarize_document:
+  input: report.txt
+  model: claude-sonnet-4-20250514
+  action: "Summarize this document and write it to ./summary.md"
+  output: STDOUT
+` + "```" + `
 
 ### Tool Use (Shell Command Execution)
 


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Implemented path expansion for '~' in codebase_index configuration for both root and output paths.
- Added error handling for path expansion failures, with fallback to unexpanded paths.
- Updated documentation to provide guidance on using the `output:` field for file writing, avoiding redundant instructions to write to a file.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/codebase_index_handler.go`: Added functionality to expand '~' in the root and output paths using `fileutil.ExpandPath`. Implemented error handling for expansion failures, with debug logging and fallback to the original path if expansion fails.
- `utils/processor/embedded_guide.go`: Updated the documentation to include guidance on using the `output:` field for file writing. Provided examples of correct and incorrect usage, emphasizing not to instruct the LLM to write to a file in the action.
</details>

___
## User Description:
Follow-up to #131

**Fixes:**

1. **Path expansion for `~` in codebase_index**
   - Added `fileutil.ExpandPath()` for `root` and `output.path` fields
   - Fixes: `/Users/krish/analysis/core-context/~/erebor/core` → `/Users/krish/erebor/core`

2. **Output file writing guidance**
   - Added clear ✅/❌ examples showing `output: ./file.md` is the correct way
   - Prevents LLM from redundantly saying "write to file" in the action
