### PR TITLE
docs: teach generate command about codebase-index output.format

### DIFF
--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -917,6 +917,7 @@ step_name:
     root: .                   # Repository path (default: current directory)
     output:
       path: .comanda/INDEX.md # Custom output path (optional)
+      format: structured      # Output format: summary, structured, full
       store: repo             # Where to store: repo, config, or both
       encrypt: false          # Enable AES-256 encryption
     expose:
@@ -938,6 +939,7 @@ step_name:
 **` + "`codebase_index`" + ` Block Attributes:**
 - ` + "`root`" + `: (string, default: ` + "`.`" + `) Repository path to scan.
 - ` + "`output.path`" + `: (string, optional) Custom output file path. Default: ` + "`.comanda/<repo>_INDEX.md`" + `
+- ` + "`output.format`" + `: (string, default: ` + "`structured`" + `) Output format: ` + "`summary`" + ` (compact 1-2KB for system prompts), ` + "`structured`" + ` (balanced with sections), or ` + "`full`" + ` (detailed with all symbols).
 - ` + "`output.store`" + `: (string, default: ` + "`repo`" + `) Where to save: ` + "`repo`" + ` (in repository), ` + "`config`" + ` (~/.comanda/), or ` + "`both`" + `.
 - ` + "`output.encrypt`" + `: (bool, default: false) Encrypt output with AES-256 GCM. Saves as ` + "`.enc`" + ` file. Requires ` + "`COMANDA_INDEX_KEY`" + ` environment variable.
 - ` + "`expose.workflow_variable`" + `: (bool, default: true) Export index as workflow variables.
@@ -2211,6 +2213,7 @@ step_name:
     root: .                   # Repository path (default: current directory)
     output:
       path: .comanda/INDEX.md # Custom output path (optional)
+      format: structured      # Output format: summary, structured, full
       store: repo             # Where to store: repo, config, or both
       encrypt: false          # Enable AES-256 encryption
     expose:
@@ -2232,6 +2235,7 @@ step_name:
 **` + "`codebase_index`" + ` Block Attributes:**
 - ` + "`root`" + `: (string, default: ` + "`.`" + `) Repository path to scan.
 - ` + "`output.path`" + `: (string, optional) Custom output file path. Default: ` + "`.comanda/<repo>_INDEX.md`" + `
+- ` + "`output.format`" + `: (string, default: ` + "`structured`" + `) Output format: ` + "`summary`" + ` (compact 1-2KB for system prompts), ` + "`structured`" + ` (balanced with sections), or ` + "`full`" + ` (detailed with all symbols).
 - ` + "`output.store`" + `: (string, default: ` + "`repo`" + `) Where to save: ` + "`repo`" + ` (in repository), ` + "`config`" + ` (~/.comanda/), or ` + "`both`" + `.
 - ` + "`output.encrypt`" + `: (bool, default: false) Encrypt output with AES-256 GCM. Saves as ` + "`.enc`" + ` file. Requires ` + "`COMANDA_INDEX_KEY`" + ` environment variable.
 - ` + "`expose.workflow_variable`" + `: (bool, default: true) Export index as workflow variables.


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
- Added documentation for the `output.format` option (summary/structured/full) in the embedded LLM guide.
- Updated the golangci-lint configuration for compatibility with version 2.
- Removed deprecated linters and reorganized the configuration to align with the latest standards.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/embedded_guide.go`: Added documentation for the `output.format` option in the `codebase_index` block. This includes specifying the available formats: summary, structured, and full, and updating the YAML example and attribute descriptions.
- `.golangci.yml`: Updated the golangci-lint configuration to version 2. This includes:
- Adding a version declaration.
- Moving `gofmt` from linters to formatters section.
- Removing deprecated linters such as `gosimple`, `stylecheck`, and `revive`, which are now included in `staticcheck`.
- Adding `uniq-by-line` to the issues section and adjusting the output format configuration.
</details>

___
## User Description:
Adds documentation for the `output.format` option (summary/structured/full) to the embedded LLM guide so that `comanda generate` knows how to create workflows with the new codebase-index output formats.

Also updates golangci-lint config for v2 compatibility.
