### PR TITLE
fix: use lipgloss for box rendering to prevent broken borders

### DIFF
--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -7,10 +7,30 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/kris-hansen/comanda/utils/processor"
 	"github.com/kris-hansen/comanda/utils/tui"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+)
+
+// Chart box styles using lipgloss
+var (
+	chartBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("240")).
+			Padding(0, 1)
+
+	chartDoubleBoxStyle = lipgloss.NewStyle().
+				Border(lipgloss.DoubleBorder()).
+				BorderForeground(lipgloss.Color("240")).
+				Padding(0, 1)
+
+	chartHeaderStyle = lipgloss.NewStyle().
+				Border(lipgloss.DoubleBorder()).
+				BorderForeground(lipgloss.Color("99")).
+				Padding(0, 1).
+				Bold(true)
 )
 
 // ChartNode represents a step in the workflow visualization
@@ -460,60 +480,24 @@ func renderChart(chart *WorkflowChart, filename string) {
 }
 
 // Unicode box-drawing characters
+// Chart icons and connectors (boxes now rendered via lipgloss)
 const (
-	boxHoriz             = "─"
-	boxVert              = "│"
-	boxTopLeft           = "┌"
-	boxTopRight          = "┐"
-	boxBottomLeft        = "└"
-	boxBottomRight       = "┘"
-	boxVertRight         = "├"
-	boxVertLeft          = "┤"
-	boxHorizDown         = "┬"
-	boxHorizUp           = "┴"
-	boxCross             = "┼"
-	boxDoubleHoriz       = "═"
-	boxDoubleVert        = "║"
-	boxDoubleTopLeft     = "╔"
-	boxDoubleTopRight    = "╗"
-	boxDoubleBottomLeft  = "╚"
-	boxDoubleBottomRight = "╝"
-	arrowDown            = "▼"
-	arrowRight           = "▶"
-	loopIcon             = "*"
-	stepIcon             = ">"
-	parallelIcon         = "="
-	inputIcon            = "<"
-	outputIcon           = ">"
+	boxVert      = "│" // Used for flow connectors
+	arrowDown    = "▼" // Used for flow connectors
+	loopIcon     = "*"
+	parallelIcon = "="
 )
 
 // printBox prints a double-line box with centered text
 func printBox(text string, width int) {
-	// Truncate if needed
-	if len(text) > width-4 {
-		text = text[:width-7] + "..."
-	}
-	padding := width - 2 - len(text)
-	leftPad := padding / 2
-	rightPad := padding - leftPad
-
-	fmt.Println(boxDoubleTopLeft + strings.Repeat(boxDoubleHoriz, width-2) + boxDoubleTopRight)
-	fmt.Printf("%s%s%s%s%s\n", boxDoubleVert, strings.Repeat(" ", leftPad), text, strings.Repeat(" ", rightPad), boxDoubleVert)
-	fmt.Println(boxDoubleBottomLeft + strings.Repeat(boxDoubleHoriz, width-2) + boxDoubleBottomRight)
+	style := chartDoubleBoxStyle.Padding(0, 4).Align(lipgloss.Center)
+	fmt.Println(style.Render(text))
 }
 
 // printSmallBox prints a single-line box
 func printSmallBox(text string, width int) {
-	if len(text) > width-4 {
-		text = text[:width-7] + "..."
-	}
-	padding := width - 2 - len(text)
-	leftPad := padding / 2
-	rightPad := padding - leftPad
-
-	fmt.Println(boxTopLeft + strings.Repeat(boxHoriz, width-2) + boxTopRight)
-	fmt.Printf("%s%s%s%s%s\n", boxVert, strings.Repeat(" ", leftPad), text, strings.Repeat(" ", rightPad), boxVert)
-	fmt.Println(boxBottomLeft + strings.Repeat(boxHoriz, width-2) + boxBottomRight)
+	style := chartBoxStyle.Padding(0, 4).Align(lipgloss.Center)
+	fmt.Println(style.Render(text))
 }
 
 // printStepBox prints a step box with name, model, and summary
@@ -523,55 +507,30 @@ func printStepBox(name, model, summary string, isValid bool, width int, node *Ch
 		status = "✗"
 	}
 
-	// Build the content lines
-	line1 := fmt.Sprintf(" %s %s", status, name)
+	// Build content lines
+	var lines []string
+	lines = append(lines, fmt.Sprintf("%s %s", status, name))
 
