### PR TITLE
fix(agentic): auto-create output directories

### DIFF
--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -561,6 +561,16 @@ func (p *Processor) expandAllowedPathsWithOutputDirs(allowedPaths []string, step
 				pathSet[absDir] = true
 				p.debugf("Auto-added output directory to allowed_paths: %s (from output: %s)", absDir, outputPath)
 			}
+
+			// Create the output directory if it doesn't exist
+			// This prevents permission errors when the agent tries to write
+			if _, err := os.Stat(absDir); os.IsNotExist(err) {
+				if err := os.MkdirAll(absDir, 0755); err != nil {
+					p.debugf("Warning: failed to create output directory %s: %v", absDir, err)
+				} else {
+					p.debugf("Auto-created output directory: %s", absDir)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Automatically creates output directories if they do not exist when processing agentic loop steps.
- Prevents permission errors by ensuring directories are created before the agent attempts to write files.
- Adds debug logging to indicate when directories are auto-created or if there is a failure in creation.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/agentic_loop.go`: Added logic to check if the output directory exists and create it with 0755 permissions if it does not. This is done during the path expansion phase. Debug messages are added to log the creation of directories or any failure in the process.
</details>

___
## User Description:
## Problem

When running an agentic loop with:
```yaml
output: ./docs/ARCHITECTURE.md
allowed_paths: [./docs]
```

If `./docs/` doesn't exist, the agent fails with permission errors. The agent can write files but can't create directories.

## Solution

When processing agentic loop steps, comanda now auto-creates output directories that don't exist:

```
Auto-created output directory: /path/to/project/docs
```

This happens during the path expansion phase, before the agentic loop starts.

## When this helps

- Fresh projects where `docs/` doesn't exist yet
- Generated workflows that reference new output paths
- Any agentic task that writes to a new directory
