### PR TITLE
feat(generate): auto-save workflows to .comanda/ directory

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,6 +124,10 @@ overridden with --model.`,
 		outputFilename := args[0]
 		userPrompt := args[1]
 
+		// If .comanda/ exists and user provided a plain filename (no path),
+		// save workflows there to keep project root clean
+		outputFilename = resolveOutputPath(outputFilename)
+
 		// Use the centralized configuration that was loaded in PersistentPreRunE
 		// No need to load it again
 
@@ -353,6 +357,26 @@ Please fix all the above errors and regenerate the workflow.`, structureErrors)
 	}
 
 	return basePrompt
+}
+
+// resolveOutputPath checks if .comanda/ exists and prefixes plain filenames with it.
+// This keeps generated workflows organized in the .comanda/ directory.
+// If user provides a path (contains / or \), we respect their choice.
+func resolveOutputPath(filename string) string {
+	// If user specified a path (contains directory separator), use as-is
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") {
+		return filename
+	}
+
+	// Check if .comanda/ directory exists
+	comandaDir := ".comanda"
+	if info, err := os.Stat(comandaDir); err == nil && info.IsDir() {
+		// .comanda exists, save workflow there
+		return filepath.Join(comandaDir, filename)
+	}
+
+	// No .comanda directory, use current directory
+	return filename
 }
 
 // detectAvailableIndexes looks for codebase indexes in .comanda/ directory

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -147,6 +147,26 @@ code_task:
 ```
 
 **Note:** Index filenames use the repository/project name as a slug (e.g., `myproject_INDEX.md`, `comanda_INDEX.md`). When writing workflows, check what indexes exist in `.comanda/` or let the agent discover them.
+
+### The .comanda Directory
+
+The `.comanda/` directory is comanda's home for project-specific files:
+- **Codebase indexes:** `{project}_INDEX.md` files
+- **Generated workflows:** When you run `comanda generate workflow.yaml "prompt"`, if `.comanda/` exists the workflow is saved there automatically
+- **Workflow artifacts:** Outputs, logs, and intermediate files
+
+**Auto-save to .comanda/:**
+When running `comanda generate`, plain filenames (without paths) are automatically saved to `.comanda/`:
+
+```bash
+# If .comanda/ exists, saves to .comanda/analyze.yaml
+comanda generate analyze.yaml "analyze the codebase"
+
+# Explicit paths are respected as-is
+comanda generate ./workflows/analyze.yaml "analyze the codebase"
+```
+
+This keeps your project root clean while organizing comanda artifacts together.
 - List with aliases: `input: [file1.txt as $file1_content, file2.txt as $file2_content]`
 
 ### Chunking


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a new feature where generated workflows are automatically saved in the `.comanda/` directory if it exists, keeping the project root clean.
- Adds a `resolveOutputPath()` function to determine the correct save location for workflow files.
- Updates documentation to explain the new behavior and the purpose of the `.comanda/` directory.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/root.go`: - Added logic to automatically save generated workflows to the `.comanda/` directory if it exists and the filename does not contain a path.
- Introduced the `resolveOutputPath()` function to handle the logic of determining the correct file path for saving workflows.
- `docs/comanda-llm-guide.md`: - Added a new section titled "The .comanda Directory" to explain the purpose of the directory and the new auto-save behavior for generated workflows.
- Provided examples and explanations on how workflows are saved to the `.comanda/` directory and how explicit paths are handled.
</details>

___
## User Description:
## Summary

When running `comanda generate`, if a `.comanda/` directory exists, workflows are automatically saved there instead of cluttering the project root.

## Behavior

```bash
# If .comanda/ exists → saves to .comanda/analyze.yaml
comanda generate analyze.yaml "analyze the codebase"

# Explicit paths are always respected
comanda generate ./workflows/analyze.yaml "analyze the codebase"
```

## Why

The `.comanda/` directory is already home to:
- Codebase indexes (`{project}_INDEX.md`)
- Index metadata (`.meta.json`)

It makes sense to also store generated workflows there, keeping all comanda artifacts organized together.

## Changes

1. **cmd/root.go:** Added `resolveOutputPath()` function that:
   - Checks if `.comanda/` exists
   - Prefixes plain filenames with `.comanda/`
   - Respects explicit paths (containing `/` or `\`)

2. **docs/comanda-llm-guide.md:** Added "The .comanda Directory" section explaining this behavior
