### PR TITLE
fix(agentic): auto-create directories in allowed_paths

### DIFF
--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -535,11 +535,38 @@ func (p *Processor) processInlineAgenticLoop(step Step) (string, error) {
 // expandAllowedPathsWithOutputDirs adds parent directories of any output file paths
 // to the allowed_paths list. This ensures agents can write to output locations
 // without requiring explicit configuration of every output directory.
+// It also creates any directories in allowed_paths that don't exist yet.
 func (p *Processor) expandAllowedPathsWithOutputDirs(allowedPaths []string, steps []Step) []string {
 	// Use a map to deduplicate paths
 	pathSet := make(map[string]bool)
 	for _, path := range allowedPaths {
 		pathSet[path] = true
+
+		// Create allowed_path directories if they don't exist
+		// This prevents permission errors when the agent tries to write to .comanda/ etc.
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			p.debugf("Warning: failed to resolve allowed_path %s: %v", path, err)
+			continue
+		}
+
+		// Check if this looks like a directory path (no extension or ends with /)
+		// or if it already exists as a directory
+		info, statErr := os.Stat(absPath)
+		isDir := (statErr == nil && info.IsDir()) ||
+			strings.HasSuffix(path, "/") ||
+			filepath.Ext(path) == ""
+
+		if isDir && os.IsNotExist(statErr) {
+			if err := os.MkdirAll(absPath, 0755); err != nil {
+				p.debugf("Warning: failed to create allowed_path directory %s: %v", absPath, err)
+			} else {
+				p.debugf("Auto-created allowed_path directory: %s", absPath)
+				if p.streamLog != nil && p.streamLog.IsEnabled() {
+					p.streamLog.Log("📁 Created directory: %s", path)
+				}
+			}
+		}
 	}
 
 	// Extract output directories from steps


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Automatically creates directories specified in `allowed_paths` if they do not exist to prevent permission errors.
- Detects directory paths by checking if they end with a '/', have no file extension, or already exist as directories.
- Logs the creation of directories to the stream output for better visibility.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/processor/agentic_loop.go`: Enhanced the `expandAllowedPathsWithOutputDirs` function to automatically create directories specified in `allowed_paths` if they do not exist. This is done by resolving the absolute path and checking if the path is a directory or should be treated as one. If the directory does not exist, it is created, and a log entry is made to indicate the creation of the directory.
</details>

___
## User Description:
## Problem

When a workflow specifies `allowed_paths: [., .comanda]` but `.comanda/` doesn't exist, the agent gets permission errors trying to write files there — even though the path is explicitly allowed.

Example failure:
```yaml
agentic_loop:
  allowed_paths: [., .comanda]
  # ...
output: .comanda/ARCHITECTURE.md
```

Agent output: "DONE — ready to save whenever the write permission is granted"

## Solution

When expanding allowed_paths at agentic loop start, automatically create any directory paths that don't exist yet.

Directory paths are detected by:
- Ending with `/`
- Having no file extension
- Already existing as a directory

## Changes

- `expandAllowedPathsWithOutputDirs()` now also creates directories from `allowed_paths` (not just output dirs)
- Logs directory creation to stream output for visibility

## Testing

Existing tests pass. The fix is conservative — only creates directories, not files.