-	// Truncate lines if needed
-	maxContent := width - 4
-
-	// Print the box
-	fmt.Println(boxTopLeft + strings.Repeat(boxHoriz, width-2) + boxTopRight)
-
-	// Name line
-	if len(line1) > maxContent {
-		line1 = line1[:maxContent-3] + "..."
-	}
-	fmt.Printf("%s %-*s %s\n", boxVert, width-4, line1, boxVert)
-
-	// Separator
-	fmt.Println(boxVertRight + strings.Repeat(boxHoriz, width-2) + boxVertLeft)
-
-	// Model line
+	// Add model if present
 	if model != "" && model != "N/A" && model != "[]" {
-		modelLine := fmt.Sprintf(" Model: %s", model)
-		if len(modelLine) > maxContent {
-			modelLine = modelLine[:maxContent-3] + "..."
-		}
-		fmt.Printf("%s %-*s %s\n", boxVert, width-4, modelLine, boxVert)
+		lines = append(lines, fmt.Sprintf("Model: %s", model))
 	}
 
-	// Action/prompt line
+	// Add action/summary if present
 	if summary != "" {
-		actionLine := fmt.Sprintf(" %s", summary)
-		if len(actionLine) > maxContent {
-			actionLine = actionLine[:maxContent-3] + "..."
-		}
-		fmt.Printf("%s %-*s %s\n", boxVert, width-4, actionLine, boxVert)
+		lines = append(lines, summary)
 	}
 
-	// Show output if available
+	// Add output if available
 	if node != nil && len(node.Output) > 0 {
 		outStr := strings.Join(node.Output, ", ")
 		if outStr != "" && outStr != "STDOUT" && outStr != "[]" {
-			outputLine := fmt.Sprintf(" Output: %s", outStr)
-			if len(outputLine) > maxContent {
-				outputLine = outputLine[:maxContent-3] + "..."
-			}
-			fmt.Printf("%s %-*s %s\n", boxVert, width-4, outputLine, boxVert)
+			lines = append(lines, fmt.Sprintf("Output: %s", outStr))
 		}
 	}
 
-	fmt.Println(boxBottomLeft + strings.Repeat(boxHoriz, width-2) + boxBottomRight)
+	// Render with lipgloss
+	fmt.Println(tui.RenderMultiLineBox(lines, width, false))
 }
 
 // printStatsBox prints the statistics in a box
@@ -616,34 +575,34 @@ func printStatsBox(chart *WorkflowChart, width int) {
 		}
 	}
 
-	fmt.Println(boxDoubleTopLeft + strings.Repeat(boxDoubleHoriz, width-2) + boxDoubleTopRight)
-	fmt.Printf("%s %-*s %s\n", boxDoubleVert, width-4, "STATISTICS", boxDoubleVert)
-	fmt.Println(boxVertRight + strings.Repeat(boxHoriz, width-2) + boxVertLeft)
+	// Build content lines
+	var lines []string
+	lines = append(lines, "STATISTICS")
+
 	if loopCount > 0 {
-		fmt.Printf("%s %-*s %s\n", boxVert, width-4, fmt.Sprintf(" %s Loops: %d agentic", loopIcon, loopCount), boxVert)
+		lines = append(lines, fmt.Sprintf("%s Loops: %d agentic", loopIcon, loopCount))
 	} else {
-		fmt.Printf("%s %-*s %s\n", boxVert, width-4, fmt.Sprintf(" Steps: %d total, %d parallel", totalSteps, parallelSteps), boxVert)
+		lines = append(lines, fmt.Sprintf("Steps: %d total, %d parallel", totalSteps, parallelSteps))
 	}
 	if len(chart.DeferredSteps) > 0 {
-		fmt.Printf("%s %-*s %s\n", boxVert, width-4, fmt.Sprintf(" Deferred: %d conditional", len(chart.DeferredSteps)), boxVert)
+		lines = append(lines, fmt.Sprintf("Deferred: %d conditional", len(chart.DeferredSteps)))
 	}
 	if loopCount == 0 {
-		fmt.Printf("%s %-*s %s\n", boxVert, width-4, fmt.Sprintf(" Valid: %d/%d", validSteps, totalSteps), boxVert)
+		lines = append(lines, fmt.Sprintf("Valid: %d/%d", validSteps, totalSteps))
 	}
 
 	if len(modelCounts) > 0 {
-		fmt.Println(boxVertRight + strings.Repeat(boxHoriz, width-2) + boxVertLeft)
 		var models []string
 		for model := range modelCounts {
 			models = append(models, model)
 		}
 		sort.Strings(models)
 		for _, model := range models {
-			modelLine := fmt.Sprintf(" %s (%d)", model, modelCounts[model])
-			fmt.Printf("%s %-*s %s\n", boxVert, width-4, modelLine, boxVert)
+			lines = append(lines, fmt.Sprintf("%s (%d)", model, modelCounts[model]))
 		}
 	}
-	fmt.Println(boxDoubleBottomLeft + strings.Repeat(boxDoubleHoriz, width-2) + boxDoubleBottomRight)
+
+	fmt.Println(tui.RenderMultiLineBox(lines, width, true))
 }
 
 // getEntryPointText returns a short description of entry points
@@ -809,71 +768,56 @@ func renderNodeInline(node ChartNode, width int) {
 	}
 	summary := summarizeAction(node.Action, node.StepType)
 
-	maxContent := width - 6
+	// Build content lines
+	var lines []string
+	lines = append(lines, fmt.Sprintf("%s %s", status, node.Name))
 
-	// Name line
-	line1 := fmt.Sprintf(" %s %s", status, node.Name)
-	if len(line1) > maxContent {
-		line1 = line1[:maxContent-3] + "..."
-	}
-
-	fmt.Println("  " + boxTopLeft + strings.Repeat(boxHoriz, width-4) + boxTopRight)
-	fmt.Printf("  %s %-*s %s\n", boxVert, width-6, line1, boxVert)
-
-	// Model line
 	if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
-		line2 := fmt.Sprintf(" Model: %s", node.Model)
-		if len(line2) > maxContent {
-			line2 = line2[:maxContent-3] + "..."
-		}
-		fmt.Printf("  %s %-*s %s\n", boxVert, width-6, line2, boxVert)
+		lines = append(lines, fmt.Sprintf("Model: %s", node.Model))
 	}
 
-	// Action line
 	if summary != "" {
-		line3 := fmt.Sprintf(" %s", summary)
-		if len(line3) > maxContent {
-			line3 = line3[:maxContent-3] + "..."
-		}
-		fmt.Printf("  %s %-*s %s\n", boxVert, width-6, line3, boxVert)
+		lines = append(lines, summary)
 	}
 
-	// Output line
 	if len(node.Output) > 0 {
 		outStr := strings.Join(node.Output, ", ")
 		if outStr != "" && outStr != "STDOUT" && outStr != "[]" {
-			outputLine := fmt.Sprintf(" Output: %s", outStr)
-			if len(outputLine) > maxContent {
-				outputLine = outputLine[:maxContent-3] + "..."
-			}
-			fmt.Printf("  %s %-*s %s\n", boxVert, width-6, outputLine, boxVert)
+			lines = append(lines, fmt.Sprintf("Output: %s", outStr))
 		}
 	}
 
-	fmt.Println("  " + boxBottomLeft + strings.Repeat(boxHoriz, width-4) + boxBottomRight)
+	// Render with indent
+	box := tui.RenderMultiLineBox(lines, width-4, false)
+	for _, line := range strings.Split(box, "\n") {
+		fmt.Println("  " + line)
+	}
 }
 
 // renderParallelGroup draws a parallel execution group
 func renderParallelGroup(nodes []ChartNode, groupName string, stepNum int, boxWidth int) {
-	// Draw a box around the parallel group
-	fmt.Println(boxDoubleTopLeft + strings.Repeat(boxDoubleHoriz, boxWidth-2) + boxDoubleTopRight)
-	header := fmt.Sprintf(" %s PARALLEL: %s (%d steps)", parallelIcon, groupName, len(nodes))
-	if len(header) > boxWidth-4 {
-		header = header[:boxWidth-7] + "..."
-	}
-	fmt.Printf("%s %-*s %s\n", boxDoubleVert, boxWidth-4, header, boxDoubleVert)
-	fmt.Println(boxVertRight + strings.Repeat(boxHoriz, boxWidth-2) + boxVertLeft)
+	// Build header
+	header := fmt.Sprintf("%s PARALLEL: %s (%d steps)", parallelIcon, groupName, len(nodes))
 
-	// Render each parallel node as a smaller box inside
+	// Build content with inline nodes
+	var contentLines []string
 	for i, node := range nodes {
-		renderNodeInline(node, boxWidth)
+		status := "✓"
+		if !node.IsValid {
+			status = "✗"
+		}
+		contentLines = append(contentLines, fmt.Sprintf("  %s %s", status, node.Name))
+		if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+			contentLines = append(contentLines, fmt.Sprintf("    Model: %s", node.Model))
+		}
 		if i < len(nodes)-1 {
-			// Separator between parallel nodes
-			fmt.Println("  " + strings.Repeat("┄", boxWidth-6))
+			contentLines = append(contentLines, "  ┄┄┄")
 		}
 	}
 
-	fmt.Println(boxDoubleBottomLeft + strings.Repeat(boxDoubleHoriz, boxWidth-2) + boxDoubleBottomRight)
+	// Combine header and content
+	allLines := append([]string{header}, contentLines...)
+	fmt.Println(tui.RenderMultiLineBox(allLines, boxWidth, true))
 }
 
 // processAgenticLoopBlocks handles standalone agentic-loop blocks (config.AgenticLoops)
@@ -898,13 +842,11 @@ func renderAgenticLoopBox(config *processor.AgenticLoopConfig, boxWidth int) {
 		displayName = config.Name
 	}
 
+	// Build content lines
+	var lines []string
+
 	// Header
-	fmt.Println(boxDoubleTopLeft + strings.Repeat(boxDoubleHoriz, boxWidth-2) + boxDoubleTopRight)
-	header := fmt.Sprintf(" %s %s", loopIcon, displayName)
-	if len(header) > boxWidth-4 {
-		header = header[:boxWidth-7] + "..."
-	}
-	fmt.Printf("%s %-*s %s\n", boxDoubleVert, boxWidth-4, header, boxDoubleVert)
+	lines = append(lines, fmt.Sprintf("%s %s", loopIcon, displayName))
 
 	// Config line
 	exitInfo := config.ExitCondition
@@ -915,53 +857,47 @@ func renderAgenticLoopBox(config *processor.AgenticLoopConfig, boxWidth int) {
 	if maxIter == 0 {
 		maxIter = 10
 	}
-	configLine := fmt.Sprintf(" Iterations: %d │ Exit: %s", maxIter, exitInfo)
+	configLine := fmt.Sprintf("Iterations: %d │ Exit: %s", maxIter, exitInfo)
 	if config.TimeoutSeconds > 0 {
 		configLine += fmt.Sprintf(" │ Timeout: %ds", config.TimeoutSeconds)
 	}
 	if config.Stateful {
 		configLine += " │ Stateful"
 	}
-	if len(configLine) > boxWidth-4 {
-		configLine = configLine[:boxWidth-7] + "..."
-	}
-	fmt.Printf("%s %-*s %s\n", boxVert, boxWidth-4, configLine, boxVert)
+	lines = append(lines, configLine)
 
 	if config.ContextWindow > 0 {
-		ctxLine := fmt.Sprintf(" Context Window: %d iterations", config.ContextWindow)
-		fmt.Printf("%s %-*s %s\n", boxVert, boxWidth-4, ctxLine, boxVert)
+		lines = append(lines, fmt.Sprintf("Context Window: %d iterations", config.ContextWindow))
 	}
 
 	// Show allowed paths if any
 	if len(config.AllowedPaths) > 0 {
 		pathsPreview := strings.Join(config.AllowedPaths, ", ")
-		if len(pathsPreview) > boxWidth-14 {
-			pathsPreview = pathsPreview[:boxWidth-17] + "..."
-		}
-		pathsLine := fmt.Sprintf(" Paths: %s", pathsPreview)
-		fmt.Printf("%s %-*s %s\n", boxVert, boxWidth-4, pathsLine, boxVert)
+		lines = append(lines, fmt.Sprintf("Paths: %s", pathsPreview))
 	}
 
-	fmt.Println(boxVertRight + strings.Repeat(boxHoriz, boxWidth-2) + boxVertLeft)
-
-	// Render each step
+	// Add steps
+	lines = append(lines, "─────────────────────────")
 	for i, step := range config.Steps {
 		node := stepToChartNode(step, false, "")
-		renderNodeInline(node, boxWidth)
+		status := "✓"
+		if !node.IsValid {
+			status = "✗"
+		}
+		lines = append(lines, fmt.Sprintf("  %s %s", status, node.Name))
+		if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+			lines = append(lines, fmt.Sprintf("    Model: %s", node.Model))
+		}
 		if i < len(config.Steps)-1 {
-			fmt.Println("  " + strings.Repeat(" ", (boxWidth-6)/2) + boxVert)
-			fmt.Println("  " + strings.Repeat(" ", (boxWidth-6)/2) + arrowDown)
+			lines = append(lines, "    ↓")
 		}
 	}
 
 	// Loop-back indicator
