### PR TITLE
fix(generate): default agentic outputs to .comanda/ flat paths

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -314,7 +314,12 @@ User's request: %s
 
 CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.
 
-AGENTIC LOOP OUTPUT RULE: When generating agentic_loop workflows, NEVER use "output: STDOUT". Agentic loops produce substantial work over multiple iterations that must be persisted to a file. Always use a meaningful file path like "output: ./docs/ARCHITECTURE.md" or "output: ./report.md". The output file is automatically added to allowed_paths.`,
+AGENTIC LOOP OUTPUT RULE: When generating agentic_loop workflows:
+1. NEVER use "output: STDOUT" - agentic loops must persist work to files
+2. ALWAYS use flat paths in .comanda/ directory - e.g., "output: .comanda/ARCHITECTURE.md" or "output: .comanda/analysis_report.md"
+3. Do NOT create subdirectories unless the user explicitly requests them
+4. The output file is automatically added to allowed_paths
+5. If user specifies a custom path like "./docs/", use it and ensure allowed_paths includes that directory`,
 		dslGuide, userPrompt)
 
 	// Add available codebase indexes if any exist

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -442,22 +442,35 @@ complex_task:
 
 **Important:** Agentic loop output should almost always be a **file path**, not STDOUT.
 
-- **Use a file path:** `output: ./docs/ARCHITECTURE.md` or `output: ./report.md`
-- **Avoid STDOUT:** Agentic loops produce substantial output over multiple iterations; STDOUT is inappropriate
+**Default to `.comanda/` flat paths:**
+- **Preferred:** `output: .comanda/ARCHITECTURE.md` or `output: .comanda/analysis_report.md`
+- **Avoid subdirectories** unless the user explicitly requests them (e.g., `./docs/`)
+- **Avoid STDOUT:** Agentic loops produce substantial output over multiple iterations
 
 The output file serves two purposes:
 1. It's where the agent writes its final deliverable
 2. It's automatically added to `allowed_paths` so the agent can write to it
 
 ```yaml
-# GOOD: Output to a specific file
+# GOOD: Output to .comanda/ directory (default for generated workflows)
 document_codebase:
   model: claude-code
   action: "Create comprehensive architecture documentation"
   agentic_loop:
     max_iterations: 15
     exit_condition: llm_decides
-  output: ./docs/ARCHITECTURE.md  # Agent will write here
+    allowed_paths: [.comanda]
+  output: .comanda/ARCHITECTURE.md
+
+# GOOD: Custom path when user specifies (ensure allowed_paths matches)
+document_codebase:
+  model: claude-code
+  action: "Create comprehensive architecture documentation"
+  agentic_loop:
+    max_iterations: 15
+    exit_condition: llm_decides
+    allowed_paths: [.comanda, ./docs]  # Include custom output dir
+  output: ./docs/ARCHITECTURE.md
 
 # BAD: Output to STDOUT for agentic work
 document_codebase:


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Updated the generate prompt to ensure agentic loop outputs default to flat paths in the .comanda/ directory.
- Added rules to avoid using STDOUT for outputs and to prevent creating subdirectories unless explicitly requested by the user.
- Enhanced documentation with clearer examples of default and custom output paths.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/root.go`: Revised the AGENTIC LOOP OUTPUT RULE to enforce the use of flat paths in the .comanda/ directory for agentic loop outputs. Added instructions to avoid STDOUT and subdirectories unless specified by the user. Ensured that custom paths are included in allowed_paths.
- `docs/comanda-llm-guide.md`: Updated the guide to reflect the new default behavior of using .comanda/ flat paths for agentic loop outputs. Provided examples of both default and custom path configurations, emphasizing the importance of including custom directories in allowed_paths.
</details>

___
## User Description:
## Problem

Generated workflows were using paths like `./docs/ARCHITECTURE.md` for agentic loop outputs, but if `./docs/` doesn't exist, the agent can't write there (agents can write files but not create directories).

## Solution

Updated the generate prompt to instruct the LLM to:

1. **Default to flat .comanda/ paths** — e.g., `output: .comanda/ARCHITECTURE.md`
2. **Avoid subdirectories** unless the user explicitly asks for them
3. **When custom paths are needed**, ensure `allowed_paths` includes the directory

## Examples

```yaml
# Default (generated workflows will do this)
output: .comanda/ARCHITECTURE.md
allowed_paths: [.comanda]

# Custom (only when user specifies ./docs/)
output: ./docs/ARCHITECTURE.md
allowed_paths: [.comanda, ./docs]
```

## Changes

1. **cmd/root.go**: Updated AGENTIC LOOP OUTPUT RULE in generate prompt
2. **docs/comanda-llm-guide.md**: Clearer examples showing default vs custom patterns
