### PR TITLE
fix(test): make MockProvider thread-safe for parallel tests

### DIFF
--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -1227,7 +1227,9 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 
 	// Create a new handler for this step to avoid conflicts in parallel processing
 	stepHandler := input.NewHandler()
+	p.mu.Lock()
 	p.handler = stepHandler
+	p.mu.Unlock()
 
 	stepInfo := &StepInfo{
 		Name:   step.Name,
@@ -1283,7 +1285,10 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 		} else if url, ok := v["url"].(string); ok {
 			// Handle scraping configuration
 			p.debugf("Scraping content from %s for step: %s", url, step.Name)
-			if err := p.handler.ProcessScrape(url, v); err != nil {
+			p.mu.Lock()
+			handler := p.handler
+			p.mu.Unlock()
+			if err := handler.ProcessScrape(url, v); err != nil {
 				return "", fmt.Errorf("failed to process scraping input: %w", err)
 			}
 		} else {
@@ -1508,9 +1513,12 @@ func (p *Processor) processStep(step Step, isParallel bool, parallelID string) (
 		substituted := p.substituteVariables(action)
 
 		// If we're processing chunks, add chunk-specific placeholders
-		if chunkResult != nil && len(p.handler.GetInputs()) > 0 {
+		p.mu.Lock()
+		handlerInputs := p.handler.GetInputs()
+		p.mu.Unlock()
+		if chunkResult != nil && len(handlerInputs) > 0 {
 			// Get the current chunk index from the input path
-			currentInput := p.handler.GetInputs()[0]
+			currentInput := handlerInputs[0]
 			chunkIndex := -1
 			for i, chunkPath := range chunkResult.ChunkPaths {
 				if chunkPath == currentInput.Path {

--- a/utils/processor/dsl_mocks_test.go
+++ b/utils/processor/dsl_mocks_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/kris-hansen/comanda/utils/models"
 )
@@ -34,7 +35,9 @@ func restoreDetectProvider() {
 }
 
 // MockProvider implements the models.Provider interface for testing
+// Thread-safe for parallel test execution
 type MockProvider struct {
+	mu         sync.RWMutex
 	name       string
 	configured bool
 	verbose    bool
@@ -48,10 +51,16 @@ func NewMockProvider(name string) *MockProvider {
 }
 
 func (m *MockProvider) Name() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.name
 }
 
 func (m *MockProvider) SupportsModel(modelName string) bool {
+	m.mu.RLock()
+	providerName := m.name
+	m.mu.RUnlock()
+
 	validModels := map[string][]string{
 		"openai": {
 			"gpt-4",
@@ -66,7 +75,7 @@ func (m *MockProvider) SupportsModel(modelName string) bool {
 		},
 	}
 
-	if models, ok := validModels[m.name]; ok {
+	if models, ok := validModels[providerName]; ok {
 		for _, validModel := range models {
 			if modelName == validModel {
 				return true
@@ -80,13 +89,19 @@ func (m *MockProvider) Configure(apiKey string) error {
 	if apiKey == "" {
 		return fmt.Errorf("API key is required")
 	}
+	m.mu.Lock()
 	m.configured = true
 	m.apiKey = apiKey
+	m.mu.Unlock()
 	return nil
 }
 
 func (m *MockProvider) SendPrompt(model, prompt string) (string, error) {
-	if !m.configured {
+	m.mu.RLock()
+	configured := m.configured
+	m.mu.RUnlock()
+
+	if !configured {
 		return "", fmt.Errorf("provider not configured")
 	}
 	if !m.SupportsModel(model) {
@@ -96,7 +111,11 @@ func (m *MockProvider) SendPrompt(model, prompt string) (string, error) {
 }
 
 func (m *MockProvider) SendPromptWithFile(model, prompt string, file models.FileInput) (string, error) {
-	if !m.configured {
+	m.mu.RLock()
+	configured := m.configured
+	m.mu.RUnlock()
+
+	if !configured {
 		return "", fmt.Errorf("provider not configured")
 	}
 	if !m.SupportsModel(model) {
@@ -106,5 +125,7 @@ func (m *MockProvider) SendPromptWithFile(model, prompt string, file models.File
 }
 
 func (m *MockProvider) SetVerbose(verbose bool) {
+	m.mu.Lock()
 	m.verbose = verbose
+	m.mu.Unlock()
 }

--- a/utils/processor/model_handler.go
+++ b/utils/processor/model_handler.go
@@ -240,7 +240,9 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 
 		provider.SetVerbose(p.verbose)
 		// Store provider by provider name instead of model name
+		p.mu.Lock()
 		p.providers[provider.Name()] = provider
+		p.mu.Unlock()
 		p.debugf("Model %s is supported by provider %s", modelName, provider.Name())
 	}
 	return nil
@@ -264,7 +266,15 @@ func isLocalProvider(name string) bool {
 func (p *Processor) configureProviders() error {
 	p.debugf("Configuring providers")
 
-	for providerName, provider := range p.providers {
+	// Copy providers map to avoid race conditions during iteration
+	p.mu.Lock()
+	providersCopy := make(map[string]models.Provider, len(p.providers))
+	for k, v := range p.providers {
+		providersCopy[k] = v
+	}
+	p.mu.Unlock()
+
+	for providerName, provider := range providersCopy {
 		p.debugf("Configuring provider %s", providerName)
 
 		// Handle local providers (no API key needed, use "LOCAL" configuration)


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Addressed race conditions in the `Processor` and `MockProvider` to ensure thread safety during parallel processing.
- Introduced `sync.RWMutex` to `MockProvider` for safe concurrent access.
- Protected shared resources in `Processor` with mutex locks to prevent concurrent access issues.
- Improved test reliability by making `MockProvider` thread-safe.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/dsl.go`: Added mutex locks around the `p.handler` assignment and access in `processStep` to prevent race conditions during parallel processing.
- `utils/processor/dsl_mocks_test.go`: Introduced `sync.RWMutex` to `MockProvider` and added appropriate read and write locks to methods to ensure thread safety during concurrent test execution.
- `utils/processor/model_handler.go`: Added mutex locks around the `p.providers` map in `validateModel` and `configureProviders` to prevent race conditions during concurrent access and modification.
</details>

___
## User Description:
## Problem

`TestParallelProcessing` was flaky in CI — failing intermittently when the race detector caught concurrent access to `MockProvider` fields.

## Root Cause

Multiple goroutines in parallel step processing were:
1. Calling `Configure()` which writes `configured` and `apiKey`
2. Calling `SendPrompt()` which reads `configured`
3. Calling `SetVerbose()` which writes `verbose`

All without synchronization.

## Fix

Added `sync.RWMutex` to `MockProvider` with appropriate locking:
- Read locks for `Name()`, `SupportsModel()`, `SendPrompt()`, `SendPromptWithFile()`
- Write locks for `Configure()`, `SetVerbose()`

## Testing

```bash
go test ./utils/processor/... -run TestParallelProcessing -race -count=10
# All pass
```
