### PR TITLE
feat: add Git worktree support for parallel Claude Code execution

### DIFF
--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -53,8 +53,9 @@ type Model struct {
 
 // Provider represents a provider's configuration
 type Provider struct {
-	APIKey string  `yaml:"api_key"`
-	Models []Model `yaml:"models"`
+	APIKey            string  `yaml:"api_key"`
+	Models            []Model `yaml:"models"`
+	SupportsWorktrees bool    `yaml:"supports_worktrees,omitempty"`
 }
 
 // ToolConfig represents global tool execution settings

--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -21,6 +21,7 @@ type ClaudeCodeProvider struct {
 	verbose    bool
 	binaryPath string
 	debugFile  string // Optional debug file path for streaming output
+	worktree   string // Optional worktree name for isolated execution
 	mu         sync.Mutex
 }
 
@@ -312,6 +313,12 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 		c.debugf("No debug file set for agentic mode")
 	}
 
+	// Add worktree for isolated execution
+	if c.worktree != "" {
+		c.debugf("Adding --worktree flag: %s", c.worktree)
+		args = append(args, "--worktree", c.worktree)
+	}
+
 	// Add allowed paths for tool access scope
 	// Resolve paths to absolute (expands ~ and converts relative to absolute)
 	for _, path := range allowedPaths {
@@ -403,6 +410,17 @@ func (c *ClaudeCodeProvider) SetVerbose(verbose bool) {
 // This enables --debug-file which streams tool calls and execution details
 func (c *ClaudeCodeProvider) SetDebugFile(path string) {
 	c.debugFile = path
+}
+
+// SetWorktree sets the worktree name for isolated execution
+// This enables --worktree which runs Claude Code in an isolated Git worktree
+func (c *ClaudeCodeProvider) SetWorktree(name string) {
+	c.worktree = name
+}
+
+// ClearWorktree clears the worktree setting
+func (c *ClaudeCodeProvider) ClearWorktree() {
+	c.worktree = ""
 }
 
 // ValidateModel checks if the model is valid for Claude Code

--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -18,12 +18,12 @@ import (
 
 // ClaudeCodeProvider handles Claude Code CLI for agentic programming tasks
 type ClaudeCodeProvider struct {
-	verbose            bool
-	binaryPath         string
-	debugFile          string // Optional debug file path for streaming output
-	worktree           string // Optional worktree name for isolated execution
-	worktreeSupported  *bool  // Cached result of worktree flag probe
-	mu                 sync.Mutex
+	verbose           bool
+	binaryPath        string
+	debugFile         string // Optional debug file path for streaming output
+	worktree          string // Optional worktree name for isolated execution
+	worktreeSupported *bool  // Cached result of worktree flag probe
+	mu                sync.Mutex
 }
 
 // NewClaudeCodeProvider creates a new Claude Code provider instance

--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -18,11 +18,12 @@ import (
 
 // ClaudeCodeProvider handles Claude Code CLI for agentic programming tasks
 type ClaudeCodeProvider struct {
-	verbose    bool
-	binaryPath string
-	debugFile  string // Optional debug file path for streaming output
-	worktree   string // Optional worktree name for isolated execution
-	mu         sync.Mutex
+	verbose            bool
+	binaryPath         string
+	debugFile          string // Optional debug file path for streaming output
+	worktree           string // Optional worktree name for isolated execution
+	worktreeSupported  *bool  // Cached result of worktree flag probe
+	mu                 sync.Mutex
 }
 
 // NewClaudeCodeProvider creates a new Claude Code provider instance
@@ -313,10 +314,12 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 		c.debugf("No debug file set for agentic mode")
 	}
 
-	// Add worktree for isolated execution
-	if c.worktree != "" {
+	// Add worktree for isolated execution (only if flag is supported)
+	if c.worktree != "" && c.SupportsWorktreeFlag() {
 		c.debugf("Adding --worktree flag: %s", c.worktree)
 		args = append(args, "--worktree", c.worktree)
+	} else if c.worktree != "" {
+		c.debugf("Worktree requested but --worktree flag not supported, using workDir fallback")
 	}
 
 	// Add allowed paths for tool access scope
@@ -421,6 +424,34 @@ func (c *ClaudeCodeProvider) SetWorktree(name string) {
 // ClearWorktree clears the worktree setting
 func (c *ClaudeCodeProvider) ClearWorktree() {
 	c.worktree = ""
+}
+
+// SupportsWorktreeFlag probes if Claude Code CLI supports the --worktree flag
+// Result is cached after first probe
+func (c *ClaudeCodeProvider) SupportsWorktreeFlag() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Return cached result if available
+	if c.worktreeSupported != nil {
+		return *c.worktreeSupported
+	}
+
+	// Probe by checking --help output for --worktree
+	supported := false
+	if c.binaryPath != "" {
+		cmd := exec.Command(c.binaryPath, "--help")
+		output, err := cmd.Output()
+		if err == nil {
+			supported = strings.Contains(string(output), "--worktree")
+		}
+	}
+
+	c.worktreeSupported = &supported
+	if c.verbose {
+		log.Printf("[DEBUG][ClaudeCode] Worktree flag probe: supported=%v\n", supported)
+	}
+	return supported
 }
 
 // ValidateModel checks if the model is valid for Claude Code

--- a/utils/processor/action_handler.go
+++ b/utils/processor/action_handler.go
@@ -113,7 +113,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 						}
 					}
 					result, err := claudeCode.SendPromptAgentic(modelName, action,
-						agenticConfig.AllowedPaths, agenticConfig.Tools, p.runtimeDir)
+						agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 					// Stop the debug watcher
 					if debugWatcher != nil {
 						debugWatcher.Stop()
@@ -297,7 +297,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 						}
 					}
 					result, err := claudeCode.SendPromptAgentic(modelName, combinedPrompt,
-						agenticConfig.AllowedPaths, agenticConfig.Tools, p.runtimeDir)
+						agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 					// Stop the debug watcher
 					if debugWatcher != nil {
 						debugWatcher.Stop()

--- a/utils/processor/action_handler.go
+++ b/utils/processor/action_handler.go
@@ -112,6 +112,13 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 							debugWatcher.Start()
 						}
 					}
