### PR TITLE
feat(live): add debug panel for --debug/--verbose output

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -319,8 +320,26 @@ func runLiveProcess(args []string) {
 	watcher.Start()
 	defer watcher.Stop()
 
-	// Create and start the dashboard
-	_, program := tui.RunDashboard(workflowName, reporter)
+	// Set up debug output capture when debug/verbose mode is enabled
+	var debugWriter *tui.DebugWriter
+	var model *tui.DashboardModel
+	var program *tea.Program
+
+	if config.Debug || verbose {
+		// Create debug writer to capture log output
+		debugWriter = tui.NewDebugWriter(os.Stderr, 500)
+
+		// Redirect log output to our debug writer
+		log.SetOutput(debugWriter)
+		defer log.SetOutput(os.Stderr) // Restore on exit
+
+		// Create dashboard with debug panel
+		model, program = tui.RunDashboardWithDebug(workflowName, reporter, debugWriter)
+	} else {
+		// Standard dashboard without debug panel
+		model, program = tui.RunDashboard(workflowName, reporter)
+	}
+	_ = model // model available for future use
 
 	// Run the processor in a goroutine
 	processDone := make(chan error, 1)

--- a/utils/tui/dashboard.go
+++ b/utils/tui/dashboard.go
@@ -33,6 +33,7 @@ type DashboardModel struct {
 	memoryMB      float64
 	activities    []Activity
 	outputLines   []string
+	debugLines    []string
 	status        string // "running", "paused", "complete", "error"
 	errorMsg      string
 
@@ -46,13 +47,20 @@ type DashboardModel struct {
 	reporter    *ProgressReporter
 	quitting    bool
 	verbose     bool
+	debugMode   bool
+	debugScroll int
 	maxActivity int
 	maxOutput   int
+	maxDebug    int
+	debugWriter *DebugWriter
 }
 
 type dashboardKeyMap struct {
-	Quit    key.Binding
-	Verbose key.Binding
+	Quit        key.Binding
+	Verbose     key.Binding
+	ToggleDebug key.Binding
+	ScrollUp    key.Binding
+	ScrollDown  key.Binding
 }
 
 func defaultDashboardKeyMap() dashboardKeyMap {
@@ -64,6 +72,18 @@ func defaultDashboardKeyMap() dashboardKeyMap {
 		Verbose: key.NewBinding(
 			key.WithKeys("v"),
 			key.WithHelp("v", "verbose"),
+		),
+		ToggleDebug: key.NewBinding(
+			key.WithKeys("d"),
+			key.WithHelp("d", "debug panel"),
+		),
+		ScrollUp: key.NewBinding(
+			key.WithKeys("k", "up"),
+			key.WithHelp("↑/k", "scroll up"),
+		),
+		ScrollDown: key.NewBinding(
+			key.WithKeys("j", "down"),
+			key.WithHelp("↓/j", "scroll down"),
 		),
 	}
 }
@@ -95,7 +115,22 @@ func NewDashboardModel(workflowName string, reporter *ProgressReporter) *Dashboa
 		reporter:     reporter,
 		maxActivity:  8,
 		maxOutput:    5,
+		maxDebug:     20,
 	}
+}
+
+// SetDebugWriter attaches a debug writer to capture debug/verbose output.
+func (m *DashboardModel) SetDebugWriter(w *DebugWriter) {
+	m.debugWriter = w
+	m.debugMode = true
+	w.SetOnChange(func(lines []string) {
+		m.debugLines = lines
+	})
+}
+
+// DebugLinesMsg is sent when debug lines are updated
+type DebugLinesMsg struct {
+	Lines []string
 }
 
 // Init initializes the model
@@ -135,6 +170,16 @@ func (m *DashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case key.Matches(msg, m.keymap.Verbose):
 			m.verbose = !m.verbose
+		case key.Matches(msg, m.keymap.ToggleDebug):
+			m.debugMode = !m.debugMode
+		case key.Matches(msg, m.keymap.ScrollUp):
+			if m.debugMode && m.debugScroll > 0 {
+				m.debugScroll--
+			}
+		case key.Matches(msg, m.keymap.ScrollDown):
+			if m.debugMode && m.debugScroll < len(m.debugLines)-m.maxDebug {
+				m.debugScroll++
+			}
 		}
 
 	case tea.WindowSizeMsg:
