### PR TITLE
feat: add progress spinner during workflow generation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,12 +212,27 @@ overridden with --model.`,
 		var structureErrors string
 		maxAttempts := 3 // Increased to allow for both model and structure fixes
 
+		// Create spinner for visual feedback during generation
+		spinner := processor.NewSpinner()
+		if verbose {
+			// Disable spinner in verbose mode to avoid interfering with debug output
+			spinner.Disable()
+		}
+
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
 			// Build the prompt with any previous validation errors
 			prompt := buildGeneratePrompt(dslGuide, userPrompt, invalidModels, structureErrors)
 
+			// Start spinner for LLM generation
+			spinnerMsg := "Generating workflow"
+			if attempt > 1 {
+				spinnerMsg = fmt.Sprintf("Regenerating workflow (attempt %d/%d)", attempt, maxAttempts)
+			}
+			spinner.Start(spinnerMsg)
+
 			// Call the LLM
 			generatedResponse, err := provider.SendPrompt(modelForGeneration, prompt)
+			spinner.Stop()
 			if err != nil {
 				return fmt.Errorf("LLM execution failed for model '%s': %w", modelForGeneration, err)
 			}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a progress spinner to provide visual feedback during workflow generation in 'comanda generate'.
- Displays a spinner with the message "Generating workflow..." during LLM calls.
- Shows attempt number on validation retries with messages like "Regenerating workflow (attempt 2/3)...".
- Automatically disables the spinner in verbose mode to prevent interference with debug output.
- Utilizes the existing `processor.Spinner` implementation for consistency.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/root.go`: - Added a spinner for visual feedback during the workflow generation process.
- The spinner is initialized using `processor.NewSpinner()`.
- The spinner is disabled if the verbose mode is active to avoid interfering with debug output.
- The spinner starts with the message "Generating workflow" and updates to "Regenerating workflow (attempt x/y)" on retries.
- The spinner stops after the LLM call is completed.
</details>

___
## User Description:
## Summary

When running `comanda generate`, complex workflows can take several seconds to generate and there's no visual feedback - the terminal just sits silent. This PR adds a progress spinner to provide visual feedback while waiting for the LLM response.

## Changes

- Show a spinner with "Generating workflow..." during LLM calls
- Display attempt number on validation retries: "Regenerating workflow (attempt 2/3)..."
- Automatically disable spinner in verbose mode (`-v`) to avoid interference with debug output
- Reuses existing `processor.Spinner` implementation for consistency

## Demo

```
$ comanda generate summarize.yaml "Create a workflow that summarizes text"
Generating workflow using model: claude-code
Output file: summarize.yaml
Generating workflow... |
Generating workflow... /
Generating workflow... -
Generating workflow... Done!
✅ Workflow successfully generated and saved to summarize.yaml
```

## Testing

- [x] Manual testing confirms spinner displays correctly
- [x] Verified spinner is disabled in verbose mode
- [x] All existing tests pass (`go test ./cmd/...`)
