### PR TITLE
fix: default runtimeDir to workflow directory when not specified

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -132,10 +132,31 @@ Input can be provided via:
 				Enabled: false, // Disable server mode for CLI processing
 			}
 
+			// Default runtimeDir to workflow file's directory if not specified
+			// This ensures Claude Code runs in the project directory, not a temp folder
+			effectiveRuntimeDir := runtimeDir
+			if effectiveRuntimeDir == "" {
+				effectiveRuntimeDir = filepath.Dir(file)
+				if effectiveRuntimeDir == "." {
+					// Get absolute path for current directory
+					if cwd, err := os.Getwd(); err == nil {
+						effectiveRuntimeDir = cwd
+					}
+				} else {
+					// Resolve to absolute path
+					if absPath, err := filepath.Abs(effectiveRuntimeDir); err == nil {
+						effectiveRuntimeDir = absPath
+					}
+				}
+				if verbose {
+					log.Printf("[DEBUG] No --runtime-dir specified, using workflow directory: %s\n", effectiveRuntimeDir)
+				}
+			}
+
 			// Parse CLI variables
 			cliVars := parseVarsFlags(varsFlags, stdinData)
 
-			proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, runtimeDir, cliVars)
+			proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, effectiveRuntimeDir, cliVars)
 
 			// Set up stream logging if requested
 			if streamLogFile != "" {
@@ -387,7 +408,22 @@ func runWorkflowWithStreamLog(workflowFile, streamLogPath string, disableSpinner
 	serverConfig := &config.ServerConfig{Enabled: false}
 	cliVars := parseVarsFlags(varsFlags, "")
 
-	proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, runtimeDir, cliVars)
+	// Default runtimeDir to workflow file's directory if not specified
+	effectiveRuntimeDir := runtimeDir
+	if effectiveRuntimeDir == "" {
+		effectiveRuntimeDir = filepath.Dir(workflowFile)
+		if effectiveRuntimeDir == "." {
+			if cwd, err := os.Getwd(); err == nil {
+				effectiveRuntimeDir = cwd
+			}
+		} else {
+			if absPath, err := filepath.Abs(effectiveRuntimeDir); err == nil {
+				effectiveRuntimeDir = absPath
+			}
+		}
+	}
+
+	proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, effectiveRuntimeDir, cliVars)
 
 	// Disable spinner if requested (TUI mode handles progress display)
 	if len(disableSpinner) > 0 && disableSpinner[0] {


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- When the `--runtime-dir` flag is not provided, default the `runtimeDir` to the workflow file's directory.
- Ensures Claude Code runs in the project context rather than a temporary folder.
- Corrects file operations by resolving `allowed_paths` relative to the project directory.
- Applied changes to both `processCmd` and `runWorkflowWithStreamLog` functions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/process.go`: - Introduced logic to set `effectiveRuntimeDir` to the workflow file's directory if `runtimeDir` is not specified.
- Added checks to resolve the directory to an absolute path and handle cases where the directory is the current directory.
- Updated the processor initialization to use `effectiveRuntimeDir` instead of `runtimeDir`.
- Added debug logging to inform when the workflow directory is used as the runtime directory.
</details>

___
## User Description:
## Problem

When `--runtime-dir` flag is not provided, `runtimeDir` stays empty. This caused Claude Code to run in whatever the current working directory was — often a temp folder like `/var/folders/jj/.../T` where the prompt file was written.

Debug output showed:
```
[DEBUG][ClaudeCode] Starting claude command in /var/folders/jj/0fmlymc157b1lwmwt70vb8hc0000gn/T
```

This breaks file operations because `allowed_paths: [., .comanda]` are resolved relative to that temp folder, not the project.

## Solution

Default `runtimeDir` to the **workflow file's directory** when not explicitly specified. This ensures:
- Claude Code runs in the project context
- `allowed_paths` resolve correctly
- File writes go to the expected location

Applied to both process command paths (`processCmd` and `runWorkflowWithStreamLog`).
