### PR TITLE
docs: streamline README, refer to comanda.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,30 @@
-![robot image](comanda-small.jpg)
+![comanda](comanda-small.jpg)
 
 # comanda
 
-**Declarative AI pipelines for the command line.** Define LLM workflows in YAML, run them anywhere, version control everything.
+**Declarative AI pipelines for the command line.**
 
-🌐 [comanda.sh](https://comanda.sh) · 📖 [Examples](examples/README.md) · ⭐ Star to support!
+Define LLM workflows in YAML. Run Claude Code, Codex, and Gemini CLI in parallel. Version control everything.
 
-```bash
-cat main.go | comanda process code-review.yaml      # Pipe code through AI
-comanda process multi-agent/architecture.yaml       # Run multiple agents in parallel
-comanda generate "review this PR for security"      # Generate workflows from English
-```
+🌐 **[comanda.sh](https://comanda.sh)** — Getting started, features, and templates
 
 ## Install
 
 ```bash
-brew install kris-hansen/comanda/comanda    # macOS
-go install github.com/kris-hansen/comanda@latest   # or via Go
+brew install kris-hansen/comanda/comanda
 ```
 
-```bash
-comanda configure   # Set up API keys
-comanda --version   # Verify install
-```
+Or: `go install github.com/kris-hansen/comanda@latest` · [Releases](https://github.com/kris-hansen/comanda/releases)
 
 ## Quick Start
 
-**hello.yaml:**
-```yaml
-hello:
-  input: NA
-  model: gpt-4o
-  action: Write a haiku about programming
-  output: STDOUT
-```
-
 ```bash
-comanda process hello.yaml
+comanda configure                              # Set up API keys
+comanda generate "review this code for bugs"   # Generate workflow from English
+comanda process workflow.yaml                  # Run a workflow
 ```
 
-## Core Features
-
-### Multi-Agent Orchestration
-
-Run Claude Code, Codex, and Gemini CLI in parallel:
+## Example
 
 ```yaml
 parallel-process:
@@ -66,137 +47,27 @@ synthesize:
   output: STDOUT
 ```
 
-### Agentic Loops
-
-Iterate until the LLM decides work is complete:
-
-```yaml
-implement:
-  agentic_loop:
-    max_iterations: 5
-    exit_condition: llm_decides
-    allowed_paths: [./src, ./tests]
-    tools: [Read, Write, Edit, Bash]
-  input: STDIN
-  model: claude-code
-  action: "Implement and test. Say DONE when complete."
-  output: STDOUT
-```
-
-### Codebase Indexing
-
-Persistent code context for AI workflows:
-
 ```bash
-comanda index capture ~/project -n myproject   # Index once
-comanda index list                              # See all indexes
-comanda index diff myproject                    # What changed?
+cat main.go | comanda process multi-agent.yaml
 ```
 
-```yaml
-analyze:
-  codebase_index:
-    use: [project1, project2]   # Load from registry
-    aggregate: true
-  model: claude
-  action: "Compare these codebases"
-```
+## Features
 
-### Git Worktrees
+- **Multi-agent** — Claude Code, Gemini CLI, OpenAI Codex in parallel
+- **Agentic loops** — Iterative refinement with tool use
+- **Codebase indexing** — Persistent code context across workflows  
+- **Git worktrees** — Parallel execution in isolated branches
+- **All the I/O** — Files, URLs, databases, images, chunking
 
-Parallel Claude Code execution in isolated worktrees:
-
-```yaml
-worktrees:
-  repo: .
-  trees:
-    - name: feature-a
-      new_branch: true
-    - name: feature-b
-      new_branch: true
-
-parallel-process:
-  implement-a:
-    worktree: feature-a
-    model: claude-code
-    action: "Implement feature A"
-
-  implement-b:
-    worktree: feature-b
-    model: claude-code
-    action: "Implement feature B"
-```
-
-### Workflow Visualization
-
-```bash
-comanda chart workflow.yaml
-```
-
-```
-+================================================+
-| PARALLEL: parallel-process (3 steps)           |
-+------------------------------------------------+
-  ├─ claude-analysis
-  ├─ gemini-analysis
-  └─ codex-analysis
-+================================================+
-                        |
-                        v
-+------------------------------------------------+
-| synthesize                                     |
-+------------------------------------------------+
-```
-
-## Supported Providers
-
-| Type | Providers |
-|------|-----------|
-| **Cloud APIs** | OpenAI, Anthropic, Google, X.AI, DeepSeek, Moonshot |
-| **Local** | Ollama, vLLM, any OpenAI-compatible endpoint |
-| **Agentic CLIs** | Claude Code, Gemini CLI, OpenAI Codex |
-
-## All Features
-
-| Feature | Description |
-|---------|-------------|
-| Multi-provider | Cloud APIs, local models, agentic CLIs |
-| Parallel execution | Run steps concurrently |
-| Agentic loops | Iterative refinement with exit conditions |
-| Tool execution | Shell commands within workflows |
-| Codebase indexing | Persistent code context across workflows |
-| Git worktrees | Parallel branches for isolated execution |
-| File operations | Wildcards, chunking, batch processing |
-| Vision | Analyze images and screenshots |
-| Web scraping | Fetch and process URLs |
-| Database I/O | PostgreSQL read/write |
-| Memory | Persistent context via COMANDA.md |
-| qmd integration | Local semantic search |
-| Server mode | HTTP API for any workflow |
-| Visualization | ASCII workflow charts |
+See [comanda.sh/features](https://comanda.sh/features) for full details.
 
 ## Documentation
 
-- [Examples](examples/README.md) — Sample workflows
+- [Examples](examples/README.md)
 - [Multi-Agent Patterns](examples/multi-agent/README.md)
 - [Agentic Loops](examples/agentic-loop/)
-- [Tool Use Guide](examples/tool-use/README.md)
 - [Server API](docs/server-api.md)
-
-## Server Mode
-
-```bash
-comanda server
-curl -X POST "http://localhost:8080/process?filename=review.yaml" \
-  -d '{"input": "code to review"}'
-```
-
-## Development
-
-```bash
-make deps && make build && make test
-```
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+MIT


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
- Significantly reduces the README content from ~200 lines to ~60 lines, focusing on essential information.
- Directs users to the comanda.sh website for getting started, features, and templates.
- Removes outdated examples and redundant sections that are covered by the website.
- Retains key sections such as installation instructions, a quick start guide, a concise example, and feature highlights.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `README.md`: - Updated the introductory section to provide a concise description of comanda's capabilities.
- Simplified installation instructions and provided a link to releases.
- Streamlined the quick start section with updated command examples.
- Removed detailed examples and feature descriptions, replacing them with a link to the comanda.sh website for full details.
- Condensed the features section to highlight core capabilities and provided a link for more information.
- Simplified the documentation links section, removing redundant guides and focusing on key resources.
</details>

___
## User Description:
Streamlines the README significantly:

- **Before:** ~200 lines, lots of examples
- **After:** ~60 lines, essentials only

### Changes
- Point to [comanda.sh](https://comanda.sh) for getting started and features
- Remove outdated chart output example (was ASCII, now Unicode)
- Remove redundant sections already covered by website
- Keep: install, quick start, one good example, feature bullets, doc links

The website now has comprehensive docs, so the README can be a concise entry point.
