### PR TITLE
fix(generate): detect and include codebase indexes in workflow generation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,6 +212,12 @@ overridden with --model.`,
 		var structureErrors string
 		maxAttempts := 3 // Increased to allow for both model and structure fixes
 
+		// Detect available codebase indexes in .comanda/
+		availableIndexes := detectAvailableIndexes()
+		if verbose && len(availableIndexes) > 0 {
+			log.Printf("[DEBUG] Found %d codebase index(es): %v\n", len(availableIndexes), availableIndexes)
+		}
+
 		// Create spinner for visual feedback during generation
 		spinner := processor.NewSpinner()
 		if verbose {
@@ -220,8 +226,8 @@ overridden with --model.`,
 		}
 
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			// Build the prompt with any previous validation errors
-			prompt := buildGeneratePrompt(dslGuide, userPrompt, invalidModels, structureErrors)
+			// Build the prompt with any previous validation errors and available indexes
+			prompt := buildGeneratePrompt(dslGuide, userPrompt, invalidModels, structureErrors, availableIndexes)
 
 			// Start spinner for LLM generation
 			spinnerMsg := "Generating workflow"
@@ -297,7 +303,7 @@ overridden with --model.`,
 }
 
 // buildGeneratePrompt creates the prompt for workflow generation
-func buildGeneratePrompt(dslGuide, userPrompt string, invalidModels []string, structureErrors string) string {
+func buildGeneratePrompt(dslGuide, userPrompt string, invalidModels []string, structureErrors string, availableIndexes []string) string {
 	basePrompt := fmt.Sprintf(`SYSTEM: You are a YAML generator. You MUST output ONLY valid YAML content. No explanations, no markdown, no code blocks, no commentary - just raw YAML.
 
 --- BEGIN COMANDA DSL SPECIFICATION ---
@@ -308,6 +314,18 @@ User's request: %s
 
 CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.`,
 		dslGuide, userPrompt)
+
+	// Add available codebase indexes if any exist
+	if len(availableIndexes) > 0 {
+		basePrompt += "\n\n--- AVAILABLE CODEBASE INDEXES ---\n"
+		basePrompt += "The following codebase indexes are available in the .comanda/ directory:\n"
+		for _, idx := range availableIndexes {
+			basePrompt += fmt.Sprintf("- %s\n", idx)
+		}
+		basePrompt += "\nTo use a codebase index, reference it as input: .comanda/<index_name>\n"
+		basePrompt += "For agentic workflows, include .comanda in allowed_paths so the agent can read the index.\n"
+		basePrompt += "--- END AVAILABLE INDEXES ---"
+	}
 
 	// Add feedback about previous validation errors
 	if len(invalidModels) > 0 || structureErrors != "" {
@@ -333,6 +351,31 @@ Please fix all the above errors and regenerate the workflow.`, structureErrors)
 	}
 
 	return basePrompt
+}
+
+// detectAvailableIndexes looks for codebase indexes in .comanda/ directory
+func detectAvailableIndexes() []string {
+	var indexes []string
+
+	// Check current directory's .comanda/
+	comandaDir := ".comanda"
+	entries, err := os.ReadDir(comandaDir)
+	if err != nil {
+		return indexes // No .comanda directory or can't read it
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Look for index files (ending in _INDEX.md, not .meta.json)
+		if strings.HasSuffix(name, "_INDEX.md") && !strings.HasSuffix(name, ".meta.json") {
+			indexes = append(indexes, name)
+		}
+	}
+
+	return indexes
 }
 
 // extractYAMLContent extracts YAML from an LLM response, handling code blocks

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -107,6 +107,46 @@ step_name_for_processing:
 - Database query: `input: { database: { type: "postgres", query: "SELECT * FROM users" } }`
 - No input: `input: NA`
 - Input with alias for variable: `input: path/to/file.txt as $my_var`