+					// Set native worktree if provider supports it and step uses a worktree
+					worktreeName := p.getCurrentStepWorktree()
+					if worktreeName != "" && p.providerSupportsWorktrees("claude-code") {
+						p.debugf("Using native worktree support: %s", worktreeName)
+						claudeCode.SetWorktree(worktreeName)
+						defer claudeCode.ClearWorktree()
+					}
 					result, err := claudeCode.SendPromptAgentic(modelName, action,
 						agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 					// Stop the debug watcher
@@ -295,6 +302,13 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 							debugWatcher = NewDebugWatcher(debugPath, p.streamLog)
 							debugWatcher.Start()
 						}
+					}
+					// Set native worktree if provider supports it and step uses a worktree
+					worktreeName := p.getCurrentStepWorktree()
+					if worktreeName != "" && p.providerSupportsWorktrees("claude-code") {
+						p.debugf("Using native worktree support: %s", worktreeName)
+						claudeCode.SetWorktree(worktreeName)
+						defer claudeCode.ClearWorktree()
 					}
 					result, err := claudeCode.SendPromptAgentic(modelName, combinedPrompt,
 						agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -81,6 +81,24 @@ func (p *Processor) clearCurrentStepWorktree() {
 	p.currentStepWorktree = ""
 }
 
+// getCurrentStepWorktree returns the worktree name for the current step
+func (p *Processor) getCurrentStepWorktree() string {
+	return p.currentStepWorktree
+}
+
+// providerSupportsWorktrees checks if a provider has native worktree support
+func (p *Processor) providerSupportsWorktrees(providerName string) bool {
+	if p.envConfig == nil {
+		return false
+	}
+	provider, err := p.envConfig.GetProviderConfig(providerName)
+	if err != nil || provider == nil {
+		// Default to true for claude-code (native support)
+		return providerName == "claude-code"
+	}
+	return provider.SupportsWorktrees
+}
+
 // setAgenticConfig sets the current agentic config (thread-safe)
 func (p *Processor) setAgenticConfig(config *AgenticLoopConfig) {
 	p.mu.Lock()

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -85,6 +85,22 @@ type ToolListConfig struct {
 	Timeout   int      `yaml:"timeout"`   // Timeout in seconds for tool execution
 }
 
+// WorktreeConfig defines Git worktrees for parallel Claude Code execution
+type WorktreeConfig struct {
+	Repo    string         `yaml:"repo,omitempty"`     // Repository path (default: ".")
+	BaseDir string         `yaml:"base_dir,omitempty"` // Directory for worktrees (default: ".comanda-worktrees")
+	Trees   []WorktreeSpec `yaml:"trees,omitempty"`    // Explicit worktree specifications
+	Cleanup bool           `yaml:"cleanup,omitempty"`  // Cleanup worktrees after workflow (default: true)
+}
+
+// WorktreeSpec defines a single worktree
+type WorktreeSpec struct {
+	Name       string `yaml:"name"`                 // Worktree identifier (required)
+	Branch     string `yaml:"branch,omitempty"`     // Existing branch to checkout
+	NewBranch  bool   `yaml:"new_branch,omitempty"` // Create a new branch (named worktree-<name>)
+	BaseBranch string `yaml:"base,omitempty"`       // Base branch for new branch (default: HEAD)
+}
+
 // StepConfig represents the configuration for a single step
 type StepConfig struct {
 	Type       string          `yaml:"type"`            // Step type (default is standard LLM step)
@@ -115,6 +131,10 @@ type StepConfig struct {
 	AgenticLoop   *AgenticLoopConfig   `yaml:"agentic_loop,omitempty"`   // Inline agentic loop configuration
 	CodebaseIndex *CodebaseIndexConfig `yaml:"codebase_index,omitempty"` // Codebase indexing configuration
 	QmdSearch     *QmdSearchConfig     `yaml:"qmd_search,omitempty"`     // qmd search configuration
+
+	// Worktree fields
+	Worktree     string `yaml:"worktree,omitempty"`      // Run step in a specific worktree by name
+	EachWorktree bool   `yaml:"each_worktree,omitempty"` // Run step once per worktree (combine with parallel for concurrent)
 }
 
 // Step represents a named step in the DSL
@@ -134,6 +154,9 @@ type DSLConfig struct {
 	Loops        map[string]*AgenticLoopConfig `yaml:"loops,omitempty"`         // Named loops for orchestration
 	ExecuteLoops []string                      `yaml:"execute_loops,omitempty"` // Simple execution order
 	Workflow     map[string]*WorkflowNode      `yaml:"workflow,omitempty"`      // Complex workflow definition
+
+	// Worktree support for parallel Claude Code execution
+	Worktrees *WorktreeConfig `yaml:"worktrees,omitempty"` // Git worktree configuration
 }
 
 // StepDependency represents a dependency between steps

--- a/utils/processor/worktree_handler.go
+++ b/utils/processor/worktree_handler.go
@@ -1,0 +1,221 @@
+package processor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kris-hansen/comanda/utils/worktree"
+)
+
+// WorktreeHandler manages worktrees for a processor
+type WorktreeHandler struct {
+	manager    *worktree.Manager
+	config     *WorktreeConfig
+	verbose    bool
+	repoPath   string
+	worktrees  map[string]*worktree.Worktree
+	cleanupSet bool
+}
+
+// NewWorktreeHandler creates a new worktree handler
+func NewWorktreeHandler(config *WorktreeConfig, repoPath string, verbose bool) (*WorktreeHandler, error) {
+	if config == nil {
+		return nil, nil // No worktree config, nothing to do
+	}
+
+	// Default repo path to current directory
+	if repoPath == "" {
+		repoPath = "."
+	}
+	if config.Repo != "" {
+		repoPath = config.Repo
+	}
+
+	manager, err := worktree.NewManager(repoPath, verbose)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create worktree manager: %w", err)
+	}
+
+	// Set base directory if specified
+	if config.BaseDir != "" {
+		manager.SetBaseDir(config.BaseDir)
+	}
+
+	handler := &WorktreeHandler{
+		manager:    manager,
+		config:     config,
+		verbose:    verbose,
+		repoPath:   repoPath,
+		worktrees:  make(map[string]*worktree.Worktree),
+		cleanupSet: config.Cleanup,
+	}
+
+	return handler, nil
+}
+
+// debugf prints debug output if verbose mode is enabled
+func (h *WorktreeHandler) debugf(format string, args ...interface{}) {
+	if h.verbose {
+		fmt.Printf("[DEBUG][WorktreeHandler] "+format+"\n", args...)
+	}
+}
+
+// Setup creates all worktrees defined in the config
+func (h *WorktreeHandler) Setup() error {
+	if h == nil || h.config == nil {
+		return nil
+	}
+
+	h.debugf("Setting up %d worktrees", len(h.config.Trees))
+
+	for _, spec := range h.config.Trees {
+		if spec.Name == "" {
+			return fmt.Errorf("worktree spec missing required 'name' field")
+		}
+
+		var wt *worktree.Worktree
+		var err error
+
+		if spec.NewBranch {
+			// Create a new branch
+			wt, err = h.manager.CreateNewBranch(spec.Name, spec.BaseBranch)
+		} else if spec.Branch != "" {
+			// Use existing branch
+			wt, err = h.manager.Create(spec.Name, spec.Branch)
+		} else {
+			// Default: create new branch from HEAD
+			wt, err = h.manager.CreateNewBranch(spec.Name, "HEAD")
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to create worktree %s: %w", spec.Name, err)
+		}
+
+		h.worktrees[spec.Name] = wt
+		h.debugf("Created worktree: %s -> %s", spec.Name, wt.Path)
+	}
+
+	return nil
+}
+
+// GetWorktreePath returns the path for a named worktree
+func (h *WorktreeHandler) GetWorktreePath(name string) (string, error) {
+	if h == nil {
+		return "", fmt.Errorf("worktree handler not initialized")
+	}
+
+	wt, exists := h.worktrees[name]
+	if !exists {
+		return "", fmt.Errorf("worktree not found: %s", name)
+	}
+
+	return wt.Path, nil
+}
+
+// GetWorktree returns the worktree object by name
+func (h *WorktreeHandler) GetWorktree(name string) *worktree.Worktree {
+	if h == nil {
+		return nil
+	}
+	return h.worktrees[name]
+}
+
+// ListWorktrees returns all worktrees
+func (h *WorktreeHandler) ListWorktrees() []*worktree.Worktree {
+	if h == nil {
+		return nil
+	}
+
+	result := make([]*worktree.Worktree, 0, len(h.worktrees))
+	for _, wt := range h.worktrees {
+		result = append(result, wt)
+	}
+	return result
+}
+
+// ListWorktreeNames returns all worktree names
+func (h *WorktreeHandler) ListWorktreeNames() []string {
+	if h == nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(h.worktrees))
+	for name := range h.worktrees {
+		names = append(names, name)
+	}
+	return names
+}
+
+// HasWorktrees returns true if any worktrees are configured
+func (h *WorktreeHandler) HasWorktrees() bool {
+	return h != nil && len(h.worktrees) > 0
+}
+
+// GetWorkDir returns the appropriate working directory for a step
+// If worktreeName is specified and exists, returns the worktree path
+// Otherwise returns the default workDir
+func (h *WorktreeHandler) GetWorkDir(worktreeName, defaultWorkDir string) string {
+	if h == nil || worktreeName == "" {
+		return defaultWorkDir
+	}
+
+	if path, err := h.GetWorktreePath(worktreeName); err == nil {
+		return path
+	}
+
+	return defaultWorkDir
+}
+
+// Cleanup removes all worktrees if cleanup is enabled
+func (h *WorktreeHandler) Cleanup() error {
+	if h == nil || !h.cleanupSet {
+		return nil
+	}
+
+	h.debugf("Cleaning up worktrees")
+	return h.manager.CleanupAll(true) // Remove branches too
+}
+
+// GetDiffs returns diffs for all worktrees
+func (h *WorktreeHandler) GetDiffs() (map[string]string, error) {
+	if h == nil {
+		return nil, nil
+	}
+
+	diffs := make(map[string]string)
+	for name := range h.worktrees {
+		diff, err := h.manager.GetDiff(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get diff for worktree %s: %w", name, err)
+		}
+		if diff != "" {
+			diffs[name] = diff
+		}
+	}
+
+	return diffs, nil
+}
+
+// ExpandWorktreeVariables expands ${worktrees.name.path} and ${worktrees.name.branch} in a string
+func (h *WorktreeHandler) ExpandWorktreeVariables(input string) string {
+	if h == nil || !strings.Contains(input, "${worktrees.") {
+		return input
+	}
+
+	result := input
+	for name, wt := range h.worktrees {
+		// Replace ${worktrees.name.path}
+		pathVar := fmt.Sprintf("${worktrees.%s.path}", name)
+		result = strings.ReplaceAll(result, pathVar, wt.Path)
+
+		// Replace ${worktrees.name.branch}
+		branchVar := fmt.Sprintf("${worktrees.%s.branch}", name)
+		result = strings.ReplaceAll(result, branchVar, wt.Branch)
+
+		// Replace ${worktrees.name.name}
+		nameVar := fmt.Sprintf("${worktrees.%s.name}", name)
+		result = strings.ReplaceAll(result, nameVar, wt.Name)
+	}
+
+	return result
+}

