### PR TITLE
fix(generate): enforce file output for agentic loops

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -312,7 +312,9 @@ func buildGeneratePrompt(dslGuide, userPrompt string, invalidModels []string, st
 
 User's request: %s
 
-CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.`,
+CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.
+
+AGENTIC LOOP OUTPUT RULE: When generating agentic_loop workflows, NEVER use "output: STDOUT". Agentic loops produce substantial work over multiple iterations that must be persisted to a file. Always use a meaningful file path like "output: ./docs/ARCHITECTURE.md" or "output: ./report.md". The output file is automatically added to allowed_paths.`,
 		dslGuide, userPrompt)
 
 	// Add available codebase indexes if any exist

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,6 +212,12 @@ overridden with --model.`,
 		var structureErrors string
 		maxAttempts := 3 // Increased to allow for both model and structure fixes
 
+		// Detect available codebase indexes in .comanda/
+		availableIndexes := detectAvailableIndexes()
+		if verbose && len(availableIndexes) > 0 {
+			log.Printf("[DEBUG] Found %d codebase index(es): %v\n", len(availableIndexes), availableIndexes)
+		}
+
 		// Create spinner for visual feedback during generation
 		spinner := processor.NewSpinner()
 		if verbose {
@@ -220,8 +226,8 @@ overridden with --model.`,
 		}
 
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			// Build the prompt with any previous validation errors
-			prompt := buildGeneratePrompt(dslGuide, userPrompt, invalidModels, structureErrors)
+			// Build the prompt with any previous validation errors and available indexes
+			prompt := buildGeneratePrompt(dslGuide, userPrompt, invalidModels, structureErrors, availableIndexes)
 
 			// Start spinner for LLM generation
 			spinnerMsg := "Generating workflow"
@@ -297,7 +303,7 @@ overridden with --model.`,
 }
 
 // buildGeneratePrompt creates the prompt for workflow generation
-func buildGeneratePrompt(dslGuide, userPrompt string, invalidModels []string, structureErrors string) string {
+func buildGeneratePrompt(dslGuide, userPrompt string, invalidModels []string, structureErrors string, availableIndexes []string) string {
 	basePrompt := fmt.Sprintf(`SYSTEM: You are a YAML generator. You MUST output ONLY valid YAML content. No explanations, no markdown, no code blocks, no commentary - just raw YAML.
 
 --- BEGIN COMANDA DSL SPECIFICATION ---
@@ -308,6 +314,18 @@ User's request: %s
 
 CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.`,
 		dslGuide, userPrompt)
+
+	// Add available codebase indexes if any exist
+	if len(availableIndexes) > 0 {
+		basePrompt += "\n\n--- AVAILABLE CODEBASE INDEXES ---\n"
+		basePrompt += "The following codebase indexes are available in the .comanda/ directory:\n"
+		for _, idx := range availableIndexes {
+			basePrompt += fmt.Sprintf("- %s\n", idx)
+		}
+		basePrompt += "\nTo use a codebase index, reference it as input: .comanda/<index_name>\n"
+		basePrompt += "For agentic workflows, include .comanda in allowed_paths so the agent can read the index.\n"
+		basePrompt += "--- END AVAILABLE INDEXES ---"
+	}
 
 	// Add feedback about previous validation errors
 	if len(invalidModels) > 0 || structureErrors != "" {
@@ -333,6 +351,31 @@ Please fix all the above errors and regenerate the workflow.`, structureErrors)
 	}
 
 	return basePrompt
+}
+
+// detectAvailableIndexes looks for codebase indexes in .comanda/ directory
+func detectAvailableIndexes() []string {
+	var indexes []string
+
+	// Check current directory's .comanda/
+	comandaDir := ".comanda"
+	entries, err := os.ReadDir(comandaDir)
+	if err != nil {
+		return indexes // No .comanda directory or can't read it
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Look for index files (ending in _INDEX.md, not .meta.json)
+		if strings.HasSuffix(name, "_INDEX.md") && !strings.HasSuffix(name, ".meta.json") {
+			indexes = append(indexes, name)
+		}
+	}
+
+	return indexes
 }
 
 // extractYAMLContent extracts YAML from an LLM response, handling code blocks

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -107,6 +107,46 @@ step_name_for_processing:
 - Database query: `input: { database: { type: "postgres", query: "SELECT * FROM users" } }`
 - No input: `input: NA`
 - Input with alias for variable: `input: path/to/file.txt as $my_var`
+
+### Codebase Indexes
+
+Comanda can generate and use codebase indexes - structured summaries of code repositories that help LLMs understand codebases without reading every file.
+
+**Index Location:**
+Codebase indexes are stored in the `.comanda/` directory at the root of a repository:
+- `.comanda/{repo_name}_INDEX.md` - The index file
+- `.comanda/{repo_name}_INDEX.md.meta.json` - Metadata about when/how the index was generated
+
+**Using Indexes in Workflows:**
+To give an LLM context about a codebase, use the index as input:
+
+```yaml
+analyze_codebase:
+  input: .comanda/myproject_INDEX.md
+  model: claude-sonnet-4-5
+  action: "Based on this codebase index, identify potential security concerns"
+  output: STDOUT
+```
+
+**Exploring the .comanda Directory:**
+For agentic workflows that need to work with code, point the agent to the `.comanda/` directory so it can discover available indexes:
+
+```yaml
+code_task:
+  model: claude-code
+  action: |
+    First, read the codebase index in .comanda/ to understand the project structure.
+    Then implement the requested feature.
+  agentic_loop:
+    max_iterations: 10
+    exit_condition: llm_decides
+    allowed_paths:
+      - .comanda
+      - ./src
+  output: STDOUT
+```
+
+**Note:** Index filenames use the repository/project name as a slug (e.g., `myproject_INDEX.md`, `comanda_INDEX.md`). When writing workflows, check what indexes exist in `.comanda/` or let the agent discover them.
 - List with aliases: `input: [file1.txt as $file1_content, file2.txt as $file2_content]`
 
 ### Chunking

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -435,8 +435,41 @@ complex_task:
       - ./src
       - ./tests
     tools: [Read, Write, Edit, Bash]
-  output: STDOUT
+  output: ./implementation_report.md
 ```
+
+### Output Configuration for Agentic Loops
+
+**Important:** Agentic loop output should almost always be a **file path**, not STDOUT.
+
+- **Use a file path:** `output: ./docs/ARCHITECTURE.md` or `output: ./report.md`
+- **Avoid STDOUT:** Agentic loops produce substantial output over multiple iterations; STDOUT is inappropriate
+
+The output file serves two purposes:
+1. It's where the agent writes its final deliverable
+2. It's automatically added to `allowed_paths` so the agent can write to it
+
+```yaml
+# GOOD: Output to a specific file
+document_codebase:
+  model: claude-code
+  action: "Create comprehensive architecture documentation"
+  agentic_loop:
+    max_iterations: 15
+    exit_condition: llm_decides
+  output: ./docs/ARCHITECTURE.md  # Agent will write here
+
+# BAD: Output to STDOUT for agentic work
+document_codebase:
+  model: claude-code
+  action: "Create comprehensive architecture documentation"
+  agentic_loop:
+    max_iterations: 15
+    exit_condition: llm_decides
+  output: STDOUT  # Don't do this - agent can't persist work!
+```
+
+**Exception:** Use `output: STDOUT` only for quick, single-iteration agentic queries where you want immediate console output.
 
 **Key Configuration:**
 - `max_iterations`: (int, default: 10) Maximum loop iterations before stopping


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Enforces that agentic loops in generated workflows use file paths for output instead of STDOUT.
- Integrates detection and inclusion of codebase indexes from the .comanda/ directory in workflow generation.
- Updates documentation to guide users on output configuration for agentic loops and usage of codebase indexes.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/root.go`: - Added a function `detectAvailableIndexes` to scan the .comanda/ directory for codebase indexes.
- Modified the `buildGeneratePrompt` function to include available codebase indexes in the prompt.
- Updated the workflow generation logic to incorporate these indexes and enforce file output for agentic loops.
- `docs/comanda-llm-guide.md`: - Added a section on "Codebase Indexes" explaining their location, usage in workflows, and how to explore the .comanda directory.
- Introduced a new section "Output Configuration for Agentic Loops" to emphasize using file paths over STDOUT for agentic loop outputs.
- Provided examples of good and bad practices for agentic loop outputs.
</details>

___
## User Description:
## Problem

When running `comanda generate` to create agentic workflows, the LLM would generate:

```yaml
document_codebase:
  model: claude-code
  action: "Create comprehensive architecture documentation"
  agentic_loop:
    max_iterations: 15
    exit_condition: llm_decides
  output: STDOUT  # ← Wrong!
```

This causes problems:
1. The agent writes to a file mentioned in the action (e.g., `./docs/ARCHITECTURE.md`)
2. But STDOUT is captured as the "output"
3. The agent can't actually persist progress because the directory may not be in `allowed_paths`
4. When the agent fails to write, it tries to output everything to STDOUT instead ("fabricating" output)

## Solution

**1. Explicit instruction in generate prompt:**
> AGENTIC LOOP OUTPUT RULE: When generating agentic_loop workflows, NEVER use "output: STDOUT". Always use a meaningful file path like "output: ./docs/ARCHITECTURE.md"

**2. Updated documentation in comanda-llm-guide.md:**
- Clear section on "Output Configuration for Agentic Loops"
- Good vs bad examples
- Explanation that output files are auto-added to `allowed_paths`

## After this fix

```yaml
document_codebase:
  model: claude-code
  action: "Create comprehensive architecture documentation"
  agentic_loop:
    max_iterations: 15
    exit_condition: llm_decides
  output: ./docs/ARCHITECTURE.md  # ✓ Correct!
```

Now the agent has a place to write its work, and the file is automatically added to `allowed_paths`.
