### PR TITLE
fix: correct box width calculation for emoji characters

### DIFF
--- a/utils/processor/style.go
+++ b/utils/processor/style.go
@@ -217,17 +217,36 @@ func (s *Styler) StepIcon() string {
 	return s.Info(iconStep)
 }
 
+// displayWidth calculates the visual width of a string in terminal
+// Accounts for multi-byte characters and emoji (which typically display as 2 chars wide)
+func displayWidth(s string) int {
+	width := 0
+	for _, r := range s {
+		if r > 0x1F600 && r < 0x1F9FF { // Common emoji ranges
+			width += 2
+		} else if r > 0x2600 && r < 0x27BF { // Misc symbols
+			width += 2
+		} else if r > 0x1F300 && r < 0x1F5FF { // Misc symbols and pictographs
+			width += 2
+		} else {
+			width += 1
+		}
+	}
+	return width
+}
+
 // Box draws a box around content
 func (s *Styler) Box(title string, width int) string {
 	if !s.config.UseUnicode {
 		return s.asciiBox(title, width)
 	}
 
-	if width < len(title)+4 {
-		width = len(title) + 4
+	titleWidth := displayWidth(title)
+	if width < titleWidth+4 {
+		width = titleWidth + 4
 	}
 
-	padding := width - len(title) - 2
+	padding := width - titleWidth - 2
 	leftPad := padding / 2
 	rightPad := padding - leftPad
 
@@ -239,12 +258,13 @@ func (s *Styler) Box(title string, width int) string {
 }
 
 func (s *Styler) asciiBox(title string, width int) string {
-	if width < len(title)+4 {
-		width = len(title) + 4
+	titleWidth := displayWidth(title)
+	if width < titleWidth+4 {
+		width = titleWidth + 4
 	}
 
 	border := "+" + strings.Repeat("-", width) + "+"
-	padding := width - len(title)
+	padding := width - titleWidth
 	leftPad := padding / 2
 	rightPad := padding - leftPad
 	middle := "|" + strings.Repeat(" ", leftPad) + title + strings.Repeat(" ", rightPad) + "|"


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Introduced a new helper function `displayWidth()` to accurately calculate the visual width of strings containing emoji and multi-byte characters.
- Updated the `Box()` and `asciiBox()` functions to use `displayWidth()` instead of `len()` for determining the width of the title.
- Ensured that the box renders symmetrically even when the title contains emoji characters.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/style.go`: - Added `displayWidth()` function to calculate the visual width of strings, accounting for emoji and multi-byte characters.
- Modified `Box()` function to use `displayWidth()` for calculating title width and padding, ensuring proper alignment.
- Updated `asciiBox()` function similarly to use `displayWidth()` for accurate width and padding calculations.
</details>

___
## User Description:
## Problem

The progress box was misaligned when the title contained emoji:

```
┌──────────────────────────────────────────────────┐
│         🔀 Multi-Loop Orchestration         │
└──────────────────────────────────────────────────┘
```

The right border was offset because `len(title)` counts bytes (emoji = 4 bytes) instead of visual character width (emoji = 2 chars in terminal).

## Solution

Added `displayWidth()` helper that properly accounts for emoji character widths when calculating padding.

## Testing

Before: Right border misaligned
After: Box renders symmetrically
