### PR TITLE
fix: handle missing stdin gracefully in non-TTY environments

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/database"
@@ -1761,7 +1760,7 @@ Flag Groups:
 			log.Printf("%s Default generation model set to '%s'\n", greenCheckmark, selectedDefaultModel)
 		} else {
 			// Interactive mode requires a terminal
-			if !term.IsTerminal(int(syscall.Stdin)) {
+			if !term.IsTerminal(int(os.Stdin.Fd())) {
 				log.Printf("Error: Interactive configuration requires a terminal.\n")
 				log.Printf("Please run 'comanda configure' in an interactive shell,\n")
 				log.Printf("or use non-interactive flags like --list, --encrypt, --remove, etc.\n")

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -14,12 +14,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/database"
 	"github.com/kris-hansen/comanda/utils/models"
 	openai "github.com/sashabaranov/go-openai"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -1758,6 +1760,14 @@ Flag Groups:
 			envConfig.DefaultGenerationModel = selectedDefaultModel
 			log.Printf("%s Default generation model set to '%s'\n", greenCheckmark, selectedDefaultModel)
 		} else {
+			// Interactive mode requires a terminal
+			if !term.IsTerminal(int(syscall.Stdin)) {
+				log.Printf("Error: Interactive configuration requires a terminal.\n")
+				log.Printf("Please run 'comanda configure' in an interactive shell,\n")
+				log.Printf("or use non-interactive flags like --list, --encrypt, --remove, etc.\n")
+				return
+			}
+
 			reader := bufio.NewReader(os.Stdin)
 
 			// Show main menu

--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -183,6 +183,10 @@ func GetEnvPath() string {
 
 // PromptPassword prompts the user for a password securely
 func PromptPassword(prompt string) (string, error) {
+	// Check if stdin is a terminal - if not, we can't read passwords interactively
+	if !term.IsTerminal(int(syscall.Stdin)) {
+		return "", fmt.Errorf("cannot read password: stdin is not a terminal (non-interactive environment)")
+	}
 	log.Printf("%s", prompt)
 	password, err := term.ReadPassword(int(syscall.Stdin))
 	log.Printf("\n") // Add newline after password input

--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
@@ -184,11 +183,11 @@ func GetEnvPath() string {
 // PromptPassword prompts the user for a password securely
 func PromptPassword(prompt string) (string, error) {
 	// Check if stdin is a terminal - if not, we can't read passwords interactively
-	if !term.IsTerminal(int(syscall.Stdin)) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return "", fmt.Errorf("cannot read password: stdin is not a terminal (non-interactive environment)")
 	}
 	log.Printf("%s", prompt)
-	password, err := term.ReadPassword(int(syscall.Stdin))
+	password, err := term.ReadPassword(int(os.Stdin.Fd()))
 	log.Printf("\n") // Add newline after password input
 	if err != nil {
 		return "", fmt.Errorf("error reading password: %w", err)

--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -322,8 +322,9 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 
 	// Enable bypass permissions for non-interactive agentic use
 	// Without this, Claude Code prompts for permission which blocks non-interactive execution
+	// Both flags are required: --dangerously-skip-permissions AND --permission-mode bypassPermissions
 	if len(allowedPaths) > 0 {
-		args = append(args, "--dangerously-skip-permissions")
+		args = append(args, "--dangerously-skip-permissions", "--permission-mode", "bypassPermissions")
 	}
 
 	// Restrict tools if specified


### PR DESCRIPTION
## Changes

### 1. Handle missing stdin gracefully in non-TTY environments

When running `comanda configure` or other interactive commands in environments where stdin is unavailable (e.g., cron jobs, background processes), the CLI would crash with unclear errors.

- Added TTY check before starting interactive configuration mode
- Added TTY check in `PromptPassword` before attempting to read passwords
- Provides clear error messages guiding users to use non-interactive flags

### 2. Fix Claude Code permission bypass for non-interactive use

When Comanda invokes Claude Code in agentic mode, the CLI was still prompting for permissions even with `--dangerously-skip-permissions`. 

Claude Code requires **both** flags to fully bypass permission prompts:
- `--dangerously-skip-permissions`
- `--permission-mode bypassPermissions`

Added the missing flag to enable fully non-interactive agentic workflows.

## Testing

```bash
# stdin handling
echo '' | comanda configure
# Error: Interactive configuration requires a terminal.

# Claude Code permissions
echo "Write 'hello' to /tmp/test.txt" | claude --add-dir /tmp --dangerously-skip-permissions --permission-mode bypassPermissions -p
# Works without prompting
```