### PR TITLE
fix(generate): add explicit permission guidance for agentic prompts

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -323,7 +323,14 @@ AGENTIC LOOP OUTPUT RULE: When generating agentic_loop workflows:
 2. ALWAYS use flat paths in .comanda/ directory - e.g., "output: .comanda/ARCHITECTURE.md" or "output: .comanda/analysis_report.md"
 3. Do NOT create subdirectories unless the user explicitly requests them
 4. The output file is automatically added to allowed_paths
-5. If user specifies a custom path like "./docs/", use it and ensure allowed_paths includes that directory`,
+5. If user specifies a custom path like "./docs/", use it and ensure allowed_paths includes that directory
+
+AGENTIC LOOP PROMPT REQUIREMENTS: When writing the 'action' prompt for agentic loops:
+1. Always include explicit write instructions - tell the agent it HAS permission to write
+2. Include this near the end of the action prompt:
+   "WRITE ACCESS: You have full write permission to all paths in allowed_paths. Write your content directly to files. Do not write meta-commentary about permissions - just write the actual content."
+3. If the workflow involves multi-iteration document building, remind the agent to READ the existing file first and APPEND/UPDATE rather than asking for permission
+4. Never let the agent assume it lacks permission - be explicit that it can and should write immediately`,
 		dslGuide, userPrompt)
 
 	// Add available codebase indexes if any exist

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -552,6 +552,40 @@ secure_task:
   output: STDOUT
 ```
 
+### Writing Effective Agentic Prompts
+
+When writing the `action` prompt for agentic loops, be explicit about permissions to avoid agent confusion:
+
+**Always include write permission confirmation:**
+```yaml
+action: |
+  Your task: Create comprehensive documentation for this codebase.
+  
+  ...task-specific instructions...
+  
+  WRITE ACCESS: You have full write permission to all paths in allowed_paths.
+  Write your content directly to files. Do not ask for permission or write
+  meta-commentary about permissions - just write the actual content.
+```
+
+**For multi-iteration document building:**
+```yaml
+action: |
+  Iteration {{ loop.iteration }} of {{ loop.total_iterations }}.
+  
+  ...iteration-specific instructions...
+  
+  Previous work: {{ loop.previous_output }}
+  
+  IMPORTANT:
+  - READ the existing output file first to see what's already written
+  - APPEND or UPDATE sections - don't start from scratch each iteration  
+  - You have full write access - write immediately, don't ask permission
+  - If the file contains permission-related text, overwrite it with real content
+```
+
+**Why this matters:** Agents can misinterpret early errors as permission denials and enter a confused state where they write complaints about permissions instead of actual content. Explicit permission confirmation prevents this loop.
+
 ### Error Handling
 
 When path access fails, comanda provides helpful error messages showing:


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Updated the `generate` command to require explicit write permission statements in agentic prompts.
- Added a new section "Writing Effective Agentic Prompts" in the LLM guide.
- Provided examples for single and multi-iteration workflows.
- Instructed agents to overwrite permission-complaint content with actual content.
- Aimed to fix the issue where agents write permission complaints instead of actual content due to misinterpreted errors.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/root.go`: Added requirements for agentic loop prompts to include explicit write instructions, ensuring agents know they have permission to write. Included guidance for multi-iteration document building to read and update existing files rather than asking for permission.
- `docs/comanda-llm-guide.md`: Introduced a new section "Writing Effective Agentic Prompts" that provides guidelines on including explicit write permission confirmations in prompts. Added examples for both single and multi-iteration document building workflows, emphasizing the importance of preventing agents from entering a confused state due to perceived permission issues.
</details>

___
## User Description:
## Problem

Agents can enter a confused state where they successfully write to files but fill them with permission complaints instead of actual content:

```
I need write permission to `.comanda/ARCHITECTURE.md` to proceed...
```

This happens when the agent misinterprets an early error as "no permission" and then compounds that belief across iterations.

## Solution

Update the `generate` command and LLM guide to require explicit write permission statements in agentic prompts.

**Generate prompt now requires:**
1. Explicit write permission statements in the action prompt
2. Instructions to overwrite permission-complaint content
3. Guidance for multi-iteration document building

**New LLM guide section: "Writing Effective Agentic Prompts"**
- Example prompts with permission confirmation
- Multi-iteration workflow patterns
- Explanation of why this matters

## Example

Generated prompts should now include:
```yaml
action: |
  ...task instructions...
  
  WRITE ACCESS: You have full write permission to all paths in allowed_paths.
  Write your content directly to files. Do not ask for permission or write
  meta-commentary about permissions - just write the actual content.
```