--- a/utils/worktree/manager.go
+++ b/utils/worktree/manager.go
@@ -1,0 +1,330 @@
+// Package worktree provides Git worktree management for parallel Claude Code execution.
+// It enables running multiple Claude Code sessions in isolated worktrees, each with
+// their own branch and working directory, while sharing repository history.
+package worktree
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Worktree represents a single Git worktree
+type Worktree struct {
+	Name   string // User-friendly name (e.g., "feature-auth")
+	Branch string // Git branch name (e.g., "worktree-feature-auth")
+	Path   string // Absolute path to worktree directory
+}
+
+// Manager handles creation and cleanup of Git worktrees
+type Manager struct {
+	RepoPath  string               // Path to the main repository
+	BaseDir   string               // Directory for worktrees (default: .comanda-worktrees)
+	Worktrees map[string]*Worktree // Active worktrees by name
+	verbose   bool
+	mu        sync.RWMutex
+}
+
+// NewManager creates a new worktree manager
+func NewManager(repoPath string, verbose bool) (*Manager, error) {
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repo path: %w", err)
+	}
+
+	// Verify it's a git repository
+	gitDir := filepath.Join(absPath, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("not a git repository: %s", absPath)
+	}
+
+	return &Manager{
+		RepoPath:  absPath,
+		BaseDir:   ".comanda-worktrees",
+		Worktrees: make(map[string]*Worktree),
+		verbose:   verbose,
+	}, nil
+}
+
+// SetBaseDir changes the base directory for worktrees
+func (m *Manager) SetBaseDir(dir string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.BaseDir = dir
+}
+
+// debugf prints debug output if verbose mode is enabled
+func (m *Manager) debugf(format string, args ...interface{}) {
+	if m.verbose {
+		fmt.Printf("[DEBUG][Worktree] "+format+"\n", args...)
+	}
+}
+
+// Create creates a new worktree from an existing branch
+func (m *Manager) Create(name, branch string) (*Worktree, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if worktree already exists
+	if wt, exists := m.Worktrees[name]; exists {
+		return wt, nil
+	}
+
+	// Create worktree directory path
+	wtPath := filepath.Join(m.RepoPath, m.BaseDir, name)
+
+	// Ensure base directory exists
+	baseDir := filepath.Join(m.RepoPath, m.BaseDir)
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create worktree base directory: %w", err)
+	}
+
+	// Create the worktree
+	m.debugf("Creating worktree %s from branch %s at %s", name, branch, wtPath)
+	cmd := exec.Command("git", "worktree", "add", wtPath, branch)
+	cmd.Dir = m.RepoPath
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to create worktree: %w (%s)", err, stderr.String())
+	}
+
+	wt := &Worktree{
+		Name:   name,
+		Branch: branch,
+		Path:   wtPath,
+	}
+	m.Worktrees[name] = wt
+
+	m.debugf("Created worktree: %s -> %s", name, wtPath)
+	return wt, nil
+}
+
+// CreateNewBranch creates a worktree with a new branch from a base branch
+func (m *Manager) CreateNewBranch(name, baseBranch string) (*Worktree, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if worktree already exists
+	if wt, exists := m.Worktrees[name]; exists {
+		return wt, nil
+	}
+
+	// Create worktree directory path
+	wtPath := filepath.Join(m.RepoPath, m.BaseDir, name)
+	branchName := "worktree-" + name
+
+	// Ensure base directory exists
+	baseDir := filepath.Join(m.RepoPath, m.BaseDir)
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create worktree base directory: %w", err)
+	}
+
+	// If no base branch specified, use current HEAD
+	if baseBranch == "" {
+		baseBranch = "HEAD"
+	}
+
+	// Create the worktree with a new branch
+	m.debugf("Creating worktree %s with new branch %s from %s", name, branchName, baseBranch)
+	cmd := exec.Command("git", "worktree", "add", "-b", branchName, wtPath, baseBranch)
+	cmd.Dir = m.RepoPath
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to create worktree: %w (%s)", err, stderr.String())
+	}
+
+	wt := &Worktree{
+		Name:   name,
+		Branch: branchName,
+		Path:   wtPath,
+	}
+	m.Worktrees[name] = wt
+
+	m.debugf("Created worktree with new branch: %s -> %s (branch: %s)", name, wtPath, branchName)
+	return wt, nil
+}
+
+// Get returns a worktree by name
+func (m *Manager) Get(name string) *Worktree {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.Worktrees[name]
+}
+
+// List returns all active worktrees
+func (m *Manager) List() []*Worktree {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]*Worktree, 0, len(m.Worktrees))
+	for _, wt := range m.Worktrees {
+		result = append(result, wt)
+	}
+	return result
+}
+
+// Remove removes a worktree and optionally its branch
+func (m *Manager) Remove(name string, removeBranch bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	wt, exists := m.Worktrees[name]
+	if !exists {
+		return nil // Already removed
+	}
+
+	m.debugf("Removing worktree: %s", name)
+
+	// Remove the worktree
+	cmd := exec.Command("git", "worktree", "remove", wt.Path, "--force")
+	cmd.Dir = m.RepoPath
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// Try to remove directory manually if git worktree remove fails
+		if rmErr := os.RemoveAll(wt.Path); rmErr != nil {
+			return fmt.Errorf("failed to remove worktree: %w (%s)", err, stderr.String())
+		}
+		// Prune worktrees to clean up
+		pruneCmd := exec.Command("git", "worktree", "prune")
+		pruneCmd.Dir = m.RepoPath
+		_ = pruneCmd.Run()
+	}
+
+	// Optionally remove the branch
+	if removeBranch && strings.HasPrefix(wt.Branch, "worktree-") {
+		m.debugf("Removing branch: %s", wt.Branch)
+		branchCmd := exec.Command("git", "branch", "-D", wt.Branch)
+		branchCmd.Dir = m.RepoPath
+		_ = branchCmd.Run() // Ignore errors - branch might not exist or might be checked out elsewhere
+	}
+
+	delete(m.Worktrees, name)
+	return nil
+}
+
+// CleanupAll removes all managed worktrees
+func (m *Manager) CleanupAll(removeBranches bool) error {
+	m.mu.Lock()
+	names := make([]string, 0, len(m.Worktrees))
+	for name := range m.Worktrees {
+		names = append(names, name)
+	}
+	m.mu.Unlock()
+
+	var lastErr error
+	for _, name := range names {
+		if err := m.Remove(name, removeBranches); err != nil {
+			lastErr = err
+			m.debugf("Error removing worktree %s: %v", name, err)
+		}
+	}
+
+	return lastErr
+}
+
+// HasChanges checks if a worktree has uncommitted changes
+func (m *Manager) HasChanges(name string) (bool, error) {
+	m.mu.RLock()
+	wt, exists := m.Worktrees[name]
+	m.mu.RUnlock()
+
+	if !exists {
+		return false, fmt.Errorf("worktree not found: %s", name)
+	}
+
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = wt.Path
+
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to check worktree status: %w", err)
+	}
+
+	return len(bytes.TrimSpace(output)) > 0, nil
+}
+
+// GetDiff returns the diff for a worktree (staged and unstaged changes)
+func (m *Manager) GetDiff(name string) (string, error) {
+	m.mu.RLock()
+	wt, exists := m.Worktrees[name]
+	m.mu.RUnlock()
+
+	if !exists {
+		return "", fmt.Errorf("worktree not found: %s", name)
+	}
+
+	// Get both staged and unstaged changes
+	cmd := exec.Command("git", "diff", "HEAD")
+	cmd.Dir = wt.Path
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get diff: %w", err)
+	}
+
+	return string(output), nil
+}
+
+// DiscoverExisting discovers worktrees that already exist in the base directory
+func (m *Manager) DiscoverExisting() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	baseDir := filepath.Join(m.RepoPath, m.BaseDir)
+	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
+		return nil // No base directory, nothing to discover
+	}
+
+	// List git worktrees
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = m.RepoPath
+
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	// Parse worktree list
+	lines := strings.Split(string(output), "\n")
+	var currentPath, currentBranch string
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "worktree ") {
+			currentPath = strings.TrimPrefix(line, "worktree ")
+		} else if strings.HasPrefix(line, "branch ") {
+			currentBranch = strings.TrimPrefix(line, "branch refs/heads/")
+		} else if line == "" && currentPath != "" {
+			// Check if this worktree is in our base directory
+			if strings.HasPrefix(currentPath, baseDir) {
+				name := filepath.Base(currentPath)
+				if _, exists := m.Worktrees[name]; !exists {
+					m.Worktrees[name] = &Worktree{
+						Name:   name,
+						Branch: currentBranch,
+						Path:   currentPath,
+					}
+					m.debugf("Discovered existing worktree: %s", name)
+				}
+			}
+			currentPath = ""
+			currentBranch = ""
+		}
+	}
+
+	return nil
+}

