### PR TITLE
fix: disable progress display in --live TUI mode

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -425,9 +425,10 @@ func runWorkflowWithStreamLog(workflowFile, streamLogPath string, disableSpinner
 
 	proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, effectiveRuntimeDir, cliVars)
 
-	// Disable spinner if requested (TUI mode handles progress display)
+	// Disable spinner and progress display if requested (TUI mode handles progress display)
 	if len(disableSpinner) > 0 && disableSpinner[0] {
 		proc.DisableSpinner()
+		proc.DisableProgressDisplay()
 	}
 
 	// Set up stream logging

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -419,6 +419,11 @@ func (p *Processor) DisableSpinner() {
 	p.spinner.Disable()
 }
 
+// DisableProgressDisplay disables the progress display output (use when running in TUI mode)
+func (p *Processor) DisableProgressDisplay() {
+	p.progressDisplay.SetEnabled(false)
+}
+
 // SetStreamLog sets up stream logging to a file for real-time monitoring
 func (p *Processor) SetStreamLog(path string) error {
 	if path == "" {


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Disables the `ProgressDisplay` when running in `--live` TUI mode to prevent text overlap and rendering issues.
- Adds a new method `DisableProgressDisplay()` to the `Processor` to handle this functionality.
- Updates `runWorkflowWithStreamLog()` to call `DisableProgressDisplay()` when the `disableSpinner` flag is set, indicating TUI mode.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/process.go`: Modified the `runWorkflowWithStreamLog` function to call `DisableProgressDisplay()` on the `Processor` instance when the `disableSpinner` flag is set, ensuring that both the spinner and progress display are disabled in TUI mode.
- `utils/processor/dsl.go`: Added a new method `DisableProgressDisplay()` to the `Processor` struct. This method sets the `progressDisplay` to disabled, preventing it from outputting completion summaries when in TUI mode.
</details>

___
## User Description:
## Problem

When using `--live` mode, the TUI dashboard (bubbletea) takes over the terminal with alt-screen mode. However, after the workflow completes and the TUI exits, the `ProgressDisplay` still outputs completion summaries to stdout.

This causes text overlap and garbled output as shown in the issue report — the completion summary renders on top of the previous TUI output.

## Fix

Disable `ProgressDisplay` when in TUI mode, alongside the already-disabled spinner. The TUI dashboard already shows workflow completion status via the `complete` event type in the progress reporter.

## Changes

- Added `DisableProgressDisplay()` method to `Processor`
- Called it in `runWorkflowWithStreamLog()` when the `disableSpinner` flag is set (which indicates TUI mode)

## Testing

Tested with a multi-iteration agentic loop workflow using `--live` mode. The completion summary no longer overlaps with the TUI output.
