### PR TITLE
feat(live): add token estimation for context window display

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -310,6 +310,12 @@ func runLiveProcess(args []string) {
 
 	// Create log watcher
 	watcher := tui.NewLogWatcher(tmpLogPath, reporter)
+
+	// Try to extract model from workflow for better token estimation
+	if model := extractModelFromWorkflow(workflowFile); model != "" {
+		watcher.SetModel(model)
+	}
+
 	watcher.Start()
 	defer watcher.Stop()
 
@@ -364,4 +370,39 @@ func runWorkflowWithStreamLog(workflowFile, streamLogPath string) error {
 
 	// Run processor
 	return proc.Process()
+}
+
+// extractModelFromWorkflow tries to find the model from the workflow YAML
+func extractModelFromWorkflow(workflowFile string) string {
+	yamlFile, err := os.ReadFile(workflowFile)
+	if err != nil {
+		return ""
+	}
+
+	var dslConfig processor.DSLConfig
+	if err := yaml.Unmarshal(yamlFile, &dslConfig); err != nil {
+		return ""
+	}
+
+	// Check each step for a model
+	for _, step := range dslConfig.Steps {
+		if step.Config.Model != nil {
+			// Model can be string or []string
+			switch m := step.Config.Model.(type) {
+			case string:
+				if m != "" {
+					return m
+				}
+			case []interface{}:
+				if len(m) > 0 {
+					if s, ok := m[0].(string); ok && s != "" {
+						return s
+					}
+				}
+			}
+		}
+
+	}
+
+	return ""
 }

--- a/utils/tui/dashboard.go
+++ b/utils/tui/dashboard.go
@@ -364,20 +364,28 @@ func (m *DashboardModel) renderResources() string {
 
 	leftBox := lipgloss.NewStyle().Width(leftWidth).Render(left.String())
 
-	// Right column: Context window
+	// Right column: Context window (estimated)
 	var right strings.Builder
 	right.WriteString(labelStyle.Render("CONTEXT WINDOW"))
+
+	// Show (est.) indicator since we're estimating tokens
+	estStyle := lipgloss.NewStyle().Foreground(m.theme.Muted).Italic(true)
+	right.WriteString(estStyle.Render(" (est.)"))
 	right.WriteString("\n")
 
 	ctxBar := m.theme.ProgressBar(m.contextPct/100, 16)
-	right.WriteString(fmt.Sprintf("%s %.0f%%\n", ctxBar, m.contextPct))
+	right.WriteString(fmt.Sprintf("%s %.1f%%\n", ctxBar, m.contextPct))
 
 	if m.tokensAvail > 0 {
 		valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB"))
-		right.WriteString(valueStyle.Render(fmt.Sprintf("%dk / %dk tokens",
+		right.WriteString(valueStyle.Render(fmt.Sprintf("~%dk / %dk tokens",
 			m.tokensUsed/1000,
 			m.tokensAvail/1000,
 		)))
+	} else {
+		// Show placeholder when no context info yet
+		mutedStyle := lipgloss.NewStyle().Foreground(m.theme.Muted).Italic(true)
+		right.WriteString(mutedStyle.Render("awaiting model info..."))
 	}
 
 	rightBox := lipgloss.NewStyle().Width(rightWidth).Render(right.String())

--- a/utils/tui/logwatcher.go
+++ b/utils/tui/logwatcher.go
@@ -11,10 +11,12 @@ import (
 
 // LogWatcher monitors a stream log file and emits progress events
 type LogWatcher struct {
-	path     string
-	reporter *ProgressReporter
-	stop     chan struct{}
-	done     chan struct{}
+	path           string
+	reporter       *ProgressReporter
+	tokenEstimator *TokenEstimator
+	stop           chan struct{}
+	done           chan struct{}
+	totalChars     int // Track total characters for token estimation
 }
 
 // Patterns for parsing stream log
@@ -24,15 +26,27 @@ var (
 	toolPattern      = regexp.MustCompile(`→ (Read|Write|Edit|Bash|execute|calling tool:) (.+)`)
 	stepPattern      = regexp.MustCompile(`(Starting|Processing|Completed|Executing) (step|loop): (.+)`)
 	errorPattern     = regexp.MustCompile(`(?i)(error|failed|exception): (.+)`)
+	modelPattern     = regexp.MustCompile(`(?i)(model|using):\s*(claude-code|claude-[^\s,]+|gpt-[^\s,]+|gemini-[^\s,]+|o[134]-[^\s,]+)`)
 )
 
 // NewLogWatcher creates a new log watcher
 func NewLogWatcher(path string, reporter *ProgressReporter) *LogWatcher {
+	// Create token estimator with default model (will update when model is detected)
+	estimator := NewTokenEstimator("claude-code", reporter)
+
 	return &LogWatcher{
-		path:     path,
-		reporter: reporter,
-		stop:     make(chan struct{}),
-		done:     make(chan struct{}),
+		path:           path,
+		reporter:       reporter,
+		tokenEstimator: estimator,
+		stop:           make(chan struct{}),
+		done:           make(chan struct{}),
+	}
+}
+
+// SetModel updates the model for token estimation
+func (w *LogWatcher) SetModel(model string) {
+	if w.tokenEstimator != nil {
+		w.tokenEstimator.SetModel(model)
 	}
 }
 
@@ -97,15 +111,27 @@ func (w *LogWatcher) parseLine(line string) {
 		return
 	}
 
+	// Track all output for token estimation (silently - don't emit event yet)
+	w.totalChars += len(line)
+
 	// Remove timestamp prefix [HH:MM:SS]
+	cleanLine := line
 	if len(line) > 10 && line[0] == '[' {
 		if idx := strings.Index(line, "]"); idx > 0 && idx < 15 {
-			line = strings.TrimSpace(line[idx+1:])
+			cleanLine = strings.TrimSpace(line[idx+1:])
+		}
+	}
+
+	// Check for model mentions to update context window (no event emitted)
+	if matches := modelPattern.FindStringSubmatch(cleanLine); matches != nil {
+		model := matches[2]
+		if w.tokenEstimator != nil {
+			w.tokenEstimator.SetModel(model)
 		}
 	}
 
 	// Check for iteration
-	if matches := iterationPattern.FindStringSubmatch(line); matches != nil {
+	if matches := iterationPattern.FindStringSubmatch(cleanLine); matches != nil {
 		current, _ := strconv.Atoi(matches[1])
 		total, _ := strconv.Atoi(matches[2])
 		loopName := matches[3]
@@ -113,8 +139,9 @@ func (w *LogWatcher) parseLine(line string) {
 		return
 	}
 
-	// Check for context usage
-	if matches := contextPattern.FindStringSubmatch(line); matches != nil {
+	// Check for context usage (if the underlying tool outputs it)
+	// This takes precedence over our estimation
+	if matches := contextPattern.FindStringSubmatch(cleanLine); matches != nil {
 		used, _ := strconv.Atoi(matches[2])
 		avail, _ := strconv.Atoi(matches[3])
 		w.reporter.TokenUpdate(used*1000, avail*1000)
@@ -122,7 +149,7 @@ func (w *LogWatcher) parseLine(line string) {
 	}
 
 	// Check for tool calls
-	if matches := toolPattern.FindStringSubmatch(line); matches != nil {
+	if matches := toolPattern.FindStringSubmatch(cleanLine); matches != nil {
 		toolName := matches[1]
 		details := matches[2]
 		w.reporter.ToolCall(toolName + ": " + details)
@@ -130,7 +157,7 @@ func (w *LogWatcher) parseLine(line string) {
 	}
 
 	// Check for step info
-	if matches := stepPattern.FindStringSubmatch(line); matches != nil {
+	if matches := stepPattern.FindStringSubmatch(cleanLine); matches != nil {
 		action := matches[1]
 		stepName := matches[3]
 		if action == "Starting" || action == "Executing" {
@@ -142,7 +169,7 @@ func (w *LogWatcher) parseLine(line string) {
 	}
 
 	// Check for errors
-	if matches := errorPattern.FindStringSubmatch(line); matches != nil {
+	if matches := errorPattern.FindStringSubmatch(cleanLine); matches != nil {
 		w.reporter.Emit(ProgressEvent{
 			Type:    "error",
 			Message: matches[2],
@@ -151,10 +178,19 @@ func (w *LogWatcher) parseLine(line string) {
 	}
 
 	// Generic output for other lines (if they seem meaningful)
-	if len(line) > 5 && !strings.HasPrefix(line, "─") && !strings.HasPrefix(line, "═") {
+	if len(cleanLine) > 5 && !strings.HasPrefix(cleanLine, "─") && !strings.HasPrefix(cleanLine, "═") {
 		// Skip decorative lines
-		if !strings.HasPrefix(line, "  ") {
-			w.reporter.Output(line)
+		if !strings.HasPrefix(cleanLine, "  ") {
+			w.reporter.Output(cleanLine)
+		}
+	}
+
+	// Track chars for token estimation (silent - added to running total)
+	if w.tokenEstimator != nil {
+		w.tokenEstimator.AddOutput(line)
+		// Emit token update every ~2000 chars to keep UI updated without flooding
+		if w.totalChars%2000 < len(line) {
+			w.tokenEstimator.EmitUpdate()
 		}
 	}
 }

--- a/utils/tui/tokenestimator.go
+++ b/utils/tui/tokenestimator.go
@@ -1,0 +1,154 @@
+package tui
+
+import (
+	"sync"
+)
+
+// ModelContextWindow holds context window sizes for different models
+var ModelContextWindow = map[string]int{
+	// Claude models
+	"claude-code":                200000,
+	"claude-sonnet-4-20250514":   200000,
+	"claude-opus-4-20250514":     200000,
+	"claude-3-5-sonnet-20241022": 200000,
+	"claude-3-5-haiku-20241022":  200000,
+	"claude-3-opus-20240229":     200000,
+	"claude-3-sonnet-20240229":   200000,
+	"claude-3-haiku-20240307":    200000,
+
+	// OpenAI models
+	"gpt-4":        128000,
+	"gpt-4-turbo":  128000,
+	"gpt-4o":       128000,
+	"gpt-4o-mini":  128000,
+	"gpt-4.1":      1000000,
+	"gpt-4.1-mini": 1000000,
+	"gpt-4.1-nano": 1000000,
+	"o1":           200000,
+	"o1-mini":      128000,
+	"o1-preview":   128000,
+	"o3":           200000,
+	"o3-mini":      200000,
+	"o4-mini":      200000,
+
+	// Google models
+	"gemini-2.0-flash":      1000000,
+	"gemini-2.0-flash-lite": 1000000,
+	"gemini-2.5-pro":        1000000,
+	"gemini-2.5-flash":      1000000,
+	"gemini-1.5-pro":        2000000,
+	"gemini-1.5-flash":      1000000,
+
+	// Defaults
+	"default": 128000,
+}
+
+// TokenEstimator tracks estimated token usage during workflow execution
+type TokenEstimator struct {
+	mu           sync.Mutex
+	inputChars   int
+	outputChars  int
+	model        string
+	contextLimit int
+	reporter     *ProgressReporter
+}
+
+// NewTokenEstimator creates a token estimator for a given model
+func NewTokenEstimator(model string, reporter *ProgressReporter) *TokenEstimator {
+	contextLimit := ModelContextWindow["default"]
+
+	// Try to find exact match
+	if limit, ok := ModelContextWindow[model]; ok {
+		contextLimit = limit
+	} else {
+		// Try prefix matching for versioned models
+		for prefix, limit := range ModelContextWindow {
+			if len(model) > len(prefix) && model[:len(prefix)] == prefix {
+				contextLimit = limit
+				break
+			}
+		}
+	}
+
+	return &TokenEstimator{
+		model:        model,
+		contextLimit: contextLimit,
+		reporter:     reporter,
+	}
+}
+
+// AddInput records input characters
+// Does not emit events - call EmitUpdate() explicitly when ready
+func (t *TokenEstimator) AddInput(text string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.inputChars += len(text)
+}
+
+// AddOutput records output characters (can be called incrementally for streaming)
+// Does not emit events - call EmitUpdate() explicitly when ready
+func (t *TokenEstimator) AddOutput(text string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.outputChars += len(text)
+}
+
+// Reset clears the token counts (e.g., between steps)
+func (t *TokenEstimator) Reset() {
+	t.mu.Lock()
+	t.inputChars = 0
+	t.outputChars = 0
+	t.mu.Unlock()
+
+	t.EmitUpdate()
+}
+
+// SetModel updates the model and context limit
+func (t *TokenEstimator) SetModel(model string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.model = model
+	if limit, ok := ModelContextWindow[model]; ok {
+		t.contextLimit = limit
+	}
+}
+
+// GetEstimates returns estimated token counts
+// Uses ~4 characters per token as rough estimate for English text
+func (t *TokenEstimator) GetEstimates() (inputTokens, outputTokens, contextLimit int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Rough estimate: 4 chars per token for English, 2-3 for code
+	// Using 3.5 as middle ground
+	inputTokens = t.inputChars * 10 / 35
+	outputTokens = t.outputChars * 10 / 35
+	contextLimit = t.contextLimit
+
+	return inputTokens, outputTokens, contextLimit
+}
+
+// GetContextPercent returns the estimated context window usage percentage
+func (t *TokenEstimator) GetContextPercent() float64 {
+	inputTokens, outputTokens, contextLimit := t.GetEstimates()
+	if contextLimit == 0 {
+		return 0
+	}
+	totalUsed := inputTokens + outputTokens
+	return float64(totalUsed) / float64(contextLimit) * 100
+}
+
+// EmitUpdate sends the current token estimate to the reporter
+func (t *TokenEstimator) EmitUpdate() {
+	if t.reporter == nil {
+		return
+	}
+
+	inputTokens, outputTokens, contextLimit := t.GetEstimates()
+	totalUsed := inputTokens + outputTokens
+
+	t.reporter.TokenUpdate(totalUsed, contextLimit)
+}

--- a/utils/tui/tokenestimator_test.go
+++ b/utils/tui/tokenestimator_test.go
@@ -1,0 +1,167 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewTokenEstimator(t *testing.T) {
+	reporter := NewProgressReporter()
+	defer reporter.Close()
+
+	tests := []struct {
+		model         string
+		expectedLimit int
+	}{
+		{"claude-code", 200000},
+		{"gpt-4o", 128000},
+		{"gemini-2.0-flash", 1000000},
+		{"unknown-model", 128000}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			est := NewTokenEstimator(tt.model, reporter)
+			if est == nil {
+				t.Fatal("NewTokenEstimator returned nil")
+			}
+			_, _, limit := est.GetEstimates()
+			if limit != tt.expectedLimit {
+				t.Errorf("Expected context limit %d for %s, got %d", tt.expectedLimit, tt.model, limit)
+			}
+		})
+	}
+}
+
+func TestTokenEstimatorAddInput(t *testing.T) {
+	reporter := NewProgressReporter()
+	defer reporter.Close()
+
+	est := NewTokenEstimator("claude-code", reporter)
+
+	// Add some input text
+	est.AddInput("Hello, this is a test input.")
+	est.AddInput("More input text here.")
+
+	inputTokens, _, _ := est.GetEstimates()
+	if inputTokens == 0 {
+		t.Error("Expected non-zero input tokens after AddInput")
+	}
+}
+
+func TestTokenEstimatorAddOutput(t *testing.T) {
+	reporter := NewProgressReporter()
+	defer reporter.Close()
+
+	est := NewTokenEstimator("claude-code", reporter)
+
+	// Add some output text
+	est.AddOutput("This is the model response.")
+	est.AddOutput("More response content.")
+
+	_, outputTokens, _ := est.GetEstimates()
+	if outputTokens == 0 {
+		t.Error("Expected non-zero output tokens after AddOutput")
+	}
+}
+
+func TestTokenEstimatorReset(t *testing.T) {
+	reporter := NewProgressReporter()
+	defer reporter.Close()
+
+	est := NewTokenEstimator("claude-code", reporter)
+
+	est.AddInput("Some input")
+	est.AddOutput("Some output")
+	est.Reset()
+
+	inputTokens, outputTokens, _ := est.GetEstimates()
+	if inputTokens != 0 || outputTokens != 0 {
+		t.Errorf("Expected zero tokens after reset, got input=%d output=%d", inputTokens, outputTokens)
+	}
+}
+
+func TestTokenEstimatorSetModel(t *testing.T) {
+	reporter := NewProgressReporter()
+	defer reporter.Close()
+
+	est := NewTokenEstimator("claude-code", reporter)
+
+	// Change model
+	est.SetModel("gpt-4o")
+
+	_, _, limit := est.GetEstimates()
+	if limit != 128000 {
+		t.Errorf("Expected context limit 128000 after SetModel, got %d", limit)
+	}
+}
+
+func TestTokenEstimatorGetContextPercent(t *testing.T) {
+	reporter := NewProgressReporter()
+	defer reporter.Close()
+
+	est := NewTokenEstimator("claude-code", reporter) // 200k context
+
+	// Add enough text to reach ~1% (200k * 0.01 = 2000 tokens = ~7000 chars)
+	largeText := make([]byte, 7000)
+	for i := range largeText {
+		largeText[i] = 'a'
+	}
+	est.AddOutput(string(largeText))
+
+	pct := est.GetContextPercent()
+	if pct < 0.5 || pct > 2.0 {
+		t.Errorf("Expected context percent around 1%%, got %.2f%%", pct)
+	}
+}
+
+func TestTokenEstimatorEmitUpdate(t *testing.T) {
+	reporter := NewProgressReporter()
+	defer reporter.Close()
+
+	ch := reporter.Subscribe()
+	est := NewTokenEstimator("claude-code", reporter)
+
+	est.AddOutput("Some output text for testing")
+	est.EmitUpdate()
+
+	select {
+	case event := <-ch:
+		if event.Type != "tokens" {
+			t.Errorf("Expected 'tokens' event, got %q", event.Type)
+		}
+		if event.TokensAvail != 200000 {
+			t.Errorf("Expected TokensAvail 200000, got %d", event.TokensAvail)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Expected tokens event but none received")
+	}
+}
+
+func TestModelContextWindowValues(t *testing.T) {
+	// Verify key models have expected context windows
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"claude-code", 200000},
+		{"gpt-4", 128000},
+		{"gpt-4.1", 1000000},
+		{"gemini-2.5-pro", 1000000},
+		{"gemini-1.5-pro", 2000000},
+		{"o3-mini", 200000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got, ok := ModelContextWindow[tt.model]
+			if !ok {
+				t.Errorf("Model %s not found in ModelContextWindow", tt.model)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ModelContextWindow[%s] = %d, want %d", tt.model, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a new `TokenEstimator` module to track input/output characters and estimate token usage.
- Updates the live dashboard to display estimated token usage as a percentage of the model's context window.
- Integrates `LogWatcher` to extract model information from stream output and update token estimates.
- Adds functionality to parse workflow YAML to extract model information for better token estimation.
- Provides comprehensive tests for the `TokenEstimator` functionality.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/process.go`: Added functionality to extract the model from the workflow YAML file for better token estimation. Integrated this model information into the `LogWatcher`.
- `utils/tui/dashboard.go`: Updated the dashboard to show an estimated context window usage with an `(est.)` indicator and `~tokens` notation.
- `utils/tui/logwatcher.go`: Enhanced `LogWatcher` to track total characters for token estimation and to update the model for token estimation when detected in the log stream.
- `utils/tui/tokenestimator.go`: Introduced a new `TokenEstimator` class to estimate token usage based on character count. It supports setting models, calculating estimates, and emitting updates.
- `utils/tui/tokenestimator_test.go`: Added comprehensive tests for the `TokenEstimator`, covering model context window values, input/output character tracking, and context percentage calculations.
</details>

___
## User Description:
## Summary

Adds estimated token usage tracking to the `--live` dashboard, solving the issue where context window stats stayed at 0.

## Changes

- **TokenEstimator** - New module that tracks input/output characters and estimates tokens (~3.5 chars/token)
- **ModelContextWindow** - Map with known context limits for Claude (200k), GPT-4 (128k), GPT-4.1 (1M), Gemini (1-2M), etc.
- **LogWatcher integration** - Extracts model info from stream output and updates estimates
- **Dashboard updates** - Shows `(est.)` indicator and `~tokens` notation to indicate estimates

## How it works

1. When `--live` is used, the workflow YAML is parsed to extract the model
2. LogWatcher tracks all output characters and detects model mentions
3. TokenEstimator calculates estimated tokens based on character count
4. Updates are batched (every ~2000 chars) to avoid event flooding
5. Dashboard shows estimated usage as percentage of model's context window

## Example output

```
CONTEXT WINDOW (est.)
████████░░░░░░░░ 12.3%
~24k / 200k tokens
```

## Tests

Added comprehensive tests for TokenEstimator including context window lookup, token estimation, and event emission.
