### PR TITLE
fix: bias generate command toward linear workflows over agentic loops

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -316,6 +316,13 @@ func buildGeneratePrompt(dslGuide, userPrompt string, invalidModels []string, st
 
 User's request: %s
 
+WORKFLOW TYPE — DECIDE BEFORE GENERATING:
+Classify the request before writing any YAML. Use this decision tree:
+1. Does the task require iterating an unknown number of times until a quality condition is met (e.g., "keep fixing until tests pass")? → Use an AGENTIC LOOP.
+2. Otherwise → Use a LINEAR WORKFLOW (named steps that each run once).
+
+LINEAR WORKFLOW is the default. If the request mentions named input files, reference documents to consult, and/or a defined output format or output file, it is ALWAYS a linear workflow — never an agentic loop.
+
 CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.
 
 AGENTIC LOOP OUTPUT RULE: When generating agentic_loop workflows:

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -323,11 +323,19 @@ step_name_for_processing:
 
 Agentic loops enable iterative LLM processing until an exit condition is met. This is powerful for tasks that require refinement, multi-step reasoning, or autonomous decision-making.
 
-**When to use agentic loops:**
-- Iterative code improvement (analyze → fix → verify cycles)
-- Multi-step planning and execution
-- Tasks where the LLM decides when work is complete
-- Refinement workflows (draft → improve → finalize)
+**⚠️ DEFAULT TO LINEAR WORKFLOWS. Use agentic loops ONLY when true iteration is required.**
+
+**When to use agentic loops (ONLY for genuine iteration):**
+- Iterative code improvement where quality gates determine completion (analyze → fix → verify until tests pass)
+- Tasks where the number of iterations is genuinely unknown and the LLM must decide when done
+- Autonomous retry loops driven by external feedback (e.g., test failures, validator output)
+
+**When NOT to use agentic loops — use linear steps instead:**
+- Reading named input files, consulting reference documents, writing to a specified output — ALWAYS linear
+- Any "read A, consult B, process C, write output.md" pattern — LINEAR, not agentic
+- Workflows with defined inputs and a specified output format — use linear steps
+- Document analysis, report generation, financial analysis, credit underwriting, data extraction — linear workflows
+- When all steps are known in advance and each executes exactly once — use linear steps
 
 ### Inline Syntax (Single-Step Loop)
 
@@ -1468,13 +1476,20 @@ analyze_document:
 - Using tool commands to pre-process data before LLM analysis
 - Generating a workflow dynamically, then executing it
 - Tasks that genuinely require different models for different capabilities
-- **Agentic loops** for iterative refinement, planning, or autonomous decision-making
 
-**When to use Agentic Loops:**
-- Code improvement cycles (analyze → fix → verify)
-- Planning and execution workflows
-- Tasks where quality depends on iteration
-- When the LLM should decide when work is complete
+**⚠️ DEFAULT TO LINEAR WORKFLOWS. Agentic loops are the rare exception.**
+
+**When to use Agentic Loops (ONLY for genuine iteration):**
+- Code improvement cycles where quality gates determine completion (analyze → fix → verify until tests pass)
+- Tasks where the number of iterations is genuinely unknown and the LLM must decide when done
+- Autonomous retry loops driven by external feedback (e.g., test failures, validator output)
+
+**When NOT to use Agentic Loops — use linear steps instead:**
+- Reading named input files, consulting reference documents, writing to a specified output — this is ALWAYS linear
+- Any "read A, consult B, process C, write output.md" pattern — LINEAR, not agentic
+- Workflows with defined inputs and a specified output format — use linear steps, not loops
+- Document analysis, report generation, financial analysis, data extraction — linear workflows
+- When all steps are known in advance and each executes exactly once — use linear steps
 
 This guide covers the core concepts and syntax of Comanda's YAML DSL, including meta-processing capabilities. LLMs should use this structure to generate valid workflow files.`
 
@@ -1672,11 +1687,19 @@ step_name_for_processing:
 
 Agentic loops enable iterative LLM processing until an exit condition is met. This is powerful for tasks that require refinement, multi-step reasoning, or autonomous decision-making.
 
-**When to use agentic loops:**
-- Iterative code improvement (analyze → fix → verify cycles)
-- Multi-step planning and execution
-- Tasks where the LLM decides when work is complete
-- Refinement workflows (draft → improve → finalize)
+**⚠️ DEFAULT TO LINEAR WORKFLOWS. Use agentic loops ONLY when true iteration is required.**
+
+**When to use agentic loops (ONLY for genuine iteration):**
+- Iterative code improvement where quality gates determine completion (analyze → fix → verify until tests pass)
+- Tasks where the number of iterations is genuinely unknown and the LLM must decide when done
+- Autonomous retry loops driven by external feedback (e.g., test failures, validator output)
+
+**When NOT to use agentic loops — use linear steps instead:**
+- Reading named input files, consulting reference documents, writing to a specified output — ALWAYS linear
+- Any "read A, consult B, process C, write output.md" pattern — LINEAR, not agentic
+- Workflows with defined inputs and a specified output format — use linear steps
+- Document analysis, report generation, financial analysis, credit underwriting, data extraction — linear workflows
+- When all steps are known in advance and each executes exactly once — use linear steps
 
 ### Inline Syntax (Single-Step Loop)
 
@@ -3201,12 +3224,19 @@ analyze_document:
 - Using tool commands to pre-process data before LLM analysis
 - Generating a workflow dynamically, then executing it
 - Tasks that genuinely require different models for different capabilities
-- **Agentic loops** for iterative refinement, planning, or autonomous decision-making
 
-**When to use Agentic Loops:**
-- Code improvement cycles (analyze → fix → verify)
-- Planning and execution workflows
-- Tasks where quality depends on iteration
-- When the LLM should decide when work is complete
+**⚠️ DEFAULT TO LINEAR WORKFLOWS. Agentic loops are the rare exception.**
+
+**When to use Agentic Loops (ONLY for genuine iteration):**
+- Code improvement cycles where quality gates determine completion (analyze → fix → verify until tests pass)
+- Tasks where the number of iterations is genuinely unknown and the LLM must decide when done
+- Autonomous retry loops driven by external feedback (e.g., test failures, validator output)
+
+**When NOT to use Agentic Loops — use linear steps instead:**
+- Reading named input files, consulting reference documents, writing to a specified output — this is ALWAYS linear
+- Any "read A, consult B, process C, write output.md" pattern — LINEAR, not agentic
+- Workflows with defined inputs and a specified output format — use linear steps, not loops
+- Document analysis, report generation, financial analysis, data extraction — linear workflows
+- When all steps are known in advance and each executes exactly once — use linear steps
 
 This guide covers the core concepts and syntax of Comanda's YAML DSL, including meta-processing capabilities. LLMs should use this structure to generate valid workflow files.`

--- a/utils/server/generate_handler.go
+++ b/utils/server/generate_handler.go
@@ -208,6 +208,13 @@ func buildServerGeneratePrompt(dslGuide, userPrompt string, invalidModels []stri
 
 User's request: %s
 
+WORKFLOW TYPE — DECIDE BEFORE GENERATING:
+Classify the request before writing any YAML. Use this decision tree:
+1. Does the task require iterating an unknown number of times until a quality condition is met (e.g., "keep fixing until tests pass")? → Use an AGENTIC LOOP.
+2. Otherwise → Use a LINEAR WORKFLOW (named steps that each run once).
+
+LINEAR WORKFLOW is the default. If the request mentions named input files, reference documents to consult, and/or a defined output format or output file, it is ALWAYS a linear workflow — never an agentic loop.
+
 CRITICAL INSTRUCTION: Your entire response must be valid YAML syntax that can be directly saved to a .yaml file. Do not include ANY text before or after the YAML content. Start your response with the first line of YAML and end with the last line of YAML.`,
 		dslGuide, userPrompt)
 


### PR DESCRIPTION
## Summary

- Rewrites the "when to use agentic loops" criteria in `embedded_guide.go` (both the static and template copies) to be far more restrictive, adding an explicit "When NOT to use agentic loops" section with concrete examples (document analysis, report generation, credit underwriting, read→consult→write patterns)
- Adds a "WORKFLOW TYPE — DECIDE BEFORE GENERATING" classification block to `buildGeneratePrompt()` (`cmd/root.go`) and `buildServerGeneratePrompt()` (`generate_handler.go`) that instructs the LLM to default to linear workflows and only reach for agentic loops when genuine iteration is required

## Test plan

- [ ] All existing tests pass (`go test ./...` — confirmed green)
- [ ] Manual: run `comanda generate` with the venture debt underwriting prompt from the issue — should produce a linear multi-step YAML (read COMPANY_INFO.md, consult POLICY.md, check COMP_TRANSACTIONS.md, write output file) instead of an agentic loop
- [ ] Manual: run `comanda generate` with a genuine iteration prompt (e.g., "keep improving the code until tests pass") — should still produce an agentic loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)