### PR TITLE
fix: resolve demo-discovered bugs

### DIFF
--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -494,10 +494,23 @@ func (p *Processor) processInlineAgenticLoop(step Step) (string, error) {
 	} else {
 		// Inherit model from parent step if sub-steps don't specify their own
 		parentModel := step.Config.Model
+
+		// Validate: if parent has no model, check if any sub-steps need one
+		if parentModel == nil {
+			for _, subStep := range config.Steps {
+				if subStep.Config.Model == nil && subStep.Config.Generate != nil {
+					return "", fmt.Errorf("agentic loop '%s': sub-step '%s' requires a model but none specified (and parent has no model to inherit)",
+						step.Name, subStep.Name)
+				}
+			}
+		}
+
 		for i := range config.Steps {
 			if config.Steps[i].Config.Model == nil {
 				config.Steps[i].Config.Model = parentModel
-				p.debugf("Step '%s' inherited model from parent: %v", config.Steps[i].Name, parentModel)
+				if parentModel != nil {
+					p.debugf("Step '%s' inherited model from parent: %v", config.Steps[i].Name, parentModel)
+				}
 			}
 		}
 	}

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -198,10 +199,17 @@ func (c *DSLConfig) UnmarshalYAML(node *yaml.Node) error {
 					return fmt.Errorf("failed to decode parallel step group '%s': %w", stepName, err)
 				}
 
-				// Convert map[string]StepConfig to []Step
+				// Convert map[string]StepConfig to []Step with deterministic ordering
+				// Sort keys to ensure consistent behavior across runs
+				keys := make([]string, 0, len(parallelSteps))
+				for k := range parallelSteps {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+
 				var steps []Step
-				for subStepName, subStepConfig := range parallelSteps {
-					steps = append(steps, Step{Name: subStepName, Config: subStepConfig})
+				for _, subStepName := range keys {
+					steps = append(steps, Step{Name: subStepName, Config: parallelSteps[subStepName]})
 				}
 				c.ParallelSteps[stepName] = steps
 			} else {
@@ -632,13 +640,28 @@ func (p *Processor) expandIndexReferences(text string) string {
 }
 
 // SubstituteCLIVariables replaces {{varname}} with CLI-provided values
+// Uses regex single-pass replacement to prevent cross-variable injection
+// (i.e., if a variable's value contains {{...}}, it won't be re-substituted)
 func (p *Processor) SubstituteCLIVariables(text string) string {
-	for name, value := range p.cliVariables {
-		// Support both {{varname}} and {{ varname }} syntax
-		text = strings.ReplaceAll(text, "{{"+name+"}}", value)
-		text = strings.ReplaceAll(text, "{{ "+name+" }}", value)
+	if len(p.cliVariables) == 0 {
+		return text
 	}
-	return text
+
+	// Match {{ varname }} or {{varname}} patterns
+	pattern := regexp.MustCompile(`\{\{\s*([^}]+?)\s*\}\}`)
+
+	return pattern.ReplaceAllStringFunc(text, func(match string) string {
+		// Extract variable name (strip braces and whitespace)
+		inner := strings.TrimPrefix(match, "{{")
+		inner = strings.TrimSuffix(inner, "}}")
+		varName := strings.TrimSpace(inner)
+
+		if value, ok := p.cliVariables[varName]; ok {
+			return value
+		}
+		// Leave unrecognized patterns unchanged
+		return match
+	})
 }
 
 // substituteCLIVariablesInSlice applies CLI variable substitution to all elements in a slice


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses three bugs identified during demo preparation:
- Ensures deterministic ordering of parallel steps by sorting them by name.
- Prevents cross-variable injection in CLI variable substitution by using a regex single-pass replacement.
- Adds validation to check for missing models in inline agentic loops and provides a clear error message if needed.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/agentic_loop.go`: Added validation to check if a parent model is missing when sub-steps require a model in inline agentic loops. If a model is required but not provided, an error message is returned. Also, debug logging is adjusted to only log model inheritance if a model is actually inherited.
- `utils/processor/dsl.go`: Implemented sorting of map keys to ensure deterministic ordering of parallel steps. This change ensures consistent behavior across runs by converting `map[string]StepConfig` to `[]Step` in a sorted manner. Additionally, updated the `SubstituteCLIVariables` function to use regex for single-pass replacement, preventing cross-variable injection by ensuring that variable values containing other variable patterns are not re-substituted.
</details>

___
## User Description:
Fixes three bugs discovered during demo preparation:

## Bug 1: Non-Deterministic Parallel Step Ordering (Medium)
**File:** `utils/processor/dsl.go`

When converting `map[string]StepConfig` to `[]Step` for parallel execution, the code iterated over a Go map with random order. Now sorted by step name for consistent behavior.

## Bug 2: CLI Variable Substitution Could Cause Cross-Injection (Low-Medium)
**File:** `utils/processor/dsl.go`

`SubstituteCLIVariables` did multiple `strings.ReplaceAll` passes. If a variable's value contained `{{another_var}}`, and that other variable was substituted later, you'd get unintended injection. Now uses regex single-pass replacement.

## Bug 3: Missing Nil Model Validation in Inline Agentic Loops (Medium)
**File:** `utils/processor/agentic_loop.go`

When inheriting `parentModel` for inline agentic loop sub-steps, if the parent had no model, `nil` was silently propagated. Now validates early and returns a clear error message.

---

See `~/clawd/comanda-demo-friday/BUGS-FOUND.md` for original documentation.
