### PR TITLE
feat: add validators for execute_loops and step chaining

### DIFF
--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -542,7 +542,7 @@ func (p *Processor) extractOutputPath(output interface{}) string {
 
 	// Skip non-file outputs
 	if outputStr == "" ||
-		outputStr == "STDOUT" ||
+		outputStr == OutputSTDOUT ||
 		outputStr == "NA" ||
 		strings.HasPrefix(outputStr, "$") { // Variable reference
 		return ""

--- a/utils/processor/dsl_validator.go
+++ b/utils/processor/dsl_validator.go
@@ -8,6 +8,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Common I/O constants
+const (
+	OutputSTDOUT = "STDOUT"
+	InputSTDIN   = "STDIN"
+	InputNA      = "NA"
+)
+
 // ValidationError represents a single validation error with actionable feedback
 type ValidationError struct {
 	Line    int    // Line number (0 if unknown)
@@ -503,7 +510,7 @@ func validateInputField(stepName string, input interface{}) []ValidationError {
 
 	switch v := input.(type) {
 	case string:
-		// Valid: "file.txt", "STDIN", "NA", "tool: command", etc.
+		// Valid: "file.txt", InputSTDIN, "NA", "tool: command", etc.
 		// Just basic sanity checks
 		if v == "" {
 			errors = append(errors, ValidationError{
@@ -643,7 +650,7 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 
 					// Check for file outputs
 					if output, ok := stepMap["output"].(string); ok {
-						if output != "STDOUT" && output != "STDIN" && !strings.HasPrefix(output, "$") {
+						if output != OutputSTDOUT && output != InputSTDIN && !strings.HasPrefix(output, "$") {
 							outputFiles[output] = stepName
 						}
 					}
@@ -682,7 +689,7 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 
 			// Check for file outputs
 			if output, ok := stepMap["output"].(string); ok {
-				if output != "STDOUT" && output != "STDIN" && !strings.HasPrefix(output, "$") {
+				if output != OutputSTDOUT && output != InputSTDIN && !strings.HasPrefix(output, "$") {
 					outputFiles[output] = stepName
 				}
 			}
@@ -714,7 +721,7 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 			for _, match := range matches {
 				varName := match[1]
 				// Skip loop template variables
-				if strings.HasPrefix(varName, "LOOP") || varName == "STDIN" || varName == "STDOUT" {
+				if strings.HasPrefix(varName, "LOOP") || varName == InputSTDIN || varName == OutputSTDOUT {
 					continue
 				}
 				if _, exists := exportedVars[varName]; !exists {

--- a/utils/processor/input_handler.go
+++ b/utils/processor/input_handler.go
@@ -24,7 +24,7 @@ func fileExists(path string) bool {
 
 // isSpecialInput checks if the input is a special type (e.g., screenshot)
 func (p *Processor) isSpecialInput(input string) bool {
-	specialInputs := []string{"screenshot", "NA", "STDIN"}
+	specialInputs := []string{"screenshot", "NA", InputSTDIN}
 	for _, special := range specialInputs {
 		if input == special {
 			return true
@@ -155,7 +155,7 @@ func (p *Processor) processInputs(inputs []string) error {
 				p.debugf("Skipping NA input")
 				continue
 			}
-			if inputPath == "STDIN" {
+			if inputPath == InputSTDIN {
 				p.debugf("Skipping STDIN input as it's handled in Process()")
 				continue
 			}
@@ -213,7 +213,7 @@ func (p *Processor) isOutputInOtherSteps(path string) bool {
 	for _, step := range p.config.Steps {
 		outputs := p.NormalizeStringSlice(step.Config.Output)
 		for _, output := range outputs {
-			if output != "STDOUT" {
+			if output != OutputSTDOUT {
 				// Check for exact match
 				if output == path {
 					p.debugf("Found exact match '%s' as output in sequential step: %s", path, step.Name)
@@ -234,7 +234,7 @@ func (p *Processor) isOutputInOtherSteps(path string) bool {
 		for _, step := range steps {
 			outputs := p.NormalizeStringSlice(step.Config.Output)
 			for _, output := range outputs {
-				if output != "STDOUT" {
+				if output != OutputSTDOUT {
 					// Check for exact match
 					if output == path {
 						p.debugf("Found exact match '%s' as output in parallel step: %s (group: %s)", path, step.Name, groupName)

--- a/utils/processor/model_handler.go
+++ b/utils/processor/model_handler.go
@@ -218,7 +218,7 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 
 		// Check if model has required capabilities based on input types
 		for _, input := range inputs {
-			if input == "NA" || input == "STDIN" {
+			if input == "NA" || input == InputSTDIN {
 				continue
 			}
 

--- a/utils/processor/output_handler.go
+++ b/utils/processor/output_handler.go
@@ -112,7 +112,7 @@ func (p *Processor) handleOutputWithToolConfig(modelName string, response string
 			continue
 		}
 
-		if output == "STDOUT" {
+		if output == OutputSTDOUT {
 			if p.progress != nil {
 				// Send through progress channel for streaming
 				p.debugf("Sending output event with content: %s", response)


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces `validateExecuteLoopsIgnoredSteps` to warn when top-level steps are present alongside `execute_loops`, as they will be ignored.
- Implements `validateStepChaining` to ensure that variable references are properly exported by prior steps.
- Adds tests to verify:
  - Warnings for top-level steps with `execute_loops`.
  - Valid loops with codebase-index steps.
  - Errors for missing variable references.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/dsl_validator.go`: - Added `validateExecuteLoopsIgnoredSteps` function to check for top-level steps that will be ignored when `execute_loops` is present.
- Implemented `validateStepChaining` function to validate that step inputs reference outputs from prior steps.
- Integrated the new validators into the `ValidateWorkflowStructure` function to append errors to the validation result.
- `utils/processor/dsl_validator_test.go`: - Added `TestValidateWorkflowStructure_ExecuteLoopsIgnoresTopLevel` to test for warnings when top-level steps are present with `execute_loops`.
- Added `TestValidateWorkflowStructure_ValidLoopsWithCodebaseIndex` to ensure no warnings are issued when steps are correctly placed inside loops.
- Added `TestValidateWorkflowStructure_MissingVariableReference` to check for errors when variable references are missing.
</details>

___
## User Description:
Adds two new validators to catch common workflow mistakes:

## 1. `validateExecuteLoopsIgnoredSteps`
Warns when top-level steps exist alongside `execute_loops:` — these steps will be silently ignored.

**Example error:**
```
Step 'execute_loops': Top-level steps will be IGNORED when execute_loops is present: [index_codebase, categorize]
Fix: Move these steps inside the 'loops:' block, or remove 'execute_loops:' if you want sequential step execution.
```

## 2. `validateStepChaining`
Checks that variable references (`$VAR`) are exported by prior steps via `output_state` or codebase-index.

**Example error:**
```
Step 'analyze': References variable $CORE_INDEX but no prior step exports it
Fix: Ensure a prior step or loop sets 'output_state: $CORE_INDEX', or use a codebase-index step that exports this variable.
```

## Tests
- Top-level codebase-index + execute_loops (should warn)
- Valid loops with codebase-index inside (should pass)  
- Missing variable references (should error)
