### PR TITLE
feat: Make comanda generate qmd-aware

### DIFF
--- a/utils/processor/qmd_search_handler.go
+++ b/utils/processor/qmd_search_handler.go
@@ -12,9 +12,9 @@ import (
 
 // qmd search timeouts based on mode
 const (
-	qmdSearchTimeout  = 30 * time.Second  // BM25 is fast
-	qmdVsearchTimeout = 2 * time.Minute   // Vector search can be slow (model loading)
-	qmdQueryTimeout   = 5 * time.Minute   // Hybrid + reranking is slowest
+	qmdSearchTimeout  = 30 * time.Second // BM25 is fast
+	qmdVsearchTimeout = 2 * time.Minute  // Vector search can be slow (model loading)
+	qmdQueryTimeout   = 5 * time.Minute  // Hybrid + reranking is slowest
 )
 
 // processQmdSearchStep handles the qmd-search step type


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced a new step type, **qmd Search Step**, to Comanda workflows, expanding the step types from six to seven.
- Added documentation for integrating qmd within the `codebase_index` block, including attributes for qmd collection, context, and embedding.
- Provided full documentation for the `qmd-search` step type, detailing its structure, attributes, and usage scenarios.
- Included validation rules for the new qmd-search step.
- Added examples demonstrating the use of qmd-search in Retrieval-Augmented Generation (RAG) workflows and code search with codebase-index.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/embedded_guide.go`: - Updated the overview section to include the new **qmd Search Step** as the seventh step type.
- Documented the `qmd` configuration block within the `codebase_index` step, detailing attributes like `collection`, `context`, and `embed`.
- Added a comprehensive section on the `qmd_search` step, including its definition, attributes, and examples of usage in workflows.
- Introduced validation rules for the qmd-search step, specifying required fields and defaults.
</details>

___
## User Description:
## Summary

Updates the embedded LLM guide so that `comanda generate` knows about qmd integration and can generate workflows that use qmd for search.

## Changes

### 1. Overview Update
- Added **qmd Search Step** as step type #7

### 2. Codebase Index qmd Integration
Added documentation for the `qmd` config block in `codebase_index`:

```yaml
codebase_index:
  root: ./src
  qmd:
    collection: myproject   # Register as qmd collection
    context: "Project source code"
    embed: false            # Enable semantic search
```

### 3. New qmd-search Step Documentation

Full documentation for the `qmd-search` step type:

```yaml
search_docs:
  type: qmd-search
  qmd_search:
    query: "${USER_QUESTION}"
    collection: docs
    mode: search          # search, vsearch, or query
    limit: 5
    min_score: 0.3
  output: CONTEXT
```

### 4. Validation Rules
Added validation rules for qmd-search steps.

### 5. Examples
- RAG workflow example
- Code search with codebase-index example

## Testing

```bash
go build ./...  # ✅ Builds successfully
```

## Impact

After this PR, `comanda generate` will be able to:
- Generate RAG workflows using qmd-search
- Create codebase indexes with qmd registration
- Suggest appropriate search modes (BM25, vector, hybrid)
