### PR TITLE
fix: add --permission-mode bypassPermissions for Claude Code non-interactive use

### DIFF
--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -322,8 +322,9 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 
 	// Enable bypass permissions for non-interactive agentic use
 	// Without this, Claude Code prompts for permission which blocks non-interactive execution
+	// Both flags are required: --dangerously-skip-permissions AND --permission-mode bypassPermissions
 	if len(allowedPaths) > 0 {
-		args = append(args, "--dangerously-skip-permissions")
+		args = append(args, "--dangerously-skip-permissions", "--permission-mode", "bypassPermissions")
 	}
 
 	// Restrict tools if specified


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Added the `--permission-mode bypassPermissions` flag to the Claude Code arguments in agentic mode.
- Ensures that both `--dangerously-skip-permissions` and `--permission-mode bypassPermissions` are used to fully bypass permission prompts.
- This change is crucial for enabling non-interactive or automated workflows without manual permission prompts.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/models/claudecode.go`: Modified the `buildArgsAgentic` function to include the `--permission-mode bypassPermissions` flag alongside `--dangerously-skip-permissions` when allowed paths are specified. This ensures that permission prompts are fully bypassed in non-interactive agentic mode.
</details>

___
## User Description:
## Problem

When Comanda invokes Claude Code in agentic mode, the CLI was still prompting for permissions even with `--dangerously-skip-permissions`. This blocked non-interactive/automated workflows.

## Solution

Claude Code requires **both** flags to fully bypass permission prompts:
- `--dangerously-skip-permissions`
- `--permission-mode bypassPermissions`

Added the missing `--permission-mode bypassPermissions` flag to the agentic mode arguments.

## Testing

Verified with:
```bash
echo "Write 'hello' to /tmp/test.txt" | claude --add-dir /tmp --dangerously-skip-permissions --permission-mode bypassPermissions -p
```

This now works without prompting for permissions.
