### PR TITLE
fix: correct pluralization for loop count display

### DIFF
--- a/utils/processor/progress_display.go
+++ b/utils/processor/progress_display.go
@@ -58,7 +58,11 @@ func (p *ProgressDisplay) StartWorkflow(name string, loopCount int) {
 	fmt.Println()
 
 	if loopCount > 0 {
-		fmt.Printf("  %s %d loops to execute\n", p.styler.Muted(iconBullet), loopCount)
+		loopWord := "loops"
+		if loopCount == 1 {
+			loopWord = "loop"
+		}
+		fmt.Printf("  %s %d %s to execute\n", p.styler.Muted(iconBullet), loopCount, loopWord)
 		fmt.Println()
 	}
 }

--- a/utils/processor/style.go
+++ b/utils/processor/style.go
@@ -217,17 +217,36 @@ func (s *Styler) StepIcon() string {
 	return s.Info(iconStep)
 }
 
+// displayWidth calculates the visual width of a string in terminal
+// Accounts for multi-byte characters and emoji (which typically display as 2 chars wide)
+func displayWidth(s string) int {
+	width := 0
+	for _, r := range s {
+		if r > 0x1F600 && r < 0x1F9FF { // Common emoji ranges
+			width += 2
+		} else if r > 0x2600 && r < 0x27BF { // Misc symbols
+			width += 2
+		} else if r > 0x1F300 && r < 0x1F5FF { // Misc symbols and pictographs
+			width += 2
+		} else {
+			width += 1
+		}
+	}
+	return width
+}
+
 // Box draws a box around content
 func (s *Styler) Box(title string, width int) string {
 	if !s.config.UseUnicode {
 		return s.asciiBox(title, width)
 	}
 
-	if width < len(title)+4 {
-		width = len(title) + 4
+	titleWidth := displayWidth(title)
+	if width < titleWidth+4 {
+		width = titleWidth + 4
 	}
 
-	padding := width - len(title) - 2
+	padding := width - titleWidth - 2
 	leftPad := padding / 2
 	rightPad := padding - leftPad
 
@@ -239,12 +258,13 @@ func (s *Styler) Box(title string, width int) string {
 }
 
 func (s *Styler) asciiBox(title string, width int) string {
-	if width < len(title)+4 {
-		width = len(title) + 4
+	titleWidth := displayWidth(title)
+	if width < titleWidth+4 {
+		width = titleWidth + 4
 	}
 
 	border := "+" + strings.Repeat("-", width) + "+"
-	padding := width - len(title)
+	padding := width - titleWidth
 	leftPad := padding / 2
 	rightPad := padding - leftPad
 	middle := "|" + strings.Repeat(" ", leftPad) + title + strings.Repeat(" ", rightPad) + "|"


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Corrects the pluralization of the word "loop" in the loop count display to ensure proper grammar.
- Fixes the calculation of box width to account for the visual width of emoji characters, preventing misalignment in terminal displays.
- Introduces a helper function `displayWidth()` to calculate the visual width of strings, considering multi-byte characters and emojis.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/progress_display.go`: Adjusted the loop count display logic to use the singular form "loop" when the count is one. This ensures grammatically correct output.
- `utils/processor/style.go`: Added a new function `displayWidth()` to calculate the visual width of strings, accounting for multi-byte and emoji characters. Updated the `Box()` and `asciiBox()` methods to use `displayWidth()` for determining the correct padding and width, ensuring proper alignment in terminal displays.
</details>

___
## User Description:
Fixes the display to show '1 loop to execute' instead of '1 loops to execute' when there's only one loop.

**Before:** `1 loops to execute`
**After:** `1 loop to execute`
