### PR TITLE
fix(claudecode): add --allow-dangerously-skip-permissions flag

### DIFF
--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -337,9 +337,12 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 
 	// Enable bypass permissions for non-interactive agentic use
 	// Without this, Claude Code prompts for permission which blocks non-interactive execution
-	// Both flags are required: --dangerously-skip-permissions AND --permission-mode bypassPermissions
+	// Three flags may be required depending on Claude Code version:
+	// --allow-dangerously-skip-permissions (enables the bypass option)
+	// --dangerously-skip-permissions (activates bypass)
+	// --permission-mode bypassPermissions (sets the mode)
 	if len(allowedPaths) > 0 {
-		args = append(args, "--dangerously-skip-permissions", "--permission-mode", "bypassPermissions")
+		args = append(args, "--allow-dangerously-skip-permissions", "--dangerously-skip-permissions", "--permission-mode", "bypassPermissions")
 	}
 
 	// Restrict tools if specified


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Fixes an issue where Claude Code agentic workflows report 'write permissions not granted' despite correct `allowed_paths` configuration.
- Adds the `--allow-dangerously-skip-permissions` flag to ensure that permissions are bypassed correctly in non-interactive executions.
- Ensures compatibility with all recent Claude Code versions by including necessary flags.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/models/claudecode.go`: Modified the `buildArgsAgentic` function to include the `--allow-dangerously-skip-permissions` flag along with `--dangerously-skip-permissions` and `--permission-mode bypassPermissions` when `allowedPaths` are configured. This change ensures that the permissions are bypassed correctly for non-interactive agentic use in various versions of Claude Code.
</details>

___
## User Description:
## Problem

Claude Code agentic workflows report 'write permissions not granted' even when `allowed_paths` is correctly configured. The agent tries to write, gets blocked, and gives up.

Example log output:
```
Allowed paths: [/Users/krish/erebor/core-test/core /Users/krish/erebor/core-test/core/.comanda]
...
Output: It seems write permissions aren't being granted. Let me output the documentation directly as my iteration output.
```

## Root Cause

Some Claude Code versions require `--allow-dangerously-skip-permissions` to be passed *before* `--dangerously-skip-permissions` will work. Without this flag, Claude Code may still prompt for or deny permission to write files.

## Solution

Add `--allow-dangerously-skip-permissions` to the Claude Code invocation when agentic paths are configured.

## Testing

Built successfully. The fix adds a flag that is accepted by all recent Claude Code versions.