@@ -258,6 +303,11 @@ func (m *DashboardModel) View() string {
 	// Output section
 	if len(m.outputLines) > 0 || m.verbose {
 		sections = append(sections, m.renderOutput())
+	}
+
+	// Debug panel (shown when debug mode is enabled)
+	if m.debugMode && len(m.debugLines) > 0 {
+		sections = append(sections, m.renderDebugPanel())
 	}
 
 	// Footer
@@ -478,6 +528,72 @@ func (m *DashboardModel) renderOutput() string {
 	return boxStyle.Render(content.String())
 }
 
+func (m *DashboardModel) renderDebugPanel() string {
+	// Calculate available height for debug panel
+	panelHeight := m.maxDebug
+	if m.height > 0 {
+		// Use remaining space, min 10 lines
+		usedHeight := 20 // approximate header + progress + resources + activity
+		if m.verbose || len(m.outputLines) > 0 {
+			usedHeight += m.maxOutput + 3
+		}
+		available := m.height - usedHeight - 5
+		if available > 10 {
+			panelHeight = available
+		} else {
+			panelHeight = 10
+		}
+	}
+
+	boxStyle := m.theme.BoxNormal.Width(m.width - 4)
+
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Secondary)
+	mutedStyle := lipgloss.NewStyle().Foreground(m.theme.Muted)
+	debugStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
+
+	var content strings.Builder
+	content.WriteString(labelStyle.Render("DEBUG LOG"))
+
+	// Show scroll position if scrollable
+	totalLines := len(m.debugLines)
+	if totalLines > panelHeight {
+		content.WriteString(mutedStyle.Render(fmt.Sprintf(" (%d-%d of %d) ↑↓ scroll",
+			m.debugScroll+1,
+			min(m.debugScroll+panelHeight, totalLines),
+			totalLines,
+		)))
+	} else {
+		content.WriteString(mutedStyle.Render(fmt.Sprintf(" (%d lines)", totalLines)))
+	}
+	content.WriteString("\n")
+
+	if totalLines == 0 {
+		content.WriteString(mutedStyle.Italic(true).Render("  No debug output yet..."))
+	} else {
+		// Calculate visible range
+		start := m.debugScroll
+		end := start + panelHeight
+		if end > totalLines {
+			end = totalLines
+			start = end - panelHeight
+			if start < 0 {
+				start = 0
+			}
+		}
+
+		for _, line := range m.debugLines[start:end] {
+			// Truncate long lines
+			maxLen := m.width - 10
+			if len(line) > maxLen {
+				line = line[:maxLen-3] + "..."
+			}
+			content.WriteString("  " + debugStyle.Render(line) + "\n")
+		}
+	}
+
+	return boxStyle.Render(content.String())
+}
+
 func (m *DashboardModel) renderFooter() string {
 	helpStyle := lipgloss.NewStyle().
 		Foreground(m.theme.Muted).
@@ -485,7 +601,10 @@ func (m *DashboardModel) renderFooter() string {
 		Align(lipgloss.Center).
 		MarginTop(1)
 
-	keys := []string{"q quit", "v verbose"}
+	keys := []string{"q quit", "v verbose", "d debug"}
+	if m.debugMode && len(m.debugLines) > m.maxDebug {
+		keys = append(keys, "↑↓ scroll")
+	}
 	help := strings.Join(keys, "  •  ")
 
 	return helpStyle.Render(help)
@@ -510,4 +629,19 @@ func RunDashboard(workflowName string, reporter *ProgressReporter) (*DashboardMo
 	m := NewDashboardModel(workflowName, reporter)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	return m, p
+}
+
+// RunDashboardWithDebug starts the dashboard TUI with debug output capture
+func RunDashboardWithDebug(workflowName string, reporter *ProgressReporter, debugWriter *DebugWriter) (*DashboardModel, *tea.Program) {
+	m := NewDashboardModel(workflowName, reporter)
+	m.SetDebugWriter(debugWriter)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	return m, p
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/utils/tui/debugwriter.go
+++ b/utils/tui/debugwriter.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"io"
+	"strings"
+	"sync"
+)
+
+// DebugWriter captures debug output and forwards it to a channel for TUI display.
+// It implements io.Writer so it can be used with log.SetOutput().
+type DebugWriter struct {
+	mu       sync.Mutex
+	lines    []string
+	maxLines int
+	onChange func([]string)
+	original io.Writer
+}
+
+// NewDebugWriter creates a new DebugWriter that captures output.
+// original is the fallback writer (e.g., os.Stderr) for when TUI is not active.
+// maxLines limits how many lines are kept in the buffer.
+func NewDebugWriter(original io.Writer, maxLines int) *DebugWriter {
+	if maxLines <= 0 {
+		maxLines = 500
+	}
+	return &DebugWriter{
+		lines:    make([]string, 0, maxLines),
+		maxLines: maxLines,
+		original: original,
+	}
+}
+
+// SetOnChange sets a callback that's called whenever new lines are added.
+func (w *DebugWriter) SetOnChange(fn func([]string)) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.onChange = fn
+}
+
+// Write implements io.Writer. It captures the output and optionally forwards to original.
+func (w *DebugWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	text := string(p)
+	newLines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+
+	for _, line := range newLines {
+		if line != "" {
+			w.lines = append(w.lines, line)
+		}
+	}
+
+	// Trim to max lines
+	if len(w.lines) > w.maxLines {
+		w.lines = w.lines[len(w.lines)-w.maxLines:]
+	}
+
+	// Notify listener
+	if w.onChange != nil {
+		// Send a copy to avoid race conditions
+		linesCopy := make([]string, len(w.lines))
+		copy(linesCopy, w.lines)
+		w.onChange(linesCopy)
+	}
+
+	return len(p), nil
+}
+
+// Lines returns a copy of all captured lines.
+func (w *DebugWriter) Lines() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	linesCopy := make([]string, len(w.lines))
+	copy(linesCopy, w.lines)
+	return linesCopy
+}
+
+// LastN returns the last n lines.
+func (w *DebugWriter) LastN(n int) []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if n >= len(w.lines) {
+		linesCopy := make([]string, len(w.lines))
+		copy(linesCopy, w.lines)
+		return linesCopy
+	}
+
+	start := len(w.lines) - n
+	linesCopy := make([]string, n)
+	copy(linesCopy, w.lines[start:])
+	return linesCopy
+}
+
+// Clear empties the buffer.
+func (w *DebugWriter) Clear() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lines = w.lines[:0]
+}
+
+// Original returns the original writer for passthrough.
+func (w *DebugWriter) Original() io.Writer {
+	return w.original
+}

