### PR TITLE
fix(live): Disable spinner in TUI mode, add Ctrl+O output toggle

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -351,7 +351,7 @@ func runLiveProcess(args []string) {
 	// Run the processor in a goroutine
 	processDone := make(chan error, 1)
 	go func() {
-		err := runWorkflowWithStreamLog(workflowFile, tmpLogPath)
+		err := runWorkflowWithStreamLog(workflowFile, tmpLogPath, true) // true = disable spinner for TUI mode
 		reporter.Complete(err)
 		processDone <- err
 	}()
@@ -369,7 +369,8 @@ func runLiveProcess(args []string) {
 }
 
 // runWorkflowWithStreamLog runs a single workflow with stream logging
-func runWorkflowWithStreamLog(workflowFile, streamLogPath string) error {
+// If disableSpinner is true, the CLI spinner is disabled (for TUI mode)
+func runWorkflowWithStreamLog(workflowFile, streamLogPath string, disableSpinner ...bool) error {
 	// Read YAML file
 	yamlFile, err := os.ReadFile(workflowFile)
 	if err != nil {
@@ -387,6 +388,11 @@ func runWorkflowWithStreamLog(workflowFile, streamLogPath string) error {
 	cliVars := parseVarsFlags(varsFlags, "")
 
 	proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, runtimeDir, cliVars)
+
+	// Disable spinner if requested (TUI mode handles progress display)
+	if len(disableSpinner) > 0 && disableSpinner[0] {
+		proc.DisableSpinner()
+	}
 
 	// Set up stream logging
 	if err := proc.SetStreamLog(streamLogPath); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -323,7 +323,14 @@ AGENTIC LOOP OUTPUT RULE: When generating agentic_loop workflows:
 2. ALWAYS use flat paths in .comanda/ directory - e.g., "output: .comanda/ARCHITECTURE.md" or "output: .comanda/analysis_report.md"
 3. Do NOT create subdirectories unless the user explicitly requests them
 4. The output file is automatically added to allowed_paths
-5. If user specifies a custom path like "./docs/", use it and ensure allowed_paths includes that directory`,
+5. If user specifies a custom path like "./docs/", use it and ensure allowed_paths includes that directory
+
+AGENTIC LOOP PROMPT REQUIREMENTS: When writing the 'action' prompt for agentic loops:
+1. Always include explicit write instructions - tell the agent it HAS permission to write
+2. Include this near the end of the action prompt:
+   "WRITE ACCESS: You have full write permission to all paths in allowed_paths. Write your content directly to files. Do not write meta-commentary about permissions - just write the actual content."
+3. If the workflow involves multi-iteration document building, remind the agent to READ the existing file first and APPEND/UPDATE rather than asking for permission
+4. Never let the agent assume it lacks permission - be explicit that it can and should write immediately`,
 		dslGuide, userPrompt)
 
 	// Add available codebase indexes if any exist

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -552,6 +552,40 @@ secure_task:
   output: STDOUT
 ```
 
+### Writing Effective Agentic Prompts
+
+When writing the `action` prompt for agentic loops, be explicit about permissions to avoid agent confusion:
+
+**Always include write permission confirmation:**
+```yaml
+action: |
+  Your task: Create comprehensive documentation for this codebase.
+  
+  ...task-specific instructions...
+  
+  WRITE ACCESS: You have full write permission to all paths in allowed_paths.
+  Write your content directly to files. Do not ask for permission or write
+  meta-commentary about permissions - just write the actual content.
+```
+
+**For multi-iteration document building:**
+```yaml
+action: |
+  Iteration {{ loop.iteration }} of {{ loop.total_iterations }}.
+  
+  ...iteration-specific instructions...
+  
+  Previous work: {{ loop.previous_output }}
+  
+  IMPORTANT:
+  - READ the existing output file first to see what's already written
+  - APPEND or UPDATE sections - don't start from scratch each iteration  
+  - You have full write access - write immediately, don't ask permission
+  - If the file contains permission-related text, overwrite it with real content
+```
+
+**Why this matters:** Agents can misinterpret early errors as permission denials and enter a confused state where they write complaints about permissions instead of actual content. Explicit permission confirmation prevents this loop.
+
 ### Error Handling
 
 When path access fails, comanda provides helpful error messages showing:

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -414,6 +414,11 @@ func (p *Processor) SetProgressWriter(w ProgressWriter) {
 	p.spinner.SetProgressWriter(w)
 }
 
+// DisableSpinner disables the CLI spinner (use when running in TUI mode)
+func (p *Processor) DisableSpinner() {
+	p.spinner.Disable()
+}
+
 // SetStreamLog sets up stream logging to a file for real-time monitoring
 func (p *Processor) SetStreamLog(path string) error {
 	if path == "" {

--- a/utils/tui/dashboard.go
+++ b/utils/tui/dashboard.go
@@ -46,21 +46,24 @@ type DashboardModel struct {
 	eventChan   chan ProgressEvent
 	reporter    *ProgressReporter
 	quitting    bool
-	verbose     bool
-	debugMode   bool
-	debugScroll int
-	maxActivity int
-	maxOutput   int
-	maxDebug    int
-	debugWriter *DebugWriter
+	verbose        bool
+	debugMode      bool
+	debugScroll    int
+	outputExpanded bool
+	outputScroll   int
+	maxActivity    int
+	maxOutput      int
+	maxDebug       int
+	debugWriter    *DebugWriter
 }
 
 type dashboardKeyMap struct {
-	Quit        key.Binding
-	Verbose     key.Binding
-	ToggleDebug key.Binding
-	ScrollUp    key.Binding
-	ScrollDown  key.Binding
+	Quit         key.Binding
+	Verbose      key.Binding
+	ToggleDebug  key.Binding
+	ToggleOutput key.Binding
+	ScrollUp     key.Binding
+	ScrollDown   key.Binding
 }
 
 func defaultDashboardKeyMap() dashboardKeyMap {
@@ -76,6 +79,10 @@ func defaultDashboardKeyMap() dashboardKeyMap {
 		ToggleDebug: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("d", "debug panel"),
+		),
+		ToggleOutput: key.NewBinding(
+			key.WithKeys("ctrl+o"),
+			key.WithHelp("^O", "expand output"),
 		),
 		ScrollUp: key.NewBinding(
 			key.WithKeys("k", "up"),
@@ -172,12 +179,22 @@ func (m *DashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.verbose = !m.verbose
 		case key.Matches(msg, m.keymap.ToggleDebug):
 			m.debugMode = !m.debugMode
+		case key.Matches(msg, m.keymap.ToggleOutput):
+			m.outputExpanded = !m.outputExpanded
+			m.outputScroll = 0 // Reset scroll when toggling
 		case key.Matches(msg, m.keymap.ScrollUp):
-			if m.debugMode && m.debugScroll > 0 {
+			if m.outputExpanded && m.outputScroll > 0 {
+				m.outputScroll--
+			} else if m.debugMode && m.debugScroll > 0 {
 				m.debugScroll--
 			}
 		case key.Matches(msg, m.keymap.ScrollDown):
-			if m.debugMode && m.debugScroll < len(m.debugLines)-m.maxDebug {
+			if m.outputExpanded {
+				maxScroll := len(m.outputLines) - m.getOutputPanelHeight()
+				if maxScroll > 0 && m.outputScroll < maxScroll {
+					m.outputScroll++
+				}
+			} else if m.debugMode && m.debugScroll < len(m.debugLines)-m.maxDebug {
 				m.debugScroll++
 			}
 		}
@@ -284,6 +301,15 @@ func (m *DashboardModel) View() string {
 
 	if m.width == 0 {
 		return "Loading..."
+	}
+
+	// In expanded output mode, show only header, output, and footer
+	if m.outputExpanded {
+		var sections []string
+		sections = append(sections, m.renderHeader())
+		sections = append(sections, m.renderExpandedOutput())
+		sections = append(sections, m.renderFooter())
+		return lipgloss.JoinVertical(lipgloss.Left, sections...)
 	}
 
 	var sections []string
@@ -528,6 +554,57 @@ func (m *DashboardModel) renderOutput() string {
 	return boxStyle.Render(content.String())
 }
 
+func (m *DashboardModel) renderExpandedOutput() string {
+	panelHeight := m.getOutputPanelHeight()
+	boxStyle := m.theme.BoxNormal.Width(m.width - 4).Height(panelHeight + 2)
+
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Secondary)
+	mutedStyle := lipgloss.NewStyle().Foreground(m.theme.Muted)
+
+	var content strings.Builder
+	content.WriteString(labelStyle.Render("OUTPUT"))
+	content.WriteString(mutedStyle.Render(" (expanded)"))
+
+	// Show scroll position if scrollable
+	totalLines := len(m.outputLines)
+	if totalLines > panelHeight {
+		content.WriteString(mutedStyle.Render(fmt.Sprintf(" (%d-%d of %d) ↑↓ scroll",
+			m.outputScroll+1,
+			min(m.outputScroll+panelHeight, totalLines),
+			totalLines,
+		)))
+	} else {
+		content.WriteString(mutedStyle.Render(fmt.Sprintf(" (%d lines)", totalLines)))
+	}
+	content.WriteString("\n")
+
+	if totalLines == 0 {
+		content.WriteString(mutedStyle.Italic(true).Render("  No output yet..."))
+	} else {
+		// Calculate visible range
+		start := m.outputScroll
+		end := start + panelHeight
+		if end > totalLines {
+			end = totalLines
+			start = end - panelHeight
+			if start < 0 {
+				start = 0
+			}
+		}
+
+		for _, line := range m.outputLines[start:end] {
+			// Truncate long lines
+			maxLen := m.width - 10
+			if len(line) > maxLen {
+				line = line[:maxLen-3] + "..."
+			}
+			content.WriteString("  " + line + "\n")
+		}
+	}
+
+	return boxStyle.Render(content.String())
+}
+
 func (m *DashboardModel) renderDebugPanel() string {
 	// Calculate available height for debug panel
 	panelHeight := m.maxDebug
@@ -601,9 +678,14 @@ func (m *DashboardModel) renderFooter() string {
 		Align(lipgloss.Center).
 		MarginTop(1)
 
-	keys := []string{"q quit", "v verbose", "d debug"}
-	if m.debugMode && len(m.debugLines) > m.maxDebug {
-		keys = append(keys, "↑↓ scroll")
+	var keys []string
+	if m.outputExpanded {
+		keys = []string{"q quit", "^O collapse", "↑↓ scroll"}
+	} else {
+		keys = []string{"q quit", "v verbose", "d debug", "^O output"}
+		if m.debugMode && len(m.debugLines) > m.maxDebug {
+			keys = append(keys, "↑↓ scroll")
+		}
 	}
 	help := strings.Join(keys, "  •  ")
 
@@ -644,4 +726,16 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// getOutputPanelHeight returns the height of the output panel based on expanded state
+func (m *DashboardModel) getOutputPanelHeight() int {
+	if !m.outputExpanded {
+		return m.maxOutput
+	}
+	// In expanded mode, use most of the screen
+	if m.height > 10 {
+		return m.height - 8 // Leave room for header and footer
+	}
+	return 20
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Disables the CLI spinner when running in `--live` TUI mode to prevent multi-line artifacts.
- Introduces a new feature allowing users to toggle between normal and expanded output views using Ctrl+O.
- In expanded mode, the output panel occupies most of the screen with full scroll support.
- Adds new methods and state variables to support these features.
- Updates the footer to dynamically show relevant key hints.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/process.go`: Modified the `runWorkflowWithStreamLog` function to accept a `disableSpinner` parameter, which disables the spinner in TUI mode.
- `utils/processor/dsl.go`: Added a `DisableSpinner` method to the `Processor` struct to disable the CLI spinner when in TUI mode.
- `utils/tui/dashboard.go`: Enhanced the `DashboardModel` to include `outputExpanded` and `outputScroll` states. Added a new keybinding for toggling output view with Ctrl+O. Implemented logic to handle expanded output view, including scroll functionality and dynamic footer updates.
- `docs/comanda-llm-guide.md`: Added a section on writing effective agentic prompts, emphasizing the importance of explicit write permission instructions to prevent agents from entering a confused state.
</details>

___
## User Description:
## Changes

### Bug Fix: Processing line going multi-line
- Disables the CLI spinner when running in `--live` TUI mode
- The spinner was printing directly to stdout with carriage returns, which conflicted with the alt-screen TUI and caused multi-line artifacts

### New Feature: Ctrl+O expanded output view
- Press **Ctrl+O** to toggle between normal and expanded output view
- In expanded mode:
  - Output panel takes up most of the screen
  - Full scroll support with ↑/↓ keys
  - Shows scroll position indicator (e.g., "25-50 of 120")
- Press **Ctrl+O** again to collapse back to normal view

### Technical Details
- Added `DisableSpinner()` method to `Processor` for TUI mode
- Added `outputExpanded` and `outputScroll` state to dashboard model
- Added `ToggleOutput` keybinding (`ctrl+o`)
- Footer updates dynamically to show relevant key hints

## Testing
- `go build ./...` ✓
- `go test ./utils/tui/...` ✓
