### PR TITLE
fix: inherit parent model for agentic loop sub-steps

### DIFF
--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -468,6 +468,15 @@ func (p *Processor) processInlineAgenticLoop(step Step) (string, error) {
 	// If no steps defined in the loop config, use the step itself
 	if len(config.Steps) == 0 {
 		config.Steps = []Step{singleStep}
+	} else {
+		// Inherit model from parent step if sub-steps don't specify their own
+		parentModel := step.Config.Model
+		for i := range config.Steps {
+			if config.Steps[i].Config.Model == nil {
+				config.Steps[i].Config.Model = parentModel
+				p.debugf("Step '%s' inherited model from parent: %v", config.Steps[i].Name, parentModel)
+			}
+		}
 	}
 
 	return p.processAgenticLoop(step.Name, config, p.lastOutput)


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Fixes an issue where sub-steps in an agentic loop would fail if they did not have a model specified, despite the parent step having a model.
- Ensures that sub-steps inherit the model from the parent step if they do not specify their own model.
- Adds debug logging to confirm when a sub-step inherits a model from its parent.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/agentic_loop.go`: - Added logic to inherit the model from the parent step for sub-steps that do not specify their own model.
- Introduced a debug log statement to indicate when a sub-step inherits the model from the parent step.
</details>

___
## User Description:
## Problem

When an agentic loop has explicit `steps:` defined, each sub-step needs its own `model:` specified. If a sub-step doesn't have a model, it fails with:

```
model validation error: no model specified
```

This is confusing because the parent step HAS a model specified:

```yaml
backend-documenter:
  agentic_loop:
    max_iterations: 5
    steps:
      - name: step-1
        action: 'Document the code'
        # No model specified - fails!
  model: claude-code  # This model should be inherited
```

## Solution

When processing inline agentic loops, inherit the parent step's model for any sub-step that doesn't specify its own model.

```go
// Inherit model from parent step if sub-steps don't specify their own
parentModel := step.Config.Model
for i := range config.Steps {
    if config.Steps[i].Config.Model == nil {
        config.Steps[i].Config.Model = parentModel
    }
}
```

Now the workflow above works correctly - `step-1` inherits `claude-code` from the parent.
