### PR TITLE
fix: use claude-code as default model in embedded guide examples

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,7 +110,7 @@ overridden with --model.`,
   comanda generate summarize.yaml "Create a workflow that summarizes text input"
 
   # Generate with a specific model
-  comanda generate analyze.yaml "Analyze sentiment of text" -m claude-sonnet-4-20250514
+  comanda generate analyze.yaml "Analyze sentiment of text" -m claude-code
 
   # Generate a multi-step workflow
   comanda generate pipeline.yaml "Extract key points, translate to Spanish, format as bullets"`,

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -876,7 +876,7 @@ index_codebase:
 
 analyze_codebase:
   input: $SRC_INDEX          # ✅ Use the variable!
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Analyze this codebase structure"
   output: STDOUT
 ` + "```" + `
@@ -892,7 +892,7 @@ index_codebase:
 
 analyze_codebase:
   input: .comanda/INDEX.md    # ❌ WRONG! Path may not resolve correctly
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Analyze this codebase structure"
   output: STDOUT
 ` + "```" + `
@@ -1022,7 +1022,7 @@ When the result should be saved to a file, use the ` + "`output:`" + ` field dir
 ` + "```yaml" + `
 summarize_document:
   input: report.txt
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Summarize this document"
   output: ./summary.md
 ` + "```" + `
@@ -1031,7 +1031,7 @@ summarize_document:
 ` + "```yaml" + `
 summarize_document:
   input: report.txt
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Summarize this document and write it to ./summary.md"
   output: STDOUT
 ` + "```" + `
@@ -1948,7 +1948,7 @@ index_codebase:
 
 analyze_codebase:
   input: $SRC_INDEX          # ✅ Use the variable!
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Analyze this codebase structure"
   output: STDOUT
 ` + "```" + `
@@ -1964,7 +1964,7 @@ index_codebase:
 
 analyze_codebase:
   input: .comanda/INDEX.md    # ❌ WRONG! Path may not resolve correctly
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Analyze this codebase structure"
   output: STDOUT
 ` + "```" + `
@@ -2162,7 +2162,7 @@ When the result should be saved to a file, use the ` + "`output:`" + ` field dir
 ` + "```yaml" + `
 summarize_document:
   input: report.txt
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Summarize this document"
   output: ./summary.md
 ` + "```" + `
@@ -2171,7 +2171,7 @@ summarize_document:
 ` + "```yaml" + `
 summarize_document:
   input: report.txt
-  model: claude-sonnet-4-20250514
+  model: claude-code
   action: "Summarize this document and write it to ./summary.md"
   output: STDOUT
 ` + "```" + `


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Changed the default model in embedded guide examples from `claude-sonnet-4-20250514` to `claude-code`.
- This change ensures compatibility for users without Anthropic API configuration, as `claude-code` works with Claude Code CLI authentication.
- Updated examples in `cmd/root.go` and `utils/processor/embedded_guide.go` to reflect this change.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/root.go`: Updated the example command to use `claude-code` instead of `claude-sonnet-4-20250514` for model specification in the help text.
- `utils/processor/embedded_guide.go`: Replaced all instances of `claude-sonnet-4-20250514` with `claude-code` in the embedded guide examples. This includes sections on analyzing codebase structures and summarizing documents, ensuring the examples are aligned with the recommended model usage.
</details>

___
## User Description:
## Problem

The `generate` command was frequently selecting invalid models like `claude-sonnet-4-20250514` because the embedded guide examples used this model. When users didn't have Anthropic API configured, the validation would fail and retry:

```
Retrying generation due to invalid model(s): [claude-sonnet-4-20250514]
```

## Solution

Changed all examples in `embedded_guide.go` to use `claude-code` instead:

- **Works without API keys** - uses Claude Code CLI authentication
- **Recommended for agentic workflows** - supports tools and loops
- **Reduces friction** - most users have Claude Code installed

## Changes

- `utils/processor/embedded_guide.go`: Updated 8 model references
- `cmd/root.go`: Updated example in help text
