### PR TITLE
fix: hide cursor during spinner animation

### DIFF
--- a/utils/processor/spinner.go
+++ b/utils/processor/spinner.go
@@ -2,8 +2,11 @@ package processor
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"time"
+
+	"golang.org/x/term"
 )
 
 type Spinner struct {
@@ -20,7 +23,7 @@ type Spinner struct {
 
 func NewSpinner() *Spinner {
 	return &Spinner{
-		chars: []string{"|", "/", "-", "\\"},
+		chars: []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
 		stop:  make(chan struct{}),
 	}
 }
@@ -62,6 +65,11 @@ func (s *Spinner) Start(message string) {
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
+		// Hide cursor during spinner animation (only if stdout is a terminal)
+		isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+		if isTTY {
+			fmt.Print("\033[?25l")
+		}
 		for {
 			select {
 			case <-s.stop:
@@ -73,6 +81,10 @@ func (s *Spinner) Start(message string) {
 
 				if !disabled {
 					fmt.Printf("\r%s     \n", msg)
+				}
+				// Show cursor again (only if stdout is a terminal)
+				if isTTY {
+					fmt.Print("\033[?25h")
 				}
 				// Send completion update
 				if progress != nil {


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Hides the terminal cursor during the spinner animation to prevent the distracting blinking cursor from being visible during workflow execution.
- Ensures the cursor is hidden when the spinner starts and restored when it stops.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/spinner.go`: - Added code to hide the terminal cursor at the start of the spinner animation using the escape sequence `\033[?25l`.
- Added code to show the terminal cursor again after the spinner animation stops using the escape sequence `\033[?25h`.
</details>

___
## User Description:
Hides the terminal cursor during spinner animation to eliminate the distracting blinking cursor visible during workflow execution.

**Before:** Blinking cursor visible during execution
**After:** Clean spinner animation without cursor
