### PR TITLE
[fix] Tighten workflow validation and examples coverage

### DIFF
--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -509,6 +509,7 @@ document_codebase:
 - `exit_condition`: (string) When to stop - `llm_decides` (agent says DONE) or `pattern_match`
 - `allowed_paths`: (list of strings) Directories the agent can access
 - `tools`: (list of strings, optional) Tool whitelist - Read, Write, Edit, Bash, etc.
+- `prompt_improvement`: (map, optional) Automatically refine the next iteration's prompt based on the latest result
 
 ### Simplified Path Configuration
 
@@ -583,6 +584,20 @@ action: |
   - You have full write access - write immediately, don't ask permission
   - If the file contains permission-related text, overwrite it with real content
 ```
+
+**For self-improving prompt loops:**
+```yaml
+agentic_loop:
+  max_iterations: 5
+  prompt_improvement:
+    enabled: true
+    instructions: |
+      Tighten the next prompt using the latest result.
+      Keep the user's goal, preserve what worked, and make the next prompt
+      more specific and actionable.
+```
+
+This stores the refined prompt for the next pass and exposes it as `{{ loop.current_prompt }}` alongside `{{ loop.previous_output }}`.
 
 **Why this matters:** Agents can misinterpret early errors as permission denials and enter a confused state where they write complaints about permissions instead of actual content. Explicit permission confirmation prevents this loop.
 

--- a/examples/agentic-loop/code-quality-loop.yaml
+++ b/examples/agentic-loop/code-quality-loop.yaml
@@ -24,6 +24,12 @@ agentic-loop:
     max_iterations: 10
     timeout_seconds: 0
     checkpoint_interval: 2
+    prompt_improvement:
+      enabled: true
+      instructions: |
+        Refine the next iteration's prompt using the latest result.
+        Keep the goal the same, preserve effective tactics, and make the next
+        prompt more specific about what to inspect or change.
 
     # Multiple quality gates
     quality_gates:
@@ -57,6 +63,7 @@ agentic-loop:
 
           Current iteration: {{ loop.iteration }}/{{ loop.total_iterations }}
           Elapsed: {{ loop.elapsed_seconds }} seconds
+          Current refined prompt: {{ loop.current_prompt }}
 
           Instructions:
           1. Read files in ./src or ./lib (if they exist)

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -3,455 +3,279 @@ package examples
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
+	processor "github.com/kris-hansen/comanda/utils/processor"
 	"gopkg.in/yaml.v3"
 )
 
-func TestYAMLFiles(t *testing.T) {
-	// Directories to check for YAML files
-	dirs := []string{
-		".",
-		"model-examples",
-		"file-processing",
-		"web-scraping",
-		"document-processing",
-		"image-processing",
+func TestExampleWorkflowsValidateAndParse(t *testing.T) {
+	files := discoverExampleYAMLFiles(t)
+	if len(files) == 0 {
+		t.Fatal("no YAML files found in examples directory")
 	}
 
-	yamlCount := 0
-	for _, dir := range dirs {
-		files, err := os.ReadDir(dir)
-		if err != nil {
-			t.Fatalf("Failed to read directory %s: %v", dir, err)
-		}
-
-		for _, file := range files {
-			if !file.IsDir() && strings.HasSuffix(file.Name(), ".yaml") {
-				yamlCount++
-				filePath := filepath.Join(dir, file.Name())
-				t.Run(filePath, func(t *testing.T) {
-					validateYAMLFile(t, filePath)
-				})
+	for _, filename := range files {
+		t.Run(filename, func(t *testing.T) {
+			content, err := os.ReadFile(filename)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", filename, err)
 			}
-		}
-	}
 
-	if yamlCount == 0 {
-		t.Error("No YAML files found in examples directory")
+			var root yaml.Node
+			if err := yaml.Unmarshal(content, &root); err != nil {
+				t.Fatalf("failed to parse YAML in %s: %v", filename, err)
+			}
+
+			validationResult := processor.ValidateWorkflowStructure(string(content))
+			if !validationResult.Valid {
+				t.Fatalf("workflow validation failed for %s:\n%s", filename, validationResult.ErrorSummary())
+			}
+
+			var config processor.DSLConfig
+			if err := yaml.Unmarshal(content, &config); err != nil {
+				t.Fatalf("failed to parse workflow into DSLConfig for %s: %v", filename, err)
+			}
+		})
 	}
 }
 
-func validateYAMLFile(t *testing.T, filename string) {
-	content, err := os.ReadFile(filename)
+func TestExampleReferencedInputsExist(t *testing.T) {
+	files := discoverExampleYAMLFiles(t)
+
+	for _, filename := range files {
+		t.Run(filename, func(t *testing.T) {
+			content, err := os.ReadFile(filename)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", filename, err)
+			}
+
+			var root yaml.Node
+			if err := yaml.Unmarshal(content, &root); err != nil {
+				t.Fatalf("failed to parse YAML in %s: %v", filename, err)
+			}
+
+			if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+				t.Fatalf("file %s: expected document node at root", filename)
+			}
+
+			outputFiles := make(map[string]bool)
+			collectOutputFiles(root.Content[0], outputFiles)
+			validateReferencedPaths(t, filename, root.Content[0], outputFiles)
+		})
+	}
+}
+
+func discoverExampleYAMLFiles(t *testing.T) []string {
+	t.Helper()
+
+	var files []string
+	err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".yaml") {
+			files = append(files, path)
+		}
+		return nil
+	})
 	if err != nil {
-		t.Errorf("Failed to read file %s: %v", filename, err)
+		t.Fatalf("failed to walk examples directory: %v", err)
+	}
+
+	sort.Strings(files)
+	return files
+}
+
+func collectOutputFiles(node *yaml.Node, outputFiles map[string]bool) {
+	if node == nil {
 		return
 	}
 
-	var root yaml.Node
-	err = yaml.Unmarshal(content, &root)
-	if err != nil {
-		t.Errorf("Failed to parse YAML in %s: %v", filename, err)
-		return
-	}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			collectOutputFiles(child, outputFiles)
+		}
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			value := node.Content[i+1]
 
-	// Root should be a document
-	if root.Kind != yaml.DocumentNode {
-		t.Errorf("File %s: expected document node at root", filename)
-		return
-	}
+			switch key {
+			case "output":
+				collectScalarOutputs(value, outputFiles)
+			case "capture_outputs":
+				collectScalarOutputs(value, outputFiles)
+			}
 
-	// Document should contain a mapping
-	doc := root.Content[0]
-	if doc.Kind != yaml.MappingNode {
-		t.Errorf("File %s: expected mapping node as document content", filename)
-		return
-	}
-
-	// First pass: collect all output files
-	outputFiles := make(map[string]bool)
-	for i := 0; i < len(doc.Content); i += 2 {
-		value := doc.Content[i+1]
-		if value.Kind == yaml.MappingNode {
 			collectOutputFiles(value, outputFiles)
 		}
-	}
-
-	// Validate each step in the document
-	foundSteps := false
-	for i := 0; i < len(doc.Content); i += 2 {
-		key := doc.Content[i]
-		value := doc.Content[i+1]
-
-		// Consider any mapping with the required fields as a step
-		if value.Kind == yaml.MappingNode {
-			foundSteps = true
-			validateStep(t, filename, key.Value, value, outputFiles)
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			collectOutputFiles(child, outputFiles)
 		}
-	}
-
-	if !foundSteps {
-		t.Errorf("File %s contains no valid steps", filename)
 	}
 }
 
-func collectOutputFiles(stepNode *yaml.Node, outputFiles map[string]bool) {
-	for i := 0; i < len(stepNode.Content); i += 2 {
-		key := stepNode.Content[i].Value
-		value := stepNode.Content[i+1]
-
-		if key == "output" {
-			if value.Kind == yaml.ScalarNode {
-				outputFiles[value.Value] = true
-			} else if value.Kind == yaml.SequenceNode {
-				for _, item := range value.Content {
-					outputFiles[item.Value] = true
-				}
-			}
-		} else if key == "generate" && value.Kind == yaml.MappingNode {
-			// Look for output within a generate block
-			for j := 0; j < len(value.Content); j += 2 {
-				genKey := value.Content[j].Value
-				genValue := value.Content[j+1]
-				if genKey == "output" && genValue.Kind == yaml.ScalarNode {
-					outputFiles[genValue.Value] = true
-				}
-			}
-		} else if key == "process" && value.Kind == yaml.MappingNode {
-			// Look for capture_outputs within a process block
-			for j := 0; j < len(value.Content); j += 2 {
-				procKey := value.Content[j].Value
-				procValue := value.Content[j+1]
-				if procKey == "capture_outputs" && procValue.Kind == yaml.SequenceNode {
-					for _, item := range procValue.Content {
-						if item.Kind == yaml.ScalarNode {
-							outputFiles[item.Value] = true
-						}
-					}
-				}
+func collectScalarOutputs(node *yaml.Node, outputFiles map[string]bool) {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		outputFiles[node.Value] = true
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if item.Kind == yaml.ScalarNode {
+				outputFiles[item.Value] = true
 			}
 		}
 	}
 }
 
-func validateStep(t *testing.T, filename, stepName string, stepNode *yaml.Node, outputFiles map[string]bool) {
-	if stepNode.Kind != yaml.MappingNode {
-		t.Errorf("Step %s in %s: expected mapping node", stepName, filename)
+func validateReferencedPaths(t *testing.T, filename string, node *yaml.Node, outputFiles map[string]bool) {
+	t.Helper()
+
+	if node == nil {
 		return
 	}
 
-	// Check if this is a generate or process step
-	isGenerateStep := false
-	isProcessStep := false
-	isResponsesStep := false
-	stepType := ""
-
-	for i := 0; i < len(stepNode.Content); i += 2 {
-		key := stepNode.Content[i].Value
-		value := stepNode.Content[i+1]
-		if key == "generate" {
-			isGenerateStep = true
-		} else if key == "process" {
-			isProcessStep = true
-		} else if key == "type" && value.Kind == yaml.ScalarNode {
-			stepType = value.Value
-			if stepType == "openai-responses" {
-				isResponsesStep = true
-			}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			validateReferencedPaths(t, filename, child, outputFiles)
 		}
-	}
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			value := node.Content[i+1]
 
-	// If it's a generate or process step, validate differently
-	if isGenerateStep {
-		validateGenerateStep(t, filename, stepName, stepNode, outputFiles)
-		return
-	} else if isProcessStep {
-		validateProcessStep(t, filename, stepName, stepNode, outputFiles)
-		return
-	}
-
-	// Standard step validation
-	requiredFields := map[string]bool{
-		"input":  false,
-		"model":  false,
-		"output": false,
-	}
-
-	// For responses steps, either action or instructions is required
-	// For standard steps, action is required
-	if isResponsesStep {
-		requiredFields["action or instructions"] = false
-	} else {
-		requiredFields["action"] = false
-	}
-
-	for i := 0; i < len(stepNode.Content); i += 2 {
-		key := stepNode.Content[i].Value
-		value := stepNode.Content[i+1]
-
-		// Special handling for instructions or action in responses steps
-		if isResponsesStep && (key == "instructions" || key == "action") {
-			requiredFields["action or instructions"] = true
-		}
-
-		if _, required := requiredFields[key]; required {
-			requiredFields[key] = true
-
-			if key == "input" {
-				// Allow scalar, sequence, or mapping for 'input'
-				if value.Kind != yaml.ScalarNode && value.Kind != yaml.SequenceNode && value.Kind != yaml.MappingNode {
-					t.Errorf("Step %s in %s: field '%s' must be either a string, array, or mapping", stepName, filename, key)
-					continue
-				}
-			} else {
-				// For other fields, allow only scalar or sequence
-				if value.Kind != yaml.ScalarNode && value.Kind != yaml.SequenceNode {
-					t.Errorf("Step %s in %s: field '%s' must be either a string or array", stepName, filename, key)
-					continue
-				}
-			}
-
-			// For sequence nodes, ensure they're not empty
-			if value.Kind == yaml.SequenceNode && len(value.Content) == 0 {
-				t.Errorf("Step %s in %s: field '%s' array is empty", stepName, filename, key)
-				continue
-			}
-
-			// For scalar nodes, ensure they're not empty
-			if value.Kind == yaml.ScalarNode && value.Value == "" {
-				t.Errorf("Step %s in %s: field '%s' is empty", stepName, filename, key)
-				continue
-			}
-
-			// Validate input paths if key is 'input'
-			if key == "input" {
+			switch key {
+			case "input":
+				validateInputValue(t, filename, value, outputFiles)
+			case "workflow_file":
 				if value.Kind == yaml.ScalarNode {
-					validateInputPath(t, filename, stepName, value.Value, outputFiles)
-				} else if value.Kind == yaml.SequenceNode {
-					for _, item := range value.Content {
-						validateInputPath(t, filename, stepName, item.Value, outputFiles)
-					}
-				} else if value.Kind == yaml.MappingNode {
-					// For mapping nodes, validate as a web scraping input
-					validateWebScrapeInput(t, filename, stepName, value)
-					// Validation for database inputs will need to go here
+					validateInputPath(t, filename, value.Value, outputFiles)
 				}
 			}
-		}
-	}
 
-	// Check if any required fields are missing
-	for field, found := range requiredFields {
-		if !found {
-			t.Errorf("Step %s in %s: missing required field '%s'", stepName, filename, field)
+			validateReferencedPaths(t, filename, value, outputFiles)
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			validateReferencedPaths(t, filename, child, outputFiles)
 		}
 	}
 }
 
-func validateInputPath(t *testing.T, filename, stepName, input string, outputFiles map[string]bool) {
-	// Skip special input types
-	if isSpecialInput(input) {
+func validateInputValue(t *testing.T, filename string, node *yaml.Node, outputFiles map[string]bool) {
+	t.Helper()
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		validateInputPath(t, filename, node.Value, outputFiles)
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if item.Kind == yaml.ScalarNode {
+				validateInputPath(t, filename, item.Value, outputFiles)
+			}
+		}
+	}
+}
+
+func validateInputPath(t *testing.T, filename, input string, outputFiles map[string]bool) {
+	t.Helper()
+
+	if isSpecialInput(input) || outputFiles[input] || !looksLikePathReference(input) {
 		return
 	}
 
-	// Handle filenames tag format
 	if strings.HasPrefix(input, "filenames:") {
 		files := strings.TrimPrefix(input, "filenames:")
-		// Split by comma and validate each file
 		for _, file := range strings.Split(files, ",") {
 			file = strings.TrimSpace(file)
 			if file != "" {
-				validateSingleInputPath(t, filename, stepName, file, outputFiles)
+				if outputFiles[file] || !looksLikePathReference(file) {
+					continue
+				}
+				validateSingleInputPath(t, filename, file)
 			}
 		}
 		return
 	}
 
-	validateSingleInputPath(t, filename, stepName, input, outputFiles)
+	validateSingleInputPath(t, filename, input)
 }
 
-func validateSingleInputPath(t *testing.T, filename, stepName, input string, outputFiles map[string]bool) {
-	// If it's an output from another step, no need to check the file
-	if outputFiles[input] {
-		return
-	}
+func validateSingleInputPath(t *testing.T, filename, input string) {
+	t.Helper()
 
-	// Get the directory of the YAML file
 	yamlDir := filepath.Dir(filename)
-
-	// Possible paths to check
 	paths := []string{
-		input,                         // As is
-		filepath.Join(yamlDir, input), // Relative to YAML file
+		input,
+		filepath.Join(yamlDir, input),
 	}
 
-	// If input starts with "examples/", also check without the prefix
 	if strings.HasPrefix(input, "examples/") {
 		paths = append(paths, strings.TrimPrefix(input, "examples/"))
 	}
 
-	// Check if file exists in any of the possible paths
-	fileExists := false
 	for _, path := range paths {
 		if _, err := os.Stat(path); err == nil {
-			fileExists = true
-			break
+			return
 		}
 	}
 
-	if !fileExists {
-		t.Errorf("Step %s in %s references non-existent input file: %s", stepName, filename, input)
-	}
-}
-
-func validateWebScrapeInput(t *testing.T, filename, stepName string, node *yaml.Node) {
-	var hasURL, hasScrapeConfig bool
-	// Iterate over mapping key/value pairs
-	for i := 0; i < len(node.Content); i += 2 {
-		key := node.Content[i].Value
-		if key == "url" {
-			hasURL = true
-		}
-		if key == "scrape_config" {
-			hasScrapeConfig = true
-		}
-	}
-	if !hasURL {
-		t.Errorf("Step %s in %s: web scraping input mapping missing required key 'url'", stepName, filename)
-	}
-	if !hasScrapeConfig {
-		t.Errorf("Step %s in %s: web scraping input mapping missing required key 'scrape_config'", stepName, filename)
-	}
+	t.Errorf("%s references non-existent input file: %s", filename, input)
 }
 
 func isSpecialInput(input string) bool {
-	// List of special input types that don't require file validation
 	specialInputs := []string{
 		"STDIN",
 		"screenshot",
 		"NA",
 	}
 
-	// Check if input is a special type
 	for _, special := range specialInputs {
 		if input == special || strings.HasPrefix(input, "STDIN as $") {
 			return true
 		}
 	}
 
-	// Check if input is a variable reference
 	if strings.HasPrefix(input, "$") {
 		return true
 	}
 
-	// Check if input is a URL
 	if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
 		return true
 	}
 
-	// Check if input contains wildcard characters
-	return containsWildcard(input)
+	return strings.ContainsAny(input, "*?[]") || strings.HasPrefix(input, "tool: ")
 }
 
-// containsWildcard checks if a path contains wildcard characters
-func containsWildcard(path string) bool {
-	return strings.ContainsAny(path, "*?[]")
-}
-
-// validateGenerateStep validates a generate step
-func validateGenerateStep(t *testing.T, filename, stepName string, stepNode *yaml.Node, outputFiles map[string]bool) {
-	hasInput := false
-	hasGenerate := false
-
-	for i := 0; i < len(stepNode.Content); i += 2 {
-		key := stepNode.Content[i].Value
-		value := stepNode.Content[i+1]
-
-		if key == "input" {
-			hasInput = true
-			// Validate input path
-			if value.Kind == yaml.ScalarNode {
-				validateInputPath(t, filename, stepName, value.Value, outputFiles)
-			}
-		} else if key == "generate" && value.Kind == yaml.MappingNode {
-			hasGenerate = true
-			// Validate generate block
-			hasAction := false
-			hasOutput := false
-
-			for j := 0; j < len(value.Content); j += 2 {
-				genKey := value.Content[j].Value
-				genValue := value.Content[j+1]
-
-				if genKey == "action" && genValue.Kind == yaml.ScalarNode && genValue.Value != "" {
-					hasAction = true
-				} else if genKey == "output" && genValue.Kind == yaml.ScalarNode && genValue.Value != "" {
-					hasOutput = true
-					// Add to output files
-					outputFiles[genValue.Value] = true
-				}
-			}
-
-			if !hasAction {
-				t.Errorf("Step %s in %s: generate block missing required field 'action'", stepName, filename)
-			}
-			if !hasOutput {
-				t.Errorf("Step %s in %s: generate block missing required field 'output'", stepName, filename)
-			}
-		}
+func looksLikePathReference(input string) bool {
+	if strings.HasPrefix(input, "./") {
+		return false
 	}
 
-	if !hasInput {
-		t.Errorf("Step %s in %s: missing required field 'input'", stepName, filename)
-	}
-	if !hasGenerate {
-		t.Errorf("Step %s in %s: missing required field 'generate'", stepName, filename)
-	}
-}
-
-// validateProcessStep validates a process step
-func validateProcessStep(t *testing.T, filename, stepName string, stepNode *yaml.Node, outputFiles map[string]bool) {
-	hasInput := false
-	hasProcess := false
-
-	for i := 0; i < len(stepNode.Content); i += 2 {
-		key := stepNode.Content[i].Value
-		value := stepNode.Content[i+1]
-
-		if key == "input" {
-			hasInput = true
-			// Validate input path
-			if value.Kind == yaml.ScalarNode {
-				validateInputPath(t, filename, stepName, value.Value, outputFiles)
-			}
-		} else if key == "process" && value.Kind == yaml.MappingNode {
-			hasProcess = true
-			// Validate process block
-			hasWorkflowFile := false
-
-			for j := 0; j < len(value.Content); j += 2 {
-				procKey := value.Content[j].Value
-				procValue := value.Content[j+1]
-
-				if procKey == "workflow_file" && procValue.Kind == yaml.ScalarNode && procValue.Value != "" {
-					hasWorkflowFile = true
-					// Check if workflow file exists or is an output from another step
-					validateInputPath(t, filename, stepName, procValue.Value, outputFiles)
-				}
-			}
-
-			if !hasWorkflowFile {
-				t.Errorf("Step %s in %s: process block missing required field 'workflow_file'", stepName, filename)
-			}
-		}
+	if strings.ContainsAny(input, "\n\r\t") {
+		return false
 	}
 
-	if !hasInput {
-		t.Errorf("Step %s in %s: missing required field 'input'", stepName, filename)
+	if strings.Contains(input, "${") || strings.Contains(input, "{{") {
+		return false
 	}
-	if !hasProcess {
-		t.Errorf("Step %s in %s: missing required field 'process'", stepName, filename)
+
+	if strings.Contains(input, " ") {
+		return false
 	}
+
+	if filepath.Ext(input) != "" {
+		return true
+	}
+
+	return strings.Contains(input, "/") || strings.HasPrefix(input, ".")
 }

--- a/examples/index-registry/analyze-from-registry.yaml
+++ b/examples/index-registry/analyze-from-registry.yaml
@@ -7,20 +7,20 @@
 # Usage:
 #   comanda process examples/index-registry/analyze-from-registry.yaml
 
-steps:
-  # Load a single index from registry
-  load_single:
-    codebase_index:
-      use: comanda                    # Load 'comanda' index from registry
-    model: skip                        # No LLM needed for this step
+# Load a single index from registry
+load_single:
+  step_type: codebase-index
+  codebase_index:
+    use: comanda
 
-  # Analyze the loaded codebase
-  analyze:
-    input: |
-      Here is a codebase index:
-      
-      ${COMANDA_INDEX}
-      
-      Summarize the architecture and key components.
-    model: anthropic/claude-sonnet
-    output: analysis.md
+# Analyze the loaded codebase
+analyze:
+  input: |
+    Here is a codebase index:
+    
+    ${COMANDA_INDEX}
+    
+    Summarize the architecture and key components.
+  model: anthropic/claude-sonnet
+  action: Summarize the architecture and key components in the loaded registry index.
+  output: analysis.md

--- a/examples/index-registry/multi-codebase-analysis.yaml
+++ b/examples/index-registry/multi-codebase-analysis.yaml
@@ -10,38 +10,39 @@
 # Usage:
 #   comanda process examples/index-registry/multi-codebase-analysis.yaml
 
-steps:
-  # Load multiple indexes from registry
-  load_codebases:
-    codebase_index:
-      use: [comanda, clawdbot]        # Load multiple indexes
-      aggregate: true                  # Combine into AGGREGATED_INDEX
-      max_age: 24h                     # Warn if indexes are stale
-    model: skip
+# Load multiple indexes from registry
+load_codebases:
+  step_type: codebase-index
+  codebase_index:
+    use: [comanda, clawdbot]
+    aggregate: true
+    max_age: 24h
 
-  # Compare the codebases
-  compare:
-    input: |
-      I have code context from two projects:
-      
-      ## Comanda
-      ${COMANDA_INDEX}
-      
-      ## Clawdbot  
-      ${CLAWDBOT_INDEX}
-      
-      Compare the architecture patterns used in these two projects.
-      What are the similarities and differences?
-    model: anthropic/claude-sonnet
-    output: comparison.md
+# Compare the codebases
+compare:
+  input: |
+    I have code context from two projects:
+    
+    ## Comanda
+    ${COMANDA_INDEX}
+    
+    ## Clawdbot  
+    ${CLAWDBOT_INDEX}
+    
+    Compare the architecture patterns used in these two projects.
+    What are the similarities and differences?
+  model: anthropic/claude-sonnet
+  action: Compare the architecture patterns in the two loaded codebase indexes.
+  output: comparison.md
 
-  # Or use the aggregated index
-  aggregate_analysis:
-    input: |
-      Here are multiple codebase indexes:
-      
-      ${AGGREGATED_INDEX}
-      
-      How might these projects integrate or work together?
-    model: anthropic/claude-sonnet
-    output: integration-ideas.md
+# Or use the aggregated index
+aggregate_analysis:
+  input: |
+    Here are multiple codebase indexes:
+    
+    ${AGGREGATED_INDEX}
+    
+    How might these projects integrate or work together?
+  model: anthropic/claude-sonnet
+  action: Explain how the aggregated codebases could integrate or work together.
+  output: integration-ideas.md

--- a/examples/qmd/index-with-qmd.yaml
+++ b/examples/qmd/index-with-qmd.yaml
@@ -12,8 +12,8 @@
 #   qmd search "your query" -c myproject
 
 index-codebase:
-  type: codebase-index
-  config:
+  step_type: codebase-index
+  codebase_index:
     root: .
     output:
       store: repo
@@ -32,6 +32,6 @@ summary:
       qmd search "your query" -c myproject
     
     Or use qmd-search in your workflows.
-  model: echo
+  model: NA
   action: Display summary
   output: STDOUT

--- a/examples/tool-use/beads-walkthrough.yaml
+++ b/examples/tool-use/beads-walkthrough.yaml
@@ -35,7 +35,7 @@ analyze_spec:
     - Break it down into discrete implementable tasks
     - Each task should be approximately 1000 lines of code or less
     - For each task identify type (feature, task, or bug), title, and description
-    - Output as JSON array with format [{"type": "feature|task|bug", "title": "...", "description": "..."}]
+    - 'Output as JSON array with format [{"type": "feature|task|bug", "title": "...", "description": "..."}]'
     - Keep titles concise (under 80 characters)
     - Keep descriptions to 2-3 sentences
     - Order tasks by implementation dependency (foundational first)

--- a/examples/tool-use/data.csv
+++ b/examples/tool-use/data.csv
@@ -1,0 +1,4 @@
+name,role,team
+Alice,Engineer,Platform
+Bob,Designer,Product
+Charlie,Manager,Operations

--- a/examples/tool-use/logfile.txt
+++ b/examples/tool-use/logfile.txt
@@ -1,0 +1,3 @@
+2026-01-01 10:00:00 INFO Service started
+2026-01-01 10:01:00 ERROR Database timeout
+2026-01-01 10:02:00 INFO Retrying request

--- a/examples/tool-use/sample-data.json
+++ b/examples/tool-use/sample-data.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    { "id": 1, "status": "active", "name": "alpha" },
+    { "id": 2, "status": "inactive", "name": "beta" },
+    { "id": 3, "status": "active", "name": "gamma" }
+  ]
+}

--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
+
+	"github.com/kris-hansen/comanda/utils/models"
 )
 
 // Default values for agentic loop safety
@@ -212,13 +215,14 @@ func (p *Processor) processAgenticLoopWithFile(loopName string, config *AgenticL
 		}
 
 		// Set loop template variables
-		p.setLoopVariables(loopCtx, maxIterations)
+		p.ensureLoopPromptState(loopCtx, config.Steps)
+		p.setLoopVariables(loopCtx, config.Steps, maxIterations)
 
 		// Build iteration input with context
 		iterationInput := p.buildIterationContext(loopCtx, contextWindow)
 
 		// Execute the loop steps
-		output, err := p.executeLoopSteps(config.Steps, iterationInput)
+		output, err := p.executeLoopSteps(loopCtx, config, config.Steps, iterationInput)
 		if err != nil {
 			finalErr = fmt.Errorf("error in agentic loop '%s' iteration %d: %w", loopName, loopCtx.Iteration, err)
 			// Stream log error
@@ -328,6 +332,7 @@ func (p *Processor) createNewLoopContext(initialInput string) *LoopContext {
 		PreviousOutput: initialInput,
 		History:        make([]LoopIteration, 0),
 		StartTime:      time.Now(),
+		CurrentActions: make(map[string]string),
 	}
 }
 
@@ -342,12 +347,25 @@ func (p *Processor) getLoopStateDir() string {
 	return filepath.Join(homeDir, ".comanda", "loop-states")
 }
 
-// setLoopVariables sets template variables for the current loop iteration
-func (p *Processor) setLoopVariables(loopCtx *LoopContext, maxIterations int) {
-	p.variables["loop.iteration"] = fmt.Sprintf("%d", loopCtx.Iteration)
-	p.variables["loop.previous_output"] = loopCtx.PreviousOutput
-	p.variables["loop.total_iterations"] = fmt.Sprintf("%d", maxIterations)
-	p.variables["loop.elapsed_seconds"] = fmt.Sprintf("%.0f", time.Since(loopCtx.StartTime).Seconds())
+// setLoopVariables sets template variables for the current loop iteration.
+func (p *Processor) setLoopVariables(loopCtx *LoopContext, steps []Step, maxIterations int) {
+	loopVars := map[string]string{
+		"loop.iteration":        fmt.Sprintf("%d", loopCtx.Iteration),
+		"loop.previous_output":  loopCtx.PreviousOutput,
+		"loop.total_iterations": fmt.Sprintf("%d", maxIterations),
+		"loop.elapsed_seconds":  fmt.Sprintf("%.0f", time.Since(loopCtx.StartTime).Seconds()),
+	}
+
+	if currentPrompt := p.primaryLoopPrompt(loopCtx, steps); currentPrompt != "" {
+		loopVars["loop.current_prompt"] = currentPrompt
+	}
+
+	for name, value := range loopVars {
+		p.variables[name] = value
+		if p.cliVariables != nil {
+			p.cliVariables[name] = value
+		}
+	}
 }
 
 // buildIterationContext constructs the input for an iteration with historical context
@@ -375,8 +393,8 @@ func (p *Processor) buildIterationContext(loopCtx *LoopContext, contextWindow in
 	return sb.String()
 }
 
-// executeLoopSteps runs the sub-steps within an agentic loop iteration
-func (p *Processor) executeLoopSteps(steps []Step, input string) (string, error) {
+// executeLoopSteps runs the sub-steps within an agentic loop iteration.
+func (p *Processor) executeLoopSteps(loopCtx *LoopContext, loopConfig *AgenticLoopConfig, steps []Step, input string) (string, error) {
 	var output string
 
 	// If no sub-steps, return error
@@ -388,19 +406,25 @@ func (p *Processor) executeLoopSteps(steps []Step, input string) (string, error)
 	p.lastOutput = input
 
 	for i, step := range steps {
+		stepKey := loopStepKey(step, i)
+		stepToExecute := step
+		if currentAction, ok := loopCtx.CurrentActions[stepKey]; ok && currentAction != "" {
+			stepToExecute.Config.Action = currentAction
+		}
+
 		// Log step start
 		if p.streamLog != nil {
-			stepName := step.Name
+			stepName := stepToExecute.Name
 			if stepName == "" {
 				stepName = fmt.Sprintf("step-%d", i+1)
 			}
-			model := fmt.Sprintf("%v", step.Config.Model)
+			model := fmt.Sprintf("%v", stepToExecute.Config.Model)
 			if model == "" || model == "<nil>" {
 				model = "(default)"
 			}
 			p.streamLog.Log("→ Starting %s [model: %s]", stepName, model)
-			if step.Config.Action != nil {
-				p.streamLog.Log("  Action: %v", step.Config.Action)
+			if stepToExecute.Config.Action != nil {
+				p.streamLog.Log("  Action: %v", stepToExecute.Config.Action)
 			}
 			inputPreview := p.lastOutput
 			if len(inputPreview) > 200 {
@@ -410,7 +434,7 @@ func (p *Processor) executeLoopSteps(steps []Step, input string) (string, error)
 		}
 
 		stepStart := time.Now()
-		result, err := p.processStep(step, false, "")
+		result, err := p.processStep(stepToExecute, false, "")
 
 		// Log step completion
 		if p.streamLog != nil {
@@ -432,9 +456,167 @@ func (p *Processor) executeLoopSteps(steps []Step, input string) (string, error)
 		}
 		output = result
 		p.lastOutput = result
+
+		if err := p.refineLoopStepPrompt(loopCtx, loopConfig, stepToExecute, stepKey, result); err != nil {
+			return "", err
+		}
 	}
 
 	return output, nil
+}
+
+func (p *Processor) ensureLoopPromptState(loopCtx *LoopContext, steps []Step) {
+	if loopCtx.CurrentActions == nil {
+		loopCtx.CurrentActions = make(map[string]string, len(steps))
+	}
+	for i, step := range steps {
+		stepKey := loopStepKey(step, i)
+		if _, exists := loopCtx.CurrentActions[stepKey]; exists {
+			continue
+		}
+		if action := firstStepAction(step); action != "" {
+			loopCtx.CurrentActions[stepKey] = action
+		}
+	}
+}
+
+func loopStepKey(step Step, idx int) string {
+	if step.Name != "" {
+		return step.Name
+	}
+	return fmt.Sprintf("step-%d", idx+1)
+}
+
+func firstStepAction(step Step) string {
+	switch action := step.Config.Action.(type) {
+	case string:
+		return strings.TrimSpace(action)
+	case []string:
+		if len(action) > 0 {
+			return strings.TrimSpace(action[0])
+		}
+	case []interface{}:
+		if len(action) > 0 {
+			if text, ok := action[0].(string); ok {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return ""
+}
+
+func (p *Processor) primaryLoopPrompt(loopCtx *LoopContext, steps []Step) string {
+	for i, step := range steps {
+		if prompt := loopCtx.CurrentActions[loopStepKey(step, i)]; prompt != "" {
+			return prompt
+		}
+	}
+
+	keys := make([]string, 0, len(loopCtx.CurrentActions))
+	for key := range loopCtx.CurrentActions {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		if loopCtx.CurrentActions[key] != "" {
+			return loopCtx.CurrentActions[key]
+		}
+	}
+	return ""
+}
+
+func (p *Processor) refineLoopStepPrompt(loopCtx *LoopContext, loopConfig *AgenticLoopConfig, step Step, stepKey, latestResult string) error {
+	if !p.isPromptImprovementEnabled(loopConfig, step) {
+		return nil
+	}
+
+	currentAction := loopCtx.CurrentActions[stepKey]
+	if currentAction == "" {
+		currentAction = firstStepAction(step)
+	}
+	if currentAction == "" {
+		return nil
+	}
+
+	modelNames := p.NormalizeStringSlice(step.Config.Model)
+	modelName := p.promptImprovementModel(loopConfig, modelNames)
+	if modelName == "" || modelName == "NA" {
+		return nil
+	}
+
+	provider := models.DetectProvider(modelName)
+	if provider == nil {
+		return fmt.Errorf("provider not found for prompt improvement model: %s", modelName)
+	}
+	configuredProvider := p.providers[provider.Name()]
+	if configuredProvider == nil {
+		return fmt.Errorf("provider %s not configured", provider.Name())
+	}
+
+	instructions := p.promptImprovementInstructions(loopConfig, step)
+	refinementPrompt := fmt.Sprintf(`You are refining the prompt for the next iteration of an agentic loop.
+
+Return ONLY the improved prompt text to use next. Do not include commentary, markdown fences, or explanations.
+
+Current iteration: %d
+Current prompt:
+---
+%s
+---
+
+Latest result:
+---
+%s
+---
+
+Additional guidance:
+%s`, loopCtx.Iteration, currentAction, latestResult, instructions)
+
+	improvedAction, err := configuredProvider.SendPrompt(modelName, refinementPrompt)
+	if err != nil {
+		return fmt.Errorf("failed to refine loop prompt for step '%s': %w", stepKey, err)
+	}
+
+	improvedAction = strings.TrimSpace(improvedAction)
+	if improvedAction != "" {
+		loopCtx.CurrentActions[stepKey] = improvedAction
+		if p.streamLog != nil {
+			p.streamLog.Log("↻ Refined prompt for %s", stepKey)
+		}
+	}
+
+	return nil
+}
+
+func (p *Processor) isPromptImprovementEnabled(loopConfig *AgenticLoopConfig, step Step) bool {
+	if loopConfig != nil && loopConfig.PromptImprovement != nil {
+		if loopConfig.PromptImprovement.Enabled || loopConfig.PromptImprovement.Model != "" || loopConfig.PromptImprovement.Instructions != "" {
+			return true
+		}
+		return true
+	}
+
+	return len(p.NormalizeStringSlice(step.Config.NextAction)) > 0
+}
+
+func (p *Processor) promptImprovementModel(loopConfig *AgenticLoopConfig, stepModels []string) string {
+	if loopConfig != nil && loopConfig.PromptImprovement != nil && loopConfig.PromptImprovement.Model != "" {
+		return loopConfig.PromptImprovement.Model
+	}
+	if len(stepModels) > 0 {
+		return stepModels[0]
+	}
+	return ""
+}
+
+func (p *Processor) promptImprovementInstructions(loopConfig *AgenticLoopConfig, step Step) string {
+	if nextActions := p.NormalizeStringSlice(step.Config.NextAction); len(nextActions) > 0 {
+		return strings.Join(nextActions, "\n")
+	}
+	if loopConfig != nil && loopConfig.PromptImprovement != nil && strings.TrimSpace(loopConfig.PromptImprovement.Instructions) != "" {
+		return loopConfig.PromptImprovement.Instructions
+	}
+	return "Make the next prompt more specific, preserve the user's goal, incorporate what worked, avoid what failed, and increase the chance of a stronger next iteration."
 }
 
 // checkExitCondition determines if the loop should exit

--- a/utils/processor/agentic_loop_test.go
+++ b/utils/processor/agentic_loop_test.go
@@ -6,11 +6,14 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kris-hansen/comanda/utils/models"
 )
 
 func TestCheckExitCondition_LLMDecides(t *testing.T) {
 	p := &Processor{
-		variables: make(map[string]string),
+		variables:    make(map[string]string),
+		cliVariables: make(map[string]string),
 	}
 
 	tests := []struct {
@@ -221,7 +224,8 @@ func TestBuildIterationContext(t *testing.T) {
 
 func TestSetLoopVariables(t *testing.T) {
 	p := &Processor{
-		variables: make(map[string]string),
+		variables:    make(map[string]string),
+		cliVariables: make(map[string]string),
 	}
 
 	loopCtx := &LoopContext{
@@ -230,7 +234,10 @@ func TestSetLoopVariables(t *testing.T) {
 		StartTime:      time.Now().Add(-10 * time.Second),
 	}
 
-	p.setLoopVariables(loopCtx, 10)
+	steps := []Step{{Name: "analyze", Config: StepConfig{Action: "initial prompt"}}}
+	loopCtx.CurrentActions = map[string]string{"analyze": "refined prompt"}
+
+	p.setLoopVariables(loopCtx, steps, 10)
 
 	if p.variables["loop.iteration"] != "3" {
 		t.Errorf("loop.iteration = %q, want %q", p.variables["loop.iteration"], "3")
@@ -242,6 +249,14 @@ func TestSetLoopVariables(t *testing.T) {
 
 	if p.variables["loop.total_iterations"] != "10" {
 		t.Errorf("loop.total_iterations = %q, want %q", p.variables["loop.total_iterations"], "10")
+	}
+
+	if p.variables["loop.current_prompt"] != "refined prompt" {
+		t.Errorf("loop.current_prompt = %q, want %q", p.variables["loop.current_prompt"], "refined prompt")
+	}
+
+	if p.cliVariables["loop.iteration"] != "3" {
+		t.Errorf("cli loop.iteration = %q, want %q", p.cliVariables["loop.iteration"], "3")
 	}
 
 	// Elapsed seconds should be approximately 10
@@ -277,9 +292,60 @@ func TestExecuteLoopSteps_NoSteps(t *testing.T) {
 		variables: make(map[string]string),
 	}
 
-	_, err := p.executeLoopSteps([]Step{}, "input")
+	loopCtx := &LoopContext{CurrentActions: make(map[string]string)}
+	_, err := p.executeLoopSteps(loopCtx, &AgenticLoopConfig{}, []Step{}, "input")
 	if err == nil {
 		t.Error("executeLoopSteps() should return error for empty steps")
+	}
+}
+
+func TestRefineLoopStepPrompt_UpdatesCurrentAction(t *testing.T) {
+	mockProvider := &CustomMockProvider{
+		MockProvider: *NewMockProvider("openai"),
+		responses: map[string]string{
+			"refining the prompt for the next iteration": "Improved prompt for iteration 2",
+		},
+	}
+	if err := mockProvider.Configure("test-key"); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	originalDetect := models.DetectProvider
+	models.DetectProvider = func(modelName string) models.Provider {
+		return mockProvider
+	}
+	defer func() { models.DetectProvider = originalDetect }()
+
+	p := &Processor{
+		variables:    make(map[string]string),
+		cliVariables: make(map[string]string),
+		providers: map[string]models.Provider{
+			"openai": mockProvider,
+		},
+	}
+
+	loopCtx := &LoopContext{
+		Iteration:      1,
+		PreviousOutput: "initial result",
+		CurrentActions: map[string]string{"improve": "Initial prompt"},
+	}
+	loopConfig := &AgenticLoopConfig{
+		PromptImprovement: &PromptImprovementConfig{Enabled: true},
+	}
+	step := Step{
+		Name: "improve",
+		Config: StepConfig{
+			Model:  "gpt-4o-mini",
+			Action: "Initial prompt",
+		},
+	}
+
+	if err := p.refineLoopStepPrompt(loopCtx, loopConfig, step, "improve", "latest output"); err != nil {
+		t.Fatalf("refineLoopStepPrompt() failed: %v", err)
+	}
+
+	if got := loopCtx.CurrentActions["improve"]; got != "Improved prompt for iteration 2" {
+		t.Fatalf("current action = %q, want %q", got, "Improved prompt for iteration 2")
 	}
 }
 

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -287,21 +287,38 @@ func (c *DSLConfig) parseAgenticLoopBlock(node *yaml.Node) error {
 
 	// Parse steps if present
 	if stepsNode != nil {
-		if stepsNode.Kind != yaml.MappingNode {
-			return fmt.Errorf("agentic-loop steps must be a mapping")
-		}
+		switch stepsNode.Kind {
+		case yaml.MappingNode:
+			for i := 0; i < len(stepsNode.Content); i += 2 {
+				keyNode := stepsNode.Content[i]
+				valueNode := stepsNode.Content[i+1]
+				stepName := keyNode.Value
 
-		for i := 0; i < len(stepsNode.Content); i += 2 {
-			keyNode := stepsNode.Content[i]
-			valueNode := stepsNode.Content[i+1]
-			stepName := keyNode.Value
+				var stepConfig StepConfig
+				if err := valueNode.Decode(&stepConfig); err != nil {
+					return fmt.Errorf("failed to decode agentic loop step '%s': %w", stepName, err)
+				}
 
-			var stepConfig StepConfig
-			if err := valueNode.Decode(&stepConfig); err != nil {
-				return fmt.Errorf("failed to decode agentic loop step '%s': %w", stepName, err)
+				loopConfig.Steps = append(loopConfig.Steps, Step{Name: stepName, Config: stepConfig})
 			}
+		case yaml.SequenceNode:
+			for _, item := range stepsNode.Content {
+				if item.Kind != yaml.MappingNode || len(item.Content) != 2 {
+					return fmt.Errorf("agentic-loop list steps must be single-entry mappings")
+				}
 
-			loopConfig.Steps = append(loopConfig.Steps, Step{Name: stepName, Config: stepConfig})
+				stepName := item.Content[0].Value
+				valueNode := item.Content[1]
+
+				var stepConfig StepConfig
+				if err := valueNode.Decode(&stepConfig); err != nil {
+					return fmt.Errorf("failed to decode agentic loop step '%s': %w", stepName, err)
+				}
+
+				loopConfig.Steps = append(loopConfig.Steps, Step{Name: stepName, Config: stepConfig})
+			}
+		default:
+			return fmt.Errorf("agentic-loop steps must be a mapping or sequence")
 		}
 	}
 

--- a/utils/processor/dsl_validator.go
+++ b/utils/processor/dsl_validator.go
@@ -83,10 +83,20 @@ func ValidateWorkflowStructure(yamlContent string) ValidationResult {
 		return result
 	}
 
-	// Validate each step
+	// Validate each top-level entry
 	for stepName, stepValue := range workflow {
 		// Skip special top-level keys
 		if stepName == "agentic-loop" || stepName == "loops" || stepName == "execute_loops" || stepName == "workflow" {
+			continue
+		}
+
+		if stepName == "defer" || stepName == "steps" {
+			result.Errors = append(result.Errors, validateStepCollection(stepName, stepValue)...)
+			continue
+		}
+
+		if isStepCollection(stepValue) {
+			result.Errors = append(result.Errors, validateStepCollection(stepName, stepValue)...)
 			continue
 		}
 
@@ -134,7 +144,7 @@ func checkRawYAMLMistakes(content string) []ValidationError {
 
 		// Check for hyphen misuse in step fields (common mistake)
 		// Pattern: "  - input:" or "  - model:" etc. at wrong indentation
-		if regexp.MustCompile(`^\s{2,4}-\s+(input|model|action|output|type):`).MatchString(line) {
+		if regexp.MustCompile(`^\s{2,4}-\s+(input|model|action|output):`).MatchString(line) {
 			// Check if this looks like it should be a key-value, not a list item
 			errors = append(errors, ValidationError{
 				Line:    lineNum,
@@ -189,6 +199,8 @@ func validateStep(stepName string, stepValue interface{}) []ValidationError {
 	hasProcess := stepMap["process"] != nil
 	hasAgenticLoop := stepMap["agentic_loop"] != nil
 	hasCodebaseIndex := stepMap["codebase_index"] != nil || stepMap["step_type"] == "codebase-index"
+	hasQmdSearch := stepMap["qmd_search"] != nil || stepMap["type"] == "qmd-search"
+	hasSkill := stepMap["skill"] != nil
 
 	// Check for mixed step types
 	typeCount := 0
@@ -201,10 +213,16 @@ func validateStep(stepName string, stepValue interface{}) []ValidationError {
 	if hasCodebaseIndex {
 		typeCount++
 	}
+	if hasQmdSearch {
+		typeCount++
+	}
+	if hasSkill {
+		typeCount++
+	}
 	if typeCount > 1 {
 		errors = append(errors, ValidationError{
 			Field:   stepName,
-			Message: "Step mixes multiple types (generate/process/codebase_index)",
+			Message: "Step mixes multiple types (generate/process/codebase_index/qmd_search/skill)",
 			Fix:     "A step can only be one type. Split into separate steps if needed.",
 		})
 	}
@@ -217,6 +235,10 @@ func validateStep(stepName string, stepValue interface{}) []ValidationError {
 	} else if hasCodebaseIndex {
 		// Codebase index steps don't need input/model/action/output
 		errors = append(errors, validateCodebaseIndexStep(stepName, stepMap)...)
+	} else if hasQmdSearch {
+		errors = append(errors, validateQmdSearchStep(stepName, stepMap)...)
+	} else if hasSkill {
+		errors = append(errors, validateSkillStep(stepName, stepMap)...)
 	} else {
 		// Standard step (with or without agentic_loop)
 		errors = append(errors, validateStandardStep(stepName, stepMap, hasAgenticLoop)...)
@@ -225,12 +247,67 @@ func validateStep(stepName string, stepValue interface{}) []ValidationError {
 	return errors
 }
 
+func isStepCollection(stepValue interface{}) bool {
+	stepMap, ok := stepValue.(map[string]interface{})
+	if !ok || len(stepMap) == 0 {
+		return false
+	}
+
+	for _, child := range stepMap {
+		childMap, ok := child.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		if !looksLikeStepDefinition(childMap) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validateStepCollection(groupName string, groupValue interface{}) []ValidationError {
+	groupMap, ok := groupValue.(map[string]interface{})
+	if !ok {
+		return []ValidationError{{
+			Field:   groupName,
+			Message: "Step collection must be a map of named steps",
+			Fix:     "Define each nested step as 'name: { input: ..., model: ..., action: ..., output: ... }'.",
+		}}
+	}
+
+	var errors []ValidationError
+	for stepName, stepValue := range groupMap {
+		errors = append(errors, validateStep(stepName, stepValue)...)
+	}
+	return errors
+}
+
+func looksLikeStepDefinition(stepMap map[string]interface{}) bool {
+	stepKeys := []string{
+		"input", "model", "action", "output", "generate", "process",
+		"type", "agentic_loop", "codebase_index", "step_type", "qmd_search", "skill",
+	}
+
+	for _, key := range stepKeys {
+		if _, ok := stepMap[key]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
 // validateStandardStep validates a standard processing step
 func validateStandardStep(stepName string, stepMap map[string]interface{}, hasAgenticLoop bool) []ValidationError {
 	var errors []ValidationError
+	isResponsesStep := stepMap["type"] == "openai-responses"
 
 	// Required fields for standard steps
-	requiredFields := []string{"input", "model", "action", "output"}
+	requiredFields := []string{"input", "model", "output"}
+	if !isResponsesStep {
+		requiredFields = append(requiredFields, "action")
+	}
 
 	for _, field := range requiredFields {
 		if _, ok := stepMap[field]; !ok {
@@ -239,6 +316,18 @@ func validateStandardStep(stepName string, stepMap map[string]interface{}, hasAg
 				Message: fmt.Sprintf("Missing required field '%s'", field),
 				Fix:     fmt.Sprintf("Add '%s:' to the step. Use 'NA' if not applicable.", field),
 			})
+		}
+	}
+
+	if isResponsesStep {
+		if _, hasAction := stepMap["action"]; !hasAction {
+			if _, hasInstructions := stepMap["instructions"]; !hasInstructions {
+				errors = append(errors, ValidationError{
+					Field:   stepName,
+					Message: "Missing required field 'action' or 'instructions'",
+					Fix:     "Add either 'action:' or 'instructions:' to the OpenAI responses step.",
+				})
+			}
 		}
 	}
 
@@ -351,6 +440,81 @@ func validateCodebaseIndexStep(stepName string, stepMap map[string]interface{}) 
 					Fix:     "Set root to a directory path string, e.g., 'root: ./src'",
 				})
 			}
+		}
+	}
+
+	return errors
+}
+
+// validateQmdSearchStep validates a qmd-search step
+func validateQmdSearchStep(stepName string, stepMap map[string]interface{}) []ValidationError {
+	var errors []ValidationError
+
+	qmdSearch, ok := stepMap["qmd_search"].(map[string]interface{})
+	if !ok {
+		errors = append(errors, ValidationError{
+			Field:   stepName,
+			Message: "'qmd_search' must be a map/object",
+			Fix:     "Define qmd_search as: qmd_search:\n    query: \"...\"",
+		})
+		return errors
+	}
+
+	if _, ok := qmdSearch["query"]; !ok {
+		errors = append(errors, ValidationError{
+			Field:   stepName,
+			Message: "qmd_search block missing required 'query' field",
+			Fix:     "Add 'query:' with the search text or variable to look up.",
+		})
+	}
+
+	if output, ok := stepMap["output"]; ok {
+		errors = append(errors, validateOutputField(stepName, output)...)
+	} else {
+		errors = append(errors, ValidationError{
+			Field:   stepName,
+			Message: "Missing required field 'output'",
+			Fix:     "Add 'output:' to capture the search results for later steps or STDOUT.",
+		})
+	}
+
+	return errors
+}
+
+// validateSkillStep validates a skill step
+func validateSkillStep(stepName string, stepMap map[string]interface{}) []ValidationError {
+	var errors []ValidationError
+
+	skillName, ok := stepMap["skill"].(string)
+	if !ok || strings.TrimSpace(skillName) == "" {
+		errors = append(errors, ValidationError{
+			Field:   stepName,
+			Message: "skill must be a non-empty string",
+			Fix:     "Set 'skill:' to the name of an installed skill, e.g. 'skill: summarize'.",
+		})
+	}
+
+	if input, ok := stepMap["input"]; ok {
+		errors = append(errors, validateInputField(stepName, input)...)
+	}
+
+	if output, ok := stepMap["output"]; ok {
+		errors = append(errors, validateOutputField(stepName, output)...)
+	} else {
+		errors = append(errors, ValidationError{
+			Field:   stepName,
+			Message: "Missing required field 'output'",
+			Fix:     "Add 'output:' to capture the rendered skill result or use STDOUT.",
+		})
+	}
+
+	if args, ok := stepMap["args"]; ok {
+		if _, ok := args.(map[string]interface{}); !ok {
+			errors = append(errors, ValidationError{
+				Field:   stepName,
+				Message: "args must be a map/object",
+				Fix:     "Define args as key/value pairs under 'args:'.",
+			})
 		}
 	}
 
@@ -483,6 +647,8 @@ func validateLoopsBlock(loopsValue interface{}) []ValidationError {
 				Message: "Loop missing required 'steps' block",
 				Fix:     "Add 'steps:' with one or more step definitions.",
 			})
+		} else {
+			errors = append(errors, validateLoopSteps(loopName, loopMap["steps"])...)
 		}
 
 		// Validate depends_on references exist (if we can)
@@ -499,6 +665,40 @@ func validateLoopsBlock(loopsValue interface{}) []ValidationError {
 				}
 			}
 		}
+	}
+
+	return errors
+}
+
+func validateLoopSteps(loopName string, stepsValue interface{}) []ValidationError {
+	var errors []ValidationError
+
+	switch steps := stepsValue.(type) {
+	case map[string]interface{}:
+		for stepName, stepValue := range steps {
+			errors = append(errors, validateStep(stepName, stepValue)...)
+		}
+	case []interface{}:
+		for index, item := range steps {
+			stepDef, ok := item.(map[string]interface{})
+			if !ok || len(stepDef) != 1 {
+				errors = append(errors, ValidationError{
+					Field:   loopName,
+					Message: fmt.Sprintf("Loop step %d must be a single-entry map", index+1),
+					Fix:     "Use list-style loop steps like '- step_name: { ... }'.",
+				})
+				continue
+			}
+			for stepName, stepValue := range stepDef {
+				errors = append(errors, validateStep(stepName, stepValue)...)
+			}
+		}
+	default:
+		errors = append(errors, ValidationError{
+			Field:   loopName,
+			Message: "Loop steps must be a map or list of named steps",
+			Fix:     "Define steps as either 'steps: { step_name: ... }' or a list of single-entry maps.",
+		})
 	}
 
 	return errors
@@ -557,6 +757,24 @@ func validateOutputField(stepName string, output interface{}) []ValidationError 
 				Fix:     "Provide an output destination like 'STDOUT' or a filename.",
 			})
 		}
+	case []interface{}:
+		if len(v) == 0 {
+			errors = append(errors, ValidationError{
+				Field:   stepName,
+				Message: "output list is empty",
+				Fix:     "Provide at least one output destination such as 'STDOUT' or a filename.",
+			})
+		}
+		for i, item := range v {
+			outputItem, ok := item.(string)
+			if !ok || outputItem == "" {
+				errors = append(errors, ValidationError{
+					Field:   stepName,
+					Message: fmt.Sprintf("output list item %d is not a non-empty string", i),
+					Fix:     "Output list items should be strings such as 'STDOUT', variables, or file paths.",
+				})
+			}
+		}
 	case map[string]interface{}:
 		// Valid: complex output like {database: ...}
 	default:
@@ -568,6 +786,125 @@ func validateOutputField(stepName string, output interface{}) []ValidationError 
 	}
 
 	return errors
+}
+
+func collectStepOutputs(stepMap map[string]interface{}, stepName string, outputFiles map[string]string) {
+	switch output := stepMap["output"].(type) {
+	case string:
+		if strings.HasPrefix(output, "$") {
+			return
+		}
+		if output != OutputSTDOUT && output != InputSTDIN {
+			outputFiles[output] = stepName
+		}
+	case []interface{}:
+		for _, item := range output {
+			outputStr, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if outputStr == OutputSTDOUT || outputStr == InputSTDIN || strings.HasPrefix(outputStr, "$") {
+				continue
+			}
+			if outputStr != OutputSTDOUT && outputStr != InputSTDIN {
+				outputFiles[outputStr] = stepName
+			}
+		}
+	}
+}
+
+func collectStepVariables(stepMap map[string]interface{}, stepName string, exportedVars map[string]string) {
+	switch output := stepMap["output"].(type) {
+	case string:
+		if strings.HasPrefix(output, "$") {
+			exportedVars[strings.TrimPrefix(output, "$")] = stepName
+		}
+	case []interface{}:
+		for _, item := range output {
+			outputStr, ok := item.(string)
+			if ok && strings.HasPrefix(outputStr, "$") {
+				exportedVars[strings.TrimPrefix(outputStr, "$")] = stepName
+			}
+		}
+	}
+}
+
+func validateStepVariableRefs(stepName string, stepMap map[string]interface{}, exportedVars map[string]string) []ValidationError {
+	var errors []ValidationError
+	varRefRegex := regexp.MustCompile(`\$([A-Z_][A-Z0-9_]*)`)
+
+	checkRefs := func(fieldName string, value string) {
+		matches := varRefRegex.FindAllStringSubmatch(value, -1)
+		for _, match := range matches {
+			varName := match[1]
+			if fieldName == "action" && (strings.HasPrefix(varName, "LOOP") || varName == InputSTDIN || varName == OutputSTDOUT) {
+				continue
+			}
+			if _, exists := exportedVars[varName]; !exists {
+				messagePrefix := "References"
+				if fieldName == "action" {
+					messagePrefix = "Action references"
+				}
+				if fieldName == "action" {
+					if strings.Contains(varName, "_") && !strings.HasSuffix(varName, "_INDEX") {
+						continue
+					}
+				}
+				errors = append(errors, ValidationError{
+					Field:   stepName,
+					Message: fmt.Sprintf("%s variable $%s but no prior step exports it", messagePrefix, varName),
+					Fix:     fmt.Sprintf("Ensure a prior step or loop sets 'output_state: $%s', or use a codebase-index step that exports this variable.", varName),
+				})
+			}
+		}
+	}
+
+	switch input := stepMap["input"].(type) {
+	case string:
+		checkRefs("input", input)
+	case []interface{}:
+		for _, item := range input {
+			if inputStr, ok := item.(string); ok {
+				checkRefs("input", inputStr)
+			}
+		}
+	}
+
+	switch action := stepMap["action"].(type) {
+	case string:
+		checkRefs("action", action)
+	case []interface{}:
+		for _, item := range action {
+			if actionStr, ok := item.(string); ok {
+				checkRefs("action", actionStr)
+			}
+		}
+	}
+
+	return errors
+}
+
+func forEachLoopStep(stepsValue interface{}, fn func(stepName string, stepMap map[string]interface{})) {
+	switch steps := stepsValue.(type) {
+	case map[string]interface{}:
+		for stepName, stepDef := range steps {
+			if stepMap, ok := stepDef.(map[string]interface{}); ok {
+				fn(stepName, stepMap)
+			}
+		}
+	case []interface{}:
+		for _, item := range steps {
+			stepDef, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for stepName, stepValue := range stepDef {
+				if stepMap, ok := stepValue.(map[string]interface{}); ok {
+					fn(stepName, stepMap)
+				}
+			}
+		}
+	}
 }
 
 // validateExecuteLoopsIgnoredSteps checks for top-level steps that will be ignored when execute_loops is present
@@ -648,12 +985,8 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 						}
 					}
 
-					// Check for file outputs
-					if output, ok := stepMap["output"].(string); ok {
-						if output != OutputSTDOUT && output != InputSTDIN && !strings.HasPrefix(output, "$") {
-							outputFiles[output] = stepName
-						}
-					}
+					collectStepOutputs(stepMap, stepName, outputFiles)
+					collectStepVariables(stepMap, stepName, exportedVars)
 				}
 			}
 		}
@@ -663,6 +996,18 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 	if _, hasExecuteLoops := workflow["execute_loops"]; !hasExecuteLoops {
 		for stepName, stepDef := range workflow {
 			if stepName == "loops" || stepName == "execute_loops" || stepName == "workflow" || stepName == "agentic-loop" {
+				continue
+			}
+			if isStepCollection(stepDef) {
+				groupMap := stepDef.(map[string]interface{})
+				for nestedName, nestedDef := range groupMap {
+					nestedStepMap, ok := nestedDef.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					collectStepOutputs(nestedStepMap, nestedName, outputFiles)
+					collectStepVariables(nestedStepMap, nestedName, exportedVars)
+				}
 				continue
 			}
 			stepMap, ok := stepDef.(map[string]interface{})
@@ -687,57 +1032,12 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 				}
 			}
 
-			// Check for file outputs
-			if output, ok := stepMap["output"].(string); ok {
-				if output != OutputSTDOUT && output != InputSTDIN && !strings.HasPrefix(output, "$") {
-					outputFiles[output] = stepName
-				}
-			}
+			collectStepOutputs(stepMap, stepName, outputFiles)
+			collectStepVariables(stepMap, stepName, exportedVars)
 		}
 	}
 
 	// Now validate that inputs reference valid exports
-	varRefRegex := regexp.MustCompile(`\$([A-Z_][A-Z0-9_]*)`)
-
-	validateInputRefs := func(stepName string, stepMap map[string]interface{}) {
-		// Check input field for variable references
-		if input, ok := stepMap["input"].(string); ok {
-			matches := varRefRegex.FindAllStringSubmatch(input, -1)
-			for _, match := range matches {
-				varName := match[1]
-				if _, exists := exportedVars[varName]; !exists {
-					errors = append(errors, ValidationError{
-						Field:   stepName,
-						Message: fmt.Sprintf("References variable $%s but no prior step exports it", varName),
-						Fix:     fmt.Sprintf("Ensure a prior step or loop sets 'output_state: $%s', or use a codebase-index step that exports this variable.", varName),
-					})
-				}
-			}
-		}
-
-		// Check action field for variable references
-		if action, ok := stepMap["action"].(string); ok {
-			matches := varRefRegex.FindAllStringSubmatch(action, -1)
-			for _, match := range matches {
-				varName := match[1]
-				// Skip loop template variables
-				if strings.HasPrefix(varName, "LOOP") || varName == InputSTDIN || varName == OutputSTDOUT {
-					continue
-				}
-				if _, exists := exportedVars[varName]; !exists {
-					// Only warn if it looks like a workflow variable (not env var)
-					if !strings.Contains(varName, "_") || strings.HasSuffix(varName, "_INDEX") {
-						errors = append(errors, ValidationError{
-							Field:   stepName,
-							Message: fmt.Sprintf("Action references variable $%s but no prior step exports it", varName),
-							Fix:     fmt.Sprintf("Ensure a prior step or loop sets 'output_state: $%s', or this variable comes from a codebase-index step.", varName),
-						})
-					}
-				}
-			}
-		}
-	}
-
 	// Validate loops
 	if loops, ok := workflow["loops"].(map[string]interface{}); ok {
 		for loopName, loopDef := range loops {
@@ -745,13 +1045,9 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 			if !ok {
 				continue
 			}
-			if steps, ok := loopMap["steps"].(map[string]interface{}); ok {
-				for stepName, stepDef := range steps {
-					if stepMap, ok := stepDef.(map[string]interface{}); ok {
-						validateInputRefs(fmt.Sprintf("%s.%s", loopName, stepName), stepMap)
-					}
-				}
-			}
+			forEachLoopStep(loopMap["steps"], func(stepName string, stepMap map[string]interface{}) {
+				errors = append(errors, validateStepVariableRefs(fmt.Sprintf("%s.%s", loopName, stepName), stepMap, exportedVars)...)
+			})
 		}
 	}
 
@@ -761,8 +1057,17 @@ func validateStepChaining(workflow map[string]interface{}) []ValidationError {
 			if stepName == "loops" || stepName == "execute_loops" || stepName == "workflow" || stepName == "agentic-loop" {
 				continue
 			}
-			if stepMap, ok := stepDef.(map[string]interface{}); ok {
-				validateInputRefs(stepName, stepMap)
+			if stepMap, ok := stepDef.(map[string]interface{}); ok && !isStepCollection(stepMap) {
+				errors = append(errors, validateStepVariableRefs(stepName, stepMap, exportedVars)...)
+			} else if isStepCollection(stepDef) {
+				groupMap := stepDef.(map[string]interface{})
+				for nestedName, nestedDef := range groupMap {
+					nestedStepMap, ok := nestedDef.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					errors = append(errors, validateStepVariableRefs(nestedName, nestedStepMap, exportedVars)...)
+				}
 			}
 		}
 	}

--- a/utils/processor/dsl_validator_test.go
+++ b/utils/processor/dsl_validator_test.go
@@ -290,6 +290,54 @@ index_repo:
 	}
 }
 
+func TestValidateWorkflowStructure_ValidQmdSearchStep(t *testing.T) {
+	yaml := `
+search:
+  type: qmd-search
+  qmd_search:
+    query: "error handling"
+    collection: docs
+  output: CONTEXT
+`
+	result := ValidateWorkflowStructure(yaml)
+	if !result.Valid {
+		t.Errorf("Expected valid qmd-search step, got errors: %s", result.ErrorSummary())
+	}
+}
+
+func TestValidateWorkflowStructure_ValidSkillStep(t *testing.T) {
+	yaml := `
+summarize_readme:
+  skill: summarize
+  input: README.md
+  args:
+    length: short
+  output: STDOUT
+`
+	result := ValidateWorkflowStructure(yaml)
+	if !result.Valid {
+		t.Errorf("Expected valid skill step, got errors: %s", result.ErrorSummary())
+	}
+}
+
+func TestValidateWorkflowStructure_OutputSequenceAllowed(t *testing.T) {
+	yaml := `
+step_one:
+  input:
+    - NA
+  model:
+    - gpt-4o-mini
+  action:
+    - write a summary
+  output:
+    - result.txt
+`
+	result := ValidateWorkflowStructure(yaml)
+	if !result.Valid {
+		t.Errorf("Expected output sequence to be valid, got errors: %s", result.ErrorSummary())
+	}
+}
+
 func TestValidateWorkflowStructure_ValidLoopsBlock(t *testing.T) {
 	yaml := `
 loops:
@@ -321,6 +369,40 @@ execute_loops:
 	result := ValidateWorkflowStructure(yaml)
 	if !result.Valid {
 		t.Errorf("Expected valid loops block, got errors: %s", result.ErrorSummary())
+	}
+}
+
+func TestValidateWorkflowStructure_ValidListStyleLoopSteps(t *testing.T) {
+	yaml := `
+loops:
+  task-a:
+    name: task-a
+    max_iterations: 2
+    steps:
+      - execute:
+          input: NA
+          model: claude-code
+          action: "Do task A"
+          output: STDOUT
+
+  task-b:
+    name: task-b
+    depends_on: [task-a]
+    max_iterations: 1
+    steps:
+      - execute:
+          input: STDIN
+          model: claude-code
+          action: "Do task B"
+          output: STDOUT
+
+execute_loops:
+  - task-a
+  - task-b
+`
+	result := ValidateWorkflowStructure(yaml)
+	if !result.Valid {
+		t.Errorf("Expected valid list-style loop steps, got errors: %s", result.ErrorSummary())
 	}
 }
 

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -410,6 +410,7 @@ agentic-loop:
 
 **Quality Gates (Automated Validation):**
 - ` + "`quality_gates`" + `: (list, optional) Automated checks to run after each iteration. Each gate validates loop output and can trigger retry/abort/skip actions.