--- a/utils/worktree/manager.go
+++ b/utils/worktree/manager.go
@@ -186,22 +186,31 @@ func (m *Manager) Remove(name string, removeBranch bool) error {
 
 	m.debugf("Removing worktree: %s", name)
 
-	// Remove the worktree
-	cmd := exec.Command("git", "worktree", "remove", wt.Path, "--force")
-	cmd.Dir = m.RepoPath
-
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		// Try to remove directory manually if git worktree remove fails
-		if rmErr := os.RemoveAll(wt.Path); rmErr != nil {
-			return fmt.Errorf("failed to remove worktree: %w (%s)", err, stderr.String())
-		}
-		// Prune worktrees to clean up
+	// Check if the worktree directory exists before attempting removal
+	if _, err := os.Stat(wt.Path); os.IsNotExist(err) {
+		m.debugf("Worktree directory already removed: %s", wt.Path)
+		// Directory doesn't exist, just prune and clean up the map
 		pruneCmd := exec.Command("git", "worktree", "prune")
 		pruneCmd.Dir = m.RepoPath
 		_ = pruneCmd.Run()
+	} else {
+		// Remove the worktree
+		cmd := exec.Command("git", "worktree", "remove", wt.Path, "--force")
+		cmd.Dir = m.RepoPath
+
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+
+		if err := cmd.Run(); err != nil {
+			// Try to remove directory manually if git worktree remove fails
+			if rmErr := os.RemoveAll(wt.Path); rmErr != nil {
+				return fmt.Errorf("failed to remove worktree: %w (%s)", err, stderr.String())
+			}
+			// Prune worktrees to clean up
+			pruneCmd := exec.Command("git", "worktree", "prune")
+			pruneCmd.Dir = m.RepoPath
+			_ = pruneCmd.Run()
+		}
 	}
 
 	// Optionally remove the branch

--- a/utils/worktree/manager_test.go
+++ b/utils/worktree/manager_test.go
@@ -1,0 +1,196 @@
+package worktree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewManager(t *testing.T) {
+	// Create a temporary git repo for testing
+	tmpDir, err := os.MkdirTemp("", "worktree-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	// Configure git user for commits
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "config", "user.name", "Test")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+
+	// Create initial commit
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "initial")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to create initial commit: %v", err)
+	}
+
+	// Test manager creation
+	manager, err := NewManager(tmpDir, true)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	if manager.RepoPath != tmpDir {
+		t.Errorf("Expected RepoPath %s, got %s", tmpDir, manager.RepoPath)
+	}
+
+	if manager.BaseDir != ".comanda-worktrees" {
+		t.Errorf("Expected BaseDir .comanda-worktrees, got %s", manager.BaseDir)
+	}
+}
+
+func TestCreateNewBranch(t *testing.T) {
+	// Create a temporary git repo for testing
+	tmpDir, err := os.MkdirTemp("", "worktree-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	// Configure git user
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "config", "user.name", "Test")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+
+	// Create initial commit
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "initial")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to create initial commit: %v", err)
+	}
+
+	// Create manager
+	manager, err := NewManager(tmpDir, false)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	// Test creating a worktree with new branch
+	wt, err := manager.CreateNewBranch("test-feature", "")
+	if err != nil {
+		t.Fatalf("Failed to create worktree: %v", err)
+	}
+
+	if wt.Name != "test-feature" {
+		t.Errorf("Expected name 'test-feature', got %s", wt.Name)
+	}
+
+	if wt.Branch != "worktree-test-feature" {
+		t.Errorf("Expected branch 'worktree-test-feature', got %s", wt.Branch)
+	}
+
+	expectedPath := filepath.Join(tmpDir, ".comanda-worktrees", "test-feature")
+	if wt.Path != expectedPath {
+		t.Errorf("Expected path %s, got %s", expectedPath, wt.Path)
+	}
+
+	// Verify worktree directory exists
+	if _, err := os.Stat(wt.Path); os.IsNotExist(err) {
+		t.Error("Worktree directory was not created")
+	}
+
+	// Cleanup
+	if err := manager.Remove("test-feature", true); err != nil {
+		t.Errorf("Failed to remove worktree: %v", err)
+	}
+}
+
+func TestListWorktrees(t *testing.T) {
+	// Create a temporary git repo for testing
+	tmpDir, err := os.MkdirTemp("", "worktree-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	// Configure git user
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "config", "user.name", "Test")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+
+	// Create initial commit
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tmpDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "initial")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to create initial commit: %v", err)
+	}
+
+	// Create manager
+	manager, err := NewManager(tmpDir, false)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	// Create multiple worktrees
+	_, err = manager.CreateNewBranch("feature-a", "")
+	if err != nil {
+		t.Fatalf("Failed to create worktree a: %v", err)
+	}
+	_, err = manager.CreateNewBranch("feature-b", "")
+	if err != nil {
+		t.Fatalf("Failed to create worktree b: %v", err)
+	}
+
+	// List worktrees
+	worktrees := manager.List()
+	if len(worktrees) != 2 {
+		t.Errorf("Expected 2 worktrees, got %d", len(worktrees))
+	}
+
+	// Cleanup
+	manager.CleanupAll(true)
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces Git worktree support to enable running multiple Claude Code sessions in parallel, each with isolated branches and working directories.
- Implements a new package `utils/worktree` for managing Git worktrees.
- Adds a `WorktreeHandler` in the `utils/processor` package to integrate worktree management with the processor.
- Extends the DSL to support worktree configurations and step-level worktree selection.
- Provides variable expansion for worktree paths and branch names.
- Includes tests for the new worktree management functionality.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/action_handler.go`: Modified the `processActions` function to use `getEffectiveWorkDir` instead of `p.runtimeDir` for determining the working directory, allowing steps to execute in specific worktrees.
- `utils/processor/dsl.go`: Added fields to the `Processor` struct for handling worktrees. Introduced methods `getEffectiveWorkDir`, `setCurrentStepWorktree`, and `clearCurrentStepWorktree` to manage worktree contexts for steps.
- `utils/processor/types.go`: Defined new types `WorktreeConfig` and `WorktreeSpec` for configuring Git worktrees in the DSL. Added worktree-related fields to `StepConfig`.
- `utils/processor/worktree_handler.go`: Added a new `WorktreeHandler` struct to manage worktrees, including methods for setup, cleanup, and variable expansion related to worktrees.
- `utils/worktree/manager.go`: Implemented a `Manager` struct for creating and managing Git worktrees, including methods for creating new branches, listing worktrees, and cleaning up.
- `utils/worktree/manager_test.go`: Added tests for the `Manager` struct to verify the creation, listing, and cleanup of worktrees, ensuring the functionality works as expected.
</details>

___
## User Description:
## Summary

Adds Git worktree support for running multiple Claude Code sessions in parallel, each with isolated branches and working directories.

Based on [Claude Code's built-in worktree support](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees).

## Features

### New DSL Elements

**Top-level `worktrees` config:**
```yaml
worktrees:
  repo: .                    # Repository path (default: .)
  base_dir: .comanda-worktrees  # Where to create worktrees
  cleanup: true              # Auto-cleanup after workflow
  trees:
    - name: auth             # Worktree identifier
      new_branch: true       # Create new branch (worktree-auth)
    - name: api
      branch: feature/api    # Use existing branch