--- a/utils/tui/debugwriter_test.go
+++ b/utils/tui/debugwriter_test.go
@@ -1,0 +1,95 @@
+package tui
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDebugWriter_Write(t *testing.T) {
+	original := &bytes.Buffer{}
+	w := NewDebugWriter(original, 100)
+
+	// Write some content
+	n, err := w.Write([]byte("[DEBUG] test message\n"))
+	if err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if n != 21 {
+		t.Errorf("Expected 21 bytes written, got %d", n)
+	}
+
+	lines := w.Lines()
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line, got %d", len(lines))
+	}
+	if lines[0] != "[DEBUG] test message" {
+		t.Errorf("Expected '[DEBUG] test message', got '%s'", lines[0])
+	}
+}
+
+func TestDebugWriter_MaxLines(t *testing.T) {
+	original := &bytes.Buffer{}
+	w := NewDebugWriter(original, 5)
+
+	// Write more lines than maxLines
+	for i := 0; i < 10; i++ {
+		w.Write([]byte("line\n"))
+	}
+
+	lines := w.Lines()
+	if len(lines) != 5 {
+		t.Errorf("Expected 5 lines (max), got %d", len(lines))
+	}
+}
+
+func TestDebugWriter_LastN(t *testing.T) {
+	original := &bytes.Buffer{}
+	w := NewDebugWriter(original, 100)
+
+	w.Write([]byte("line1\nline2\nline3\nline4\nline5\n"))
+
+	last3 := w.LastN(3)
+	if len(last3) != 3 {
+		t.Errorf("Expected 3 lines, got %d", len(last3))
+	}
+	if last3[0] != "line3" || last3[1] != "line4" || last3[2] != "line5" {
+		t.Errorf("Unexpected lines: %v", last3)
+	}
+}
+
+func TestDebugWriter_OnChange(t *testing.T) {
+	original := &bytes.Buffer{}
+	w := NewDebugWriter(original, 100)
+
+	var callbackCalled bool
+	var receivedLines []string
+
+	w.SetOnChange(func(lines []string) {
+		callbackCalled = true
+		receivedLines = lines
+	})
+
+	w.Write([]byte("test line\n"))
+
+	if !callbackCalled {
+		t.Error("OnChange callback was not called")
+	}
+	if len(receivedLines) != 1 {
+		t.Errorf("Expected 1 line in callback, got %d", len(receivedLines))
+	}
+}
+
+func TestDebugWriter_Clear(t *testing.T) {
+	original := &bytes.Buffer{}
+	w := NewDebugWriter(original, 100)
+
+	w.Write([]byte("line1\nline2\n"))
+	if len(w.Lines()) != 2 {
+		t.Errorf("Expected 2 lines before clear")
+	}
+
+	w.Clear()
+	if len(w.Lines()) != 0 {
+		t.Errorf("Expected 0 lines after clear, got %d", len(w.Lines()))
+	}
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a dedicated debug panel within the TUI to capture and display debug/verbose output.
- Implements a `DebugWriter` to capture log output when TUI is active, redirecting it from stderr.
- Adds keyboard controls for toggling the debug panel and scrolling through the debug output.
- Ensures the debug panel auto-sizes based on terminal height and maintains a 500-line buffer.
- Includes comprehensive tests for the `DebugWriter` functionality.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/process.go`: Added logic to set up a `DebugWriter` and redirect log output to it when debug/verbose mode is enabled. Modified dashboard creation to include a debug panel when necessary.
- `utils/tui/dashboard.go`: Enhanced the `DashboardModel` to support a debug panel, including new fields for debug lines and scroll position. Added key bindings for toggling and scrolling the debug panel. Implemented rendering logic for the debug panel.
- `utils/tui/debugwriter.go`: Introduced the `DebugWriter` struct to capture and manage debug output. Implemented methods for writing, retrieving, and clearing debug lines, as well as setting change callbacks.
- `utils/tui/debugwriter_test.go`: Added tests for the `DebugWriter` to verify its ability to capture output, respect line limits, handle callbacks, and clear its buffer.
</details>

___
## User Description:
## Problem

Running `--live` with `--debug` or `--verbose` creates chaos — debug output spews across the screen, breaking the TUI layout and making it impossible to follow either the dashboard or the debug info.

## Solution

Add a dedicated debug panel that captures all debug/verbose output within the TUI:

![Debug Panel Demo](https://user-images.githubusercontent.com/placeholder/debug-panel.gif)

## Features

- **DebugWriter** — Captures `log.Printf` output when TUI is active, redirecting it from stderr
- **Debug panel** — Shows captured output in a scrollable panel within the dashboard
- **Keyboard controls:**
  - `d` — Toggle debug panel visibility
  - `↑/k` — Scroll up
  - `↓/j` — Scroll down
- **Auto-sizing** — Panel height adjusts based on terminal size
- **500-line buffer** — Retains recent debug history without unbounded growth

## Usage

```bash
# Now works cleanly!
comanda process agentic.yaml --live --debug

# Press 'd' to show/hide debug panel
# Press ↑↓ to scroll through debug output
```

## Tests

Added comprehensive tests for DebugWriter: buffer management, max lines, callbacks, clearing.