+- ` + "`prompt_improvement`" + `: (map, optional) Automatically refine the next iteration's prompt from the latest result.
 
 **Quality Gate Configuration:**
 ` + "```yaml" + `
@@ -447,6 +448,7 @@ quality_gates:
 - ` + "`{{ loop.previous_output }}`" + `: Output from previous iteration
 - ` + "`{{ loop.total_iterations }}`" + `: Maximum allowed iterations
 - ` + "`{{ loop.elapsed_seconds }}`" + `: Seconds since loop started
+- ` + "`{{ loop.current_prompt }}`" + `: The refined prompt that will be used for the next iteration
 
 **Example: Agentic Code Exploration**
 ` + "```yaml" + `

--- a/utils/processor/loop_orchestrator.go
+++ b/utils/processor/loop_orchestrator.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -238,12 +239,12 @@ func (g *DependencyGraph) findCycle() []string {
 				}
 			} else if recStack[dep] {
 				// Found cycle, reconstruct it
-				cycle := []string{dep}
-				current := node
-				for current != dep {
-					cycle = append([]string{current}, cycle...)
-					current = parent[current]
+				cycle := []string{node}
+				for current := parent[node]; current != dep; current = parent[current] {
+					cycle = append(cycle, current)
 				}
+				slices.Reverse(cycle)
+				cycle = append([]string{dep}, cycle...)
 				cycle = append(cycle, dep) // Close the cycle
 				return cycle
 			}

--- a/utils/processor/loop_orchestrator_test.go
+++ b/utils/processor/loop_orchestrator_test.go
@@ -1,0 +1,48 @@
+package processor
+
+import "testing"
+
+func TestDependencyGraphFindCycle_ClosedPath(t *testing.T) {
+	graph := &DependencyGraph{
+		nodes: map[string]*GraphNode{
+			"loop-a": {name: "loop-a"},
+			"loop-b": {name: "loop-b"},
+			"loop-c": {name: "loop-c"},
+		},
+		edges: map[string][]string{
+			"loop-a": {"loop-c"},
+			"loop-b": {"loop-a"},
+			"loop-c": {"loop-b"},
+		},
+		reverseEdges: map[string][]string{
+			"loop-a": {"loop-b"},
+			"loop-b": {"loop-c"},
+			"loop-c": {"loop-a"},
+		},
+	}
+
+	cycle := graph.findCycle()
+	if len(cycle) != 4 {
+		t.Fatalf("expected closed 3-node cycle, got %v", cycle)
+	}
+
+	if cycle[0] != cycle[len(cycle)-1] {
+		t.Fatalf("expected cycle to start and end on same node, got %v", cycle)
+	}
+
+	for i := 1; i < len(cycle)-1; i++ {
+		if cycle[i] == cycle[i+1] {
+			t.Fatalf("expected no duplicate adjacent nodes in cycle, got %v", cycle)
+		}
+	}
+
+	seen := map[string]bool{}
+	for _, node := range cycle[:len(cycle)-1] {
+		seen[node] = true
+	}
+	for _, expected := range []string{"loop-a", "loop-b", "loop-c"} {
+		if !seen[expected] {
+			t.Fatalf("expected cycle to include %s, got %v", expected, cycle)
+		}
+	}
+}

--- a/utils/processor/loop_state.go
+++ b/utils/processor/loop_state.go
@@ -20,6 +20,7 @@ type LoopState struct {
 	LastUpdateTime     time.Time           `json:"last_update_time"`
 	PreviousOutput     string              `json:"previous_output"`
 	History            []LoopIteration     `json:"history"`
+	CurrentActions     map[string]string   `json:"current_actions,omitempty"`
 	Variables          map[string]string   `json:"variables"`
 	Status             string              `json:"status"` // running, paused, completed, failed
 	ExitCondition      string              `json:"exit_condition"`
@@ -248,6 +249,7 @@ func loopStateFromContext(ctx *LoopContext, name string, config *AgenticLoopConf
 		LastUpdateTime:   time.Now(),
 		PreviousOutput:   ctx.PreviousOutput,
 		History:          ctx.History,
+		CurrentActions:   ctx.CurrentActions,
 		Variables:        variables,
 		Status:           "running",
 		ExitCondition:    config.ExitCondition,
@@ -264,6 +266,7 @@ func stateToLoopContext(state *LoopState) *LoopContext {
 		PreviousOutput: state.PreviousOutput,
 		History:        state.History,
 		StartTime:      state.StartTime,
+		CurrentActions: state.CurrentActions,
 	}
 }
 

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -34,14 +34,15 @@ func resolvePathAtParseTime(path string) string {
 
 // AgenticLoopConfig represents the configuration for an agentic loop
 type AgenticLoopConfig struct {
-	MaxIterations  int      `yaml:"max_iterations"`          // Maximum iterations before stopping (default: 10)
-	TimeoutSeconds int      `yaml:"timeout_seconds"`         // Total timeout in seconds (default: 0 = no timeout)
-	ExitCondition  string   `yaml:"exit_condition"`          // Exit condition: llm_decides, pattern_match
-	ExitPattern    string   `yaml:"exit_pattern"`            // Regex pattern for pattern_match exit condition
-	ContextWindow  int      `yaml:"context_window"`          // Number of past iterations to include in context (default: 5)
-	Steps          []Step   `yaml:"steps,omitempty"`         // Sub-steps to execute within each iteration
-	AllowedPaths   []string `yaml:"allowed_paths,omitempty"` // Directories for agentic tool access
-	Tools          []string `yaml:"tools,omitempty"`         // Optional tool whitelist (Read, Write, Edit, Bash, etc.)
+	MaxIterations     int                      `yaml:"max_iterations"`               // Maximum iterations before stopping (default: 10)
+	TimeoutSeconds    int                      `yaml:"timeout_seconds"`              // Total timeout in seconds (default: 0 = no timeout)
+	ExitCondition     string                   `yaml:"exit_condition"`               // Exit condition: llm_decides, pattern_match
+	ExitPattern       string                   `yaml:"exit_pattern"`                 // Regex pattern for pattern_match exit condition
+	ContextWindow     int                      `yaml:"context_window"`               // Number of past iterations to include in context (default: 5)
+	Steps             []Step                   `yaml:"steps,omitempty"`              // Sub-steps to execute within each iteration
+	AllowedPaths      []string                 `yaml:"allowed_paths,omitempty"`      // Directories for agentic tool access
+	Tools             []string                 `yaml:"tools,omitempty"`              // Optional tool whitelist (Read, Write, Edit, Bash, etc.)
+	PromptImprovement *PromptImprovementConfig `yaml:"prompt_improvement,omitempty"` // Optional prompt refinement between iterations
 
 	// State persistence & quality gates
 	Name               string              `yaml:"name,omitempty"`                // Loop name (required for stateful loops)
@@ -55,12 +56,20 @@ type AgenticLoopConfig struct {
 	OutputState string   `yaml:"output_state,omitempty"` // Variable to export for dependent loops
 }
 
+// PromptImprovementConfig controls automatic prompt refinement between iterations.
+type PromptImprovementConfig struct {
+	Enabled      bool   `yaml:"enabled,omitempty"`      // Defaults to true when the block is present
+	Model        string `yaml:"model,omitempty"`        // Optional model override for prompt refinement
+	Instructions string `yaml:"instructions,omitempty"` // Optional custom guidance for how to improve the next prompt
+}
+
 // LoopContext holds runtime state for an agentic loop
 type LoopContext struct {
-	Iteration      int             // Current iteration number (1-based)
-	PreviousOutput string          // Output from previous iteration
-	History        []LoopIteration // History of all iterations
-	StartTime      time.Time       // When the loop started
+	Iteration      int               // Current iteration number (1-based)
+	PreviousOutput string            // Output from previous iteration
+	History        []LoopIteration   // History of all iterations
+	StartTime      time.Time         // When the loop started
+	CurrentActions map[string]string // Current prompt/action for each loop step
 }
 
 // LoopIteration represents a single iteration's state


### PR DESCRIPTION
## Summary

This PR is a general quality pass focused on aligning Comanda's documented workflow surface with what the validator and runtime actually support.

## What changed

- Expanded DSL validation to accept supported workflow shapes that were previously rejected:
  - top-level parallel step groups
  - `defer` step collections
  - `openai-responses` steps using `instructions`
  - `qmd-search` steps
  - `skill` steps
  - sequence-style outputs
  - list-style loop steps
- Updated top-level agentic loop parsing to support list-style `steps`
- Reworked example coverage to recursively validate and parse the full `examples/` tree
- Added regression tests for validator behavior and cycle detection formatting
- Repaired stale or malformed examples in index-registry, qmd, and tool-use flows
- Added missing tool-use fixture files used by examples
- Fixed cycle formatting so dependency errors report a clean closed loop path

## Root cause

Examples, runtime parsing, and workflow validation had drifted apart over time. That left supported DSL constructs under-tested and, in some cases, incorrectly rejected by the validator used in generation/improvement flows.

## Impact

- Reduces false negatives from workflow validation
- Makes generated/improved workflows more consistent with the real DSL
- Turns `examples/` into a broader compatibility safety net
- Improves confidence in production-facing documentation and failure messages

## Validation

- `go test ./...`
- Manual runs:
  - `comanda process examples/tool-use/tool-input-example.yaml`
  - `comanda process examples/tool-use/tool-output-example.yaml`
  - `comanda process examples/codebase-index/basic-index.yaml`
  - `comanda process examples/agentic-loop/cycle-detection.yaml` (expected failure path)