+
+### Codebase Indexes
+
+Comanda can generate and use codebase indexes - structured summaries of code repositories that help LLMs understand codebases without reading every file.
+
+**Index Location:**
+Codebase indexes are stored in the `.comanda/` directory at the root of a repository:
+- `.comanda/{repo_name}_INDEX.md` - The index file
+- `.comanda/{repo_name}_INDEX.md.meta.json` - Metadata about when/how the index was generated
+
+**Using Indexes in Workflows:**
+To give an LLM context about a codebase, use the index as input:
+
+```yaml
+analyze_codebase:
+  input: .comanda/myproject_INDEX.md
+  model: claude-sonnet-4-5
+  action: "Based on this codebase index, identify potential security concerns"
+  output: STDOUT
+```
+
+**Exploring the .comanda Directory:**
+For agentic workflows that need to work with code, point the agent to the `.comanda/` directory so it can discover available indexes:
+
+```yaml
+code_task:
+  model: claude-code
+  action: |
+    First, read the codebase index in .comanda/ to understand the project structure.
+    Then implement the requested feature.
+  agentic_loop:
+    max_iterations: 10
+    exit_condition: llm_decides
+    allowed_paths:
+      - .comanda
+      - ./src
+  output: STDOUT
+```
+
+**Note:** Index filenames use the repository/project name as a slug (e.g., `myproject_INDEX.md`, `comanda_INDEX.md`). When writing workflows, check what indexes exist in `.comanda/` or let the agent discover them.
 - List with aliases: `input: [file1.txt as $file1_content, file2.txt as $file2_content]`
 
 ### Chunking


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a feature to auto-detect available codebase indexes in the `.comanda/` directory.
- Updates the workflow generation prompt to include detected codebase indexes.
- Adds comprehensive documentation on codebase indexes in `comanda-llm-guide.md`.
- Ensures that the generated workflows correctly reference the actual path of codebase indexes.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/root.go`: - Added a new function `detectAvailableIndexes` to scan the `.comanda/` directory for files ending with `_INDEX.md`.
- Modified the workflow generation process to include detected indexes in the prompt.
- Updated the `buildGeneratePrompt` function to append available indexes to the prompt if any are found.
- `docs/comanda-llm-guide.md`: - Added a new section "Codebase Indexes" explaining the purpose, location, and usage of codebase indexes.
- Provided examples of how to use codebase indexes in workflows and how to configure agentic workflows to access them.
</details>

___
## User Description:
## Problem

When using `comanda generate` and asking it to "consult a code index", the LLM didn't know:
1. That codebase indexes exist
2. Where they're stored (`.comanda/{slug}_INDEX.md`)
3. How to reference them in workflows

This resulted in the agent looking for `INDEX.md` or `.comanda/INDEX.md` instead of the actual path like `.comanda/comanda_INDEX.md`.

## Solution

**1. Auto-detect available indexes:**
The `generate` command now scans `.comanda/` for any `*_INDEX.md` files and includes them in the prompt:

```
--- AVAILABLE CODEBASE INDEXES ---
The following codebase indexes are available in the .comanda/ directory:
- comanda_INDEX.md
- myproject_INDEX.md

To use a codebase index, reference it as input: .comanda/<index_name>
For agentic workflows, include .comanda in allowed_paths so the agent can read the index.
--- END AVAILABLE INDEXES ---
```

**2. Documentation in LLM guide:**
Added a new "Codebase Indexes" section to `comanda-llm-guide.md` explaining:
- Index file locations
- How to use indexes as workflow input
- How to include `.comanda` in `allowed_paths` for agentic workflows

## Example

Now when you run:
```bash
comanda generate analyze.yaml "analyze this codebase using the code index"
```

The generated workflow will correctly reference:
```yaml
analyze_codebase:
  input: .comanda/comanda_INDEX.md  # Correct path!
  model: claude-sonnet-4-5
  action: "Analyze this codebase..."
  output: STDOUT
```