```

**Step-level worktree selection:**
```yaml
steps:
  - name: work-in-auth
    worktree: auth           # Run in 'auth' worktree
    model: claude-code
    action: "Implement authentication"
```

**Variable expansion:**
- `${worktrees.name.path}` - worktree directory path
- `${worktrees.name.branch}` - branch name

## Example: Parallel Feature Development

```yaml
worktrees:
  trees:
    - name: auth
      new_branch: true
    - name: api
      new_branch: true
    - name: ui
      new_branch: true

steps:
  - name: implement-auth
    worktree: auth
    model: claude-code
    action: "Implement JWT authentication"

  - name: implement-api
    worktree: api
    model: claude-code
    action: "Add rate limiting to API"

  - name: implement-ui
    worktree: ui
    model: claude-code
    action: "Create login component"

  - name: qa-review
    model: claude-sonnet
    action: |
      Review all branches:
      - Auth: ${worktrees.auth.path}
      - API: ${worktrees.api.path}
      - UI: ${worktrees.ui.path}
```

## Implementation

- **`utils/worktree/manager.go`** - Git worktree lifecycle management
- **`utils/processor/worktree_handler.go`** - Integration with processor
- **`utils/processor/types.go`** - New DSL types (WorktreeConfig, WorktreeSpec)
- **`utils/processor/dsl.go`** - Worktree setup, cleanup, and variable expansion
- **`utils/processor/action_handler.go`** - Pass worktree path to Claude Code

## Testing

```bash
go test ./utils/worktree/... -v
```

## Future Work

- [ ] `each_worktree: true` for running steps across all worktrees in parallel
- [ ] Integration with bead scoping for dynamic worktree creation
- [ ] Worktree diffs in QA steps
