### PR TITLE
fix: goreleaser brew config to use single archive format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,15 +31,17 @@ builds:
       - -X github.com/kris-hansen/comanda/cmd.version=v{{.Version}}
 
 archives:
-  - id: default
-    formats:
-      - tar.gz
-      - zip
+  # tar.gz archives (used by homebrew)
+  - id: targz
+    format: tar.gz
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
+    files:
+      - LICENSE
+      - README.md
+  # zip archives (alternative format, especially for Windows)
+  - id: zip
+    format: zip
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -66,10 +68,10 @@ release:
   prerelease: auto
   name_template: "v{{.Version}}"
 
-# Note: brews is deprecated but still works for CLI tools.
-# Will migrate to homebrew_casks in goreleaser v3.
 brews:
   - name: comanda
+    ids:
+      - targz  # Use only tar.gz archives for homebrew
     repository:
       owner: kris-hansen
       name: homebrew-comanda


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Resolved an issue in the release workflow where multiple archive formats were causing errors.
- Split the archive configuration into two separate entries with distinct IDs for `tar.gz` and `zip`.
- Updated the `brews` section to explicitly use only the `tar.gz` archive for Homebrew.
- Both `tar.gz` and `zip` formats are still published to GitHub releases, but Homebrew now only uses the `tar.gz` format.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.goreleaser.yaml`: - Removed the default archive configuration that included both `tar.gz` and `zip` formats.
- Added a new archive configuration with ID `targz` for `tar.gz` format, specifying it for Homebrew use.
- Added a new archive configuration with ID `zip` for `zip` format, primarily for Windows users.
- Updated the `brews` section to include `ids: [targz]`, ensuring only `tar.gz` archives are used for Homebrew.
</details>

___
## User Description:
## Problem

The release workflow was failing with:
```
error=one tap can handle only one archive of an OS/Arch combination. 
Consider using ids in the brew section
```

This happened because the `archives` section created both `.tar.gz` and `.zip` for each platform, and the `brews` section didn't specify which one to use.

## Solution

- Split archives into two separate configs with distinct IDs:
  - `targz` - tar.gz format (standard for homebrew)
  - `zip` - zip format (alternative, especially for Windows users)
- Added `ids: [targz]` to the brews section to explicitly use only tar.gz archives

Both formats are still published to GitHub releases, but homebrew now only uses the tar.gz archives.

## Testing

This should fix the release workflow that's been failing since #147.
