### PR TITLE
fix: race condition in parallel step processing

### DIFF
--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -1227,7 +1227,9 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 
 	// Create a new handler for this step to avoid conflicts in parallel processing
 	stepHandler := input.NewHandler()
+	p.mu.Lock()
 	p.handler = stepHandler
+	p.mu.Unlock()
 
 	stepInfo := &StepInfo{
 		Name:   step.Name,
@@ -1283,7 +1285,10 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 		} else if url, ok := v["url"].(string); ok {
 			// Handle scraping configuration
 			p.debugf("Scraping content from %s for step: %s", url, step.Name)
-			if err := p.handler.ProcessScrape(url, v); err != nil {
+			p.mu.Lock()
+			handler := p.handler
+			p.mu.Unlock()
+			if err := handler.ProcessScrape(url, v); err != nil {
 				return "", fmt.Errorf("failed to process scraping input: %w", err)
 			}
 		} else {
@@ -1508,9 +1513,12 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 		substituted := p.substituteVariables(action)
 
 		// If we're processing chunks, add chunk-specific placeholders
-		if chunkResult != nil && len(p.handler.GetInputs()) > 0 {
+		p.mu.Lock()
+		handlerInputs := p.handler.GetInputs()
+		p.mu.Unlock()
+		if chunkResult != nil && len(handlerInputs) > 0 {
 			// Get the current chunk index from the input path
-			currentInput := p.handler.GetInputs()[0]
+			currentInput := handlerInputs[0]
 			chunkIndex := -1
 			for i, chunkPath := range chunkResult.ChunkPaths {
 				if chunkPath == currentInput.Path {

--- a/utils/processor/model_handler.go
+++ b/utils/processor/model_handler.go
@@ -240,7 +240,9 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 
 		provider.SetVerbose(p.verbose)
 		// Store provider by provider name instead of model name
+		p.mu.Lock()
 		p.providers[provider.Name()] = provider
+		p.mu.Unlock()
 		p.debugf("Model %s is supported by provider %s", modelName, provider.Name())
 	}
 	return nil
@@ -264,7 +266,15 @@ func isLocalProvider(name string) bool {
 func (p *Processor) configureProviders() error {
 	p.debugf("Configuring providers")
 
-	for providerName, provider := range p.providers {
+	// Copy providers map to avoid race conditions during iteration
+	p.mu.Lock()
+	providersCopy := make(map[string]models.Provider, len(p.providers))
+	for k, v := range p.providers {
+		providersCopy[k] = v
+	}
+	p.mu.Unlock()
+
+	for providerName, provider := range providersCopy {
 		p.debugf("Configuring provider %s", providerName)
 
 		// Handle local providers (no API key needed, use "LOCAL" configuration)


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a race condition in parallel step processing by implementing the following fixes:
- Protects `p.providers` map writes with a mutex in `validateModel()`.
- Copies the `p.providers` map before iterating in `configureProviders()` to avoid read/write race conditions.
- Protects `p.handler` access with a mutex in `processStep()` to ensure thread safety.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/dsl.go`: - Added mutex locks and unlocks around the assignment and usage of `p.handler` in the `processStep` function to prevent concurrent access issues.
- Ensured that `p.handler` is accessed in a thread-safe manner when processing scraping inputs and when handling chunk-specific placeholders.
- `utils/processor/model_handler.go`: - Added mutex locks and unlocks around the `p.providers` map writes in the `validateModel` function to ensure thread safety.
- Created a copy of the `p.providers` map in `configureProviders` to avoid race conditions during iteration, ensuring that the original map is not modified concurrently.
</details>

___
## User Description:
## Problem

CI failed with `fatal error: concurrent map writes` in `TestParallelProcessing`:
https://github.com/kris-hansen/comanda/actions/runs/23624115862

This was a pre-existing race condition in parallel step processing that became more visible with recent changes.

## Root Cause

When multiple parallel steps run simultaneously, they were:
1. Writing to the shared `p.providers` map without synchronization
2. Iterating over `p.providers` while another goroutine was writing
3. Accessing `p.handler` from multiple goroutines

## Fix

1. **validateModel():** Protected `p.providers` map writes with mutex
2. **configureProviders():** Copy the map before iterating to avoid read/write race
3. **processStep():** Protected `p.handler` access with mutex

## Verification

```bash
go test -race -run TestParallelProcessing ./utils/processor/...
# ok  github.com/kris-hansen/comanda/utils/processor	1.659s
```