-	fmt.Println(boxVert + strings.Repeat(" ", boxWidth-2) + boxVert)
-	loopBack := fmt.Sprintf(" ↺ loop back (max %d iterations)", maxIter)
-	if len(loopBack) > boxWidth-4 {
-		loopBack = loopBack[:boxWidth-7] + "..."
-	}
-	fmt.Printf("%s %-*s %s\n", boxVert, boxWidth-4, loopBack, boxVert)
-	fmt.Println(boxDoubleBottomLeft + strings.Repeat(boxDoubleHoriz, boxWidth-2) + boxDoubleBottomRight)
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("↺ loop back (max %d iterations)", maxIter))
+
+	fmt.Println(tui.RenderMultiLineBox(lines, boxWidth, true))
 }
 
 // processMultiLoopWorkflow handles multi-loop orchestration syntax

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -294,7 +294,7 @@ func stepToChartNode(step processor.Step, isParallel bool, parallelID string) Ch
 		node.Output = []string{step.Config.Generate.Output}
 	} else if step.Config.Process != nil {
 		node.StepType = "process"
-		node.Model = "N/A"
+		node.Model = modelNA
 		node.Action = fmt.Sprintf("Process: %s", step.Config.Process.WorkflowFile)
 	} else if step.Config.Type == "openai-responses" {
 		node.StepType = "openai-responses"
@@ -486,6 +486,7 @@ const (
 	arrowDown    = "▼" // Used for flow connectors
 	loopIcon     = "*"
 	parallelIcon = "="
+	modelNA      = "N/A" // Placeholder for missing model
 )
 
 // printBox prints a double-line box with centered text
@@ -512,7 +513,7 @@ func printStepBox(name, model, summary string, isValid bool, width int, node *Ch
 	lines = append(lines, fmt.Sprintf("%s %s", status, name))
 
 	// Add model if present
-	if model != "" && model != "N/A" && model != "[]" {
+	if model != "" && model != modelNA && model != "[]" {
 		lines = append(lines, fmt.Sprintf("Model: %s", model))
 	}
 
@@ -563,13 +564,13 @@ func printStatsBox(chart *WorkflowChart, width int) {
 	// Count models
 	modelCounts := make(map[string]int)
 	for _, node := range chart.Nodes {
-		if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+		if node.Model != "" && node.Model != modelNA && node.Model != "[]" {
 			modelCounts[node.Model]++
 		}
 	}
 	for _, nodes := range chart.ParallelGroups {
 		for _, node := range nodes {
-			if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+			if node.Model != "" && node.Model != modelNA && node.Model != "[]" {
 				modelCounts[node.Model]++
 			}
 		}
@@ -772,7 +773,7 @@ func renderNodeInline(node ChartNode, width int) {
 	var lines []string
 	lines = append(lines, fmt.Sprintf("%s %s", status, node.Name))
 
-	if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+	if node.Model != "" && node.Model != modelNA && node.Model != "[]" {
 		lines = append(lines, fmt.Sprintf("Model: %s", node.Model))
 	}
 
@@ -807,7 +808,7 @@ func renderParallelGroup(nodes []ChartNode, groupName string, stepNum int, boxWi
 			status = "✗"
 		}
 		contentLines = append(contentLines, fmt.Sprintf("  %s %s", status, node.Name))
-		if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+		if node.Model != "" && node.Model != modelNA && node.Model != "[]" {
 			contentLines = append(contentLines, fmt.Sprintf("    Model: %s", node.Model))
 		}
 		if i < len(nodes)-1 {
@@ -885,7 +886,7 @@ func renderAgenticLoopBox(config *processor.AgenticLoopConfig, boxWidth int) {
 			status = "✗"
 		}
 		lines = append(lines, fmt.Sprintf("  %s %s", status, node.Name))
-		if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+		if node.Model != "" && node.Model != modelNA && node.Model != "[]" {
 			lines = append(lines, fmt.Sprintf("    Model: %s", node.Model))
 		}
 		if i < len(config.Steps)-1 {
@@ -1222,7 +1223,7 @@ func renderInteractiveChart(chart *WorkflowChart, filename string) error {
 		if node.IsValid {
 			stats.ValidSteps++
 		}
-		if node.Model != "" && node.Model != "N/A" {
+		if node.Model != "" && node.Model != modelNA {
 			stats.Models[node.Model]++
 		}
 	}
@@ -1231,7 +1232,7 @@ func renderInteractiveChart(chart *WorkflowChart, filename string) error {
 			if node.IsValid {
 				stats.ValidSteps++
 			}
-			if node.Model != "" && node.Model != "N/A" {
+			if node.Model != "" && node.Model != modelNA {
 				stats.Models[node.Model]++
 			}
 		}
@@ -1272,7 +1273,7 @@ func renderMermaidChart(chart *WorkflowChart, filename string) {
 	// Node label with details
 	nodeLabel := func(node ChartNode) string {
 		label := node.Name
-		if node.Model != "" && node.Model != "N/A" && node.Model != "[]" {
+		if node.Model != "" && node.Model != modelNA && node.Model != "[]" {
 			label += "<br/><i>" + node.Model + "</i>"
 		}
 		summary := summarizeAction(node.Action, node.StepType)

--- a/utils/processor/stream_log.go
+++ b/utils/processor/stream_log.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/kris-hansen/comanda/utils/tui"
 )
 
 // StreamLogger handles real-time logging to a file for monitoring long-running operations
@@ -64,9 +66,10 @@ func (s *StreamLogger) LogSection(title string) {
 	if !s.enabled {
 		return
 	}
-	s.Log("═══════════════════════════════════════════════════════════════")
+	separator := tui.DoubleSeparator(64)
+	s.Log("%s", separator)
 	s.Log("  %s", title)
-	s.Log("═══════════════════════════════════════════════════════════════")
+	s.Log("%s", separator)
 }
 
 // LogIteration writes iteration start info

--- a/utils/processor/style.go
+++ b/utils/processor/style.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // ANSI color codes
@@ -241,20 +243,15 @@ func (s *Styler) Box(title string, width int) string {
 		return s.asciiBox(title, width)
 	}
 
-	titleWidth := displayWidth(title)
-	if width < titleWidth+4 {
-		width = titleWidth + 4
-	}
+	// Use lipgloss for reliable box rendering with auto-width
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 4).
+		Align(lipgloss.Center).
+		Bold(true)
 
-	padding := width - titleWidth - 2
-	leftPad := padding / 2
-	rightPad := padding - leftPad
-
-	top := boxTopLeft + strings.Repeat(boxHorizontal, width) + boxTopRight
-	middle := boxVertical + strings.Repeat(" ", leftPad) + s.Bold(title) + strings.Repeat(" ", rightPad) + boxVertical
-	bottom := boxBottomLeft + strings.Repeat(boxHorizontal, width) + boxBottomRight
-
-	return top + "\n" + middle + "\n" + bottom
+	return style.Render(title)
 }
 
 func (s *Styler) asciiBox(title string, width int) string {

--- a/utils/processor/style_test.go
+++ b/utils/processor/style_test.go
@@ -151,16 +151,13 @@ func TestBoxWithEmoji(t *testing.T) {
 			t.Errorf("Bottom line has incorrect corners: %q", lines[2])
 		}
 
-		// Top and bottom should have same length (they use same width)
-		if len(lines[0]) != len(lines[2]) {
-			t.Errorf("Top and bottom have different byte lengths: %d vs %d", len(lines[0]), len(lines[2]))
-		}
-
-		// Middle display width + 2 (for corners vs vertical bars) should equal top display width
+		// All lines should have the same display width (lipgloss ensures proper alignment)
 		topWidth := displayWidth(lines[0])
 		middleWidth := displayWidth(lines[1])
-		if middleWidth+2 != topWidth {
-			t.Errorf("Box alignment issue: middle width (%d) + 2 should equal top width (%d)", middleWidth, topWidth)
+		bottomWidth := displayWidth(lines[2])
+		if topWidth != middleWidth || middleWidth != bottomWidth {
+			t.Errorf("Box alignment issue: all lines should have equal width (top=%d, middle=%d, bottom=%d)",
+				topWidth, middleWidth, bottomWidth)
 		}
 	})
 

--- a/utils/tui/boxes.go
+++ b/utils/tui/boxes.go
@@ -1,0 +1,84 @@
+// Package tui provides terminal UI components using lipgloss
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Box styles for consistent rendering across the codebase
+var (
+	// RoundedBox uses rounded corners (╭╮╰╯)
+	RoundedBox = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("240"))
+
+	// NormalBox uses standard corners (┌┐└┘)
+	NormalBox = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(lipgloss.Color("240"))
+
+	// DoubleBox uses double-line borders (╔╗╚╝)
+	DoubleBox = lipgloss.NewStyle().
+			Border(lipgloss.DoubleBorder()).
+			BorderForeground(lipgloss.Color("240"))
+
+	// HeaderBox is a bold double-line box for headers
+	HeaderBox = lipgloss.NewStyle().
+			Border(lipgloss.DoubleBorder()).
+			BorderForeground(lipgloss.Color("99")).
+			Bold(true)
+
+	// Separator creates a horizontal line
+	SeparatorStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240"))
+)
+
+// RenderBox renders text in a rounded box with auto-width
+func RenderBox(text string, width int) string {
+	// Use padding for visual balance, let lipgloss calculate width
+	return RoundedBox.Padding(0, 4).Align(lipgloss.Center).Render(text)
+}
+
+// RenderDoubleBox renders text in a double-line box with auto-width
+func RenderDoubleBox(text string, width int) string {
+	return DoubleBox.Padding(0, 4).Align(lipgloss.Center).Render(text)
+}
+
+// RenderHeaderBox renders text in a header-style box with auto-width
+func RenderHeaderBox(text string, width int) string {
+	return HeaderBox.Padding(0, 4).Align(lipgloss.Center).Render(text)
+}
+
+// RenderMultiLineBox renders multiple lines in a box with auto-width
+func RenderMultiLineBox(lines []string, width int, useDouble bool) string {
+	content := strings.Join(lines, "\n")
+	style := NormalBox
+	if useDouble {
+		style = DoubleBox
+	}
+	return style.Padding(0, 2).Render(content)
+}
+
+// Separator returns a horizontal separator line of specified width
+func Separator(width int) string {
+	return SeparatorStyle.Render(strings.Repeat("─", width))
+}
+
+// DoubleSeparator returns a double-line separator
+func DoubleSeparator(width int) string {
+	return SeparatorStyle.Render(strings.Repeat("═", width))
+}
+
+// VerticalConnector returns a vertical connector (│) centered in width
+func VerticalConnector(width int) string {
+	padding := (width - 1) / 2
+	return strings.Repeat(" ", padding) + "│"
+}
+
+// ArrowDown returns a down arrow (▼) centered in width
+func ArrowDown(width int) string {
+	padding := (width - 1) / 2
+	return strings.Repeat(" ", padding) + "▼"
+}

--- a/utils/tui/output.go
+++ b/utils/tui/output.go
@@ -39,8 +39,7 @@ func (o *Output) Header(title string) string {
 		Foreground(o.theme.Primary).
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(o.theme.Primary).
-		Padding(0, 2).
-		Width(o.width - 2).
+		Padding(0, 4).
 		Align(lipgloss.Center)
 
 	return style.Render(title)


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Replaced manual box drawing with lipgloss to fix border alignment issues.
- Utilized lipgloss's auto-width calculation to ensure borders are always properly aligned.
- Simplified the box rendering logic by removing manual padding and border calculations.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/style.go`: - Imported the lipgloss package to handle box rendering.
- Removed manual calculations for padding and border drawing.
- Introduced a new style using lipgloss with rounded borders, border color, padding, alignment, and bold text.
- Replaced the manual box rendering logic with lipgloss's Render method to ensure consistent and aligned borders.
</details>

___
## User Description:
## Problem

The manual box drawing had a width mismatch causing broken/misaligned right borders:
- Top/bottom lines: `width + 2` chars (horizontal line + 2 corners)
- Middle line: `width` chars (padding calculated as `width - titleWidth - 2`)

This 2-character mismatch caused the right border to appear disconnected.

## Solution

Replace manual box drawing with lipgloss using `Padding(0, 4)` for auto-width calculation. This ensures borders are always properly aligned regardless of content length.

## Before
```
╭────────────────────────────────────────────────╮
│            Multi-Loop Orchestration            │
╰────────────────────────────────────────────────╯
                                                  ^ misaligned
```

## After  
```
╭────────────────────────────────╮
│    Multi-Loop Orchestration    │
╰────────────────────────────────╯
```

Clean, unbroken borders every time.
