### PR TITLE
feat: add llama.cpp provider support

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/database"
+	"github.com/kris-hansen/comanda/utils/discovery"
 	"github.com/kris-hansen/comanda/utils/models"
 	openai "github.com/sashabaranov/go-openai"
 	"github.com/spf13/cobra"
@@ -291,6 +292,10 @@ type VLLMModel struct {
 	OwnedBy string `json:"owned_by"`
 }
 
+func getLlamaCPPModels() ([]string, error) {
+	return discovery.GetLlamaCPPModels()
+}
+
 func getVLLMModels() ([]VLLMModel, error) {
 	endpoint := "http://localhost:8000"
 	resp, err := http.Get(endpoint + "/v1/models")
@@ -322,6 +327,20 @@ func checkVLLMInstalled() bool {
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
+}
+
+func checkLlamaCPPInstalled() bool {
+	return models.IsLlamaCPPAvailable()
+}
+
+func promptForModelAlias(reader *bufio.Reader, target string) string {
+	log.Printf("Alias for model '%s' (press Enter to use as-is): ", target)
+	alias, _ := reader.ReadString('\n')
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return target
+	}
+	return alias
 }
 
 func validatePassword(password string) error {
@@ -922,15 +941,15 @@ func configureAPIProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
 	}
 }
 
-// configureLocalProvider handles adding local providers (Ollama, vLLM)
+// configureLocalProvider handles adding local providers (Ollama, vLLM, llama.cpp)
 func configureLocalProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
-	log.Printf("\nAvailable local providers: ollama, vllm\n")
+	log.Printf("\nAvailable local providers: ollama, vllm, llama.cpp\n")
 	log.Printf("Enter provider name: ")
 	provider, _ := reader.ReadString('\n')
 	provider = strings.TrimSpace(provider)
 
-	if provider != "ollama" && provider != "vllm" {
-		log.Printf("Invalid provider. Choose 'ollama' or 'vllm'\n")
+	if provider != "ollama" && provider != "vllm" && provider != "llama.cpp" {
+		log.Printf("Invalid provider. Choose 'ollama', 'vllm', or 'llama.cpp'\n")
 		return
 	}
 
@@ -940,6 +959,11 @@ func configureLocalProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
 	}
 	if provider == "vllm" && !checkVLLMInstalled() {
 		log.Printf("Error: vLLM server is not running.\n")
+		return
+	}
+	if provider == "llama.cpp" && !checkLlamaCPPInstalled() {
+		log.Printf("Error: llama.cpp CLI is not installed or not in PATH.\n")
+		log.Printf("Install llama.cpp or set LLAMA_CPP_BINARY to your llama-cli path.\n")
 		return
 	}
 
@@ -958,7 +982,7 @@ func configureLocalProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
 		for _, m := range ollamaModels {
 			modelNames = append(modelNames, m.Name)
 		}
-	} else {
+	} else if provider == "vllm" {
 		vllmModels, err := getVLLMModels()
 		if err != nil {
 			log.Printf("Error fetching vLLM models: %v\n", err)
@@ -967,6 +991,25 @@ func configureLocalProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
 		for _, m := range vllmModels {
 			modelNames = append(modelNames, m.ID)
 		}
+	} else {
+		ggufModels, err := getLlamaCPPModels()
+		if err != nil {
+			log.Printf("Error discovering llama.cpp GGUF models: %v\n", err)
+			return
+		}
+		modelNames = append(modelNames, ggufModels...)
+	}
+
+	if provider == "llama.cpp" && len(modelNames) == 0 {
+		log.Printf("No GGUF models found via LLAMA_CPP_MODEL_DIR or LLAMA_CPP_MODEL_DIRS.\n")
+		log.Printf("Enter path to a .gguf model file: ")
+		modelPath, _ := reader.ReadString('\n')
+		modelPath = strings.TrimSpace(modelPath)
+		if modelPath == "" {
+			log.Printf("No model path provided.\n")
+			return
+		}
+		modelNames = []string{modelPath}
 	}
 
 	if len(modelNames) == 0 {
@@ -981,15 +1024,16 @@ func configureLocalProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
 	}
 
 	for _, modelName := range selectedModels {
+		alias := promptForModelAlias(reader, modelName)
 		modes, err := promptForModes(reader, modelName)
 		if err != nil {
 			continue
 		}
-		newModel := config.Model{Name: modelName, Type: "local", Modes: modes}
+		newModel := config.Model{Name: alias, Target: modelName, Type: "local", Modes: modes}
 		if err := envConfig.AddModelToProvider(provider, newModel); err != nil {
 			log.Printf("Error adding model %s: %v\n", modelName, err)
 		} else {
-			log.Printf("%s Added model: %s\n", greenCheckmark, modelName)
+			log.Printf("%s Added model: %s\n", greenCheckmark, alias)
 		}
 	}
 }
@@ -1811,12 +1855,12 @@ Flag Groups:
 				log.Printf("\n")
 				log.Printf("Available provider types:\n")
 				log.Printf("  API-based:   openai, anthropic, google, xai, deepseek, moonshot\n")
-				log.Printf("  Local:       ollama, vllm\n")
+				log.Printf("  Local:       ollama, vllm, llama.cpp\n")
 				log.Printf("  CLI Agents:  claude-code, gemini-cli, openai-codex\n")
 				log.Printf("\nEnter provider: ")
 				provider, _ = reader.ReadString('\n')
 				provider = strings.TrimSpace(provider)
-				validProviders := []string{"openai", "anthropic", "ollama", "vllm", "google", "xai", "deepseek", "moonshot", "claude-code", "gemini-cli", "openai-codex"}
+				validProviders := []string{"openai", "anthropic", "ollama", "vllm", "llama.cpp", "google", "xai", "deepseek", "moonshot", "claude-code", "gemini-cli", "openai-codex"}
 				isValid := false
 				for _, vp := range validProviders {
 					if provider == vp {
@@ -1840,6 +1884,12 @@ Flag Groups:
 			if provider == "vllm" {
 				if !checkVLLMInstalled() {
 					log.Printf("Error: vLLM server is not running. Please start vLLM server and try again.")
+					return
+				}
+			}
+			if provider == "llama.cpp" {
+				if !checkLlamaCPPInstalled() {
+					log.Printf("Error: llama.cpp CLI is not installed or not in PATH. Install llama.cpp or set LLAMA_CPP_BINARY.")
 					return
 				}
 			}
@@ -1879,13 +1929,13 @@ Flag Groups:
 			existingProvider, err := envConfig.GetProviderConfig(provider)
 			var apiKey string
 			if err != nil {
-				if provider != "ollama" && provider != "vllm" {
+				if provider != "ollama" && provider != "vllm" && provider != "llama.cpp" {
 					// Only prompt for API key if not local providers
 					log.Printf("Enter API key: ")
 					apiKey, _ = reader.ReadString('\n')
 					apiKey = strings.TrimSpace(apiKey)
 				} else {
-					// For local providers (ollama, vllm), use "LOCAL" as the API key
+					// For local providers (ollama, vllm, llama.cpp), use "LOCAL" as the API key
 					apiKey = "LOCAL"
 				}
 				existingProvider = &config.Provider{
@@ -2031,15 +2081,39 @@ Flag Groups:
 					log.Printf("Error selecting models: %v\n", err)
 					return
 				}
+
+			case "llama.cpp":
+				modelNames, err := getLlamaCPPModels()
+				if err != nil {
+					log.Printf("Error discovering llama.cpp GGUF models: %v\n", err)
+					return
+				}
+				if len(modelNames) == 0 {
+					log.Printf("No GGUF models found via LLAMA_CPP_MODEL_DIR or LLAMA_CPP_MODEL_DIRS.\n")
+					log.Printf("Enter path to a .gguf model file: ")
+					modelPath, _ := reader.ReadString('\n')
+					modelPath = strings.TrimSpace(modelPath)
+					if modelPath == "" {
+						log.Printf("No model path provided.")
+						return
+					}
+					modelNames = []string{modelPath}
+				}
+				selectedModels, err = promptForModelSelection(modelNames)
+				if err != nil {
+					log.Printf("Error selecting models: %v\n", err)
+					return
+				}
 			}
 
 			// Add new models to provider
 			modelType := "external"
-			if provider == "ollama" || provider == "vllm" {
+			if provider == "ollama" || provider == "vllm" || provider == "llama.cpp" {
 				modelType = "local"
 			}
 
 			for _, modelName := range selectedModels {
+				alias := promptForModelAlias(reader, modelName)
 				// Prompt for modes for each model
 				modes, err := promptForModes(reader, modelName)
 				if err != nil {
@@ -2048,9 +2122,10 @@ Flag Groups:
 				}
 
 				newModel := config.Model{
-					Name:  modelName,
-					Type:  modelType,
-					Modes: modes,
+					Name:   alias,
+					Target: modelName,
+					Type:   modelType,
+					Modes:  modes,
 				}
 
 				if err := envConfig.AddModelToProvider(provider, newModel); err != nil {
@@ -2271,6 +2346,9 @@ func listConfiguration() {
 		}
 		for _, model := range provider.Models {
 			log.Printf("  - %s (%s)\n", model.Name, model.Type)
+			if model.Target != "" && model.Target != model.Name {
+				log.Printf("    Target: %s\n", model.Target)
+			}
 			if len(model.Modes) > 0 {
 				modeStr := make([]string, len(model.Modes))
 				for i, mode := range model.Modes {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -188,8 +188,15 @@ overridden with --model.`,
 
 		dslGuide := processor.GetEmbeddedLLMGuideWithModels(availableModels)
 
+		resolvedGenerationModel := modelForGeneration
+		if envConfig != nil {
+			if _, configuredModel, err := envConfig.ResolveConfiguredModel(modelForGeneration); err == nil && configuredModel != nil && configuredModel.Target != "" {
+				resolvedGenerationModel = configuredModel.Target
+			}
+		}
+
 		// Get the provider
-		provider := models.DetectProvider(modelForGeneration)
+		provider := models.DetectProvider(resolvedGenerationModel)
 		if provider == nil {
 			return fmt.Errorf("could not detect provider for model: %s", modelForGeneration)
 		}
@@ -243,7 +250,7 @@ overridden with --model.`,
 			spinner.Start(spinnerMsg)
 
 			// Call the LLM
-			generatedResponse, err := provider.SendPrompt(modelForGeneration, prompt)
+			generatedResponse, err := provider.SendPrompt(resolvedGenerationModel, prompt)
 			spinner.Stop()
 			if err != nil {
 				return fmt.Errorf("LLM execution failed for model '%s': %w", modelForGeneration, err)
@@ -391,8 +398,15 @@ overridden with --model.`,
 
 		dslGuide := processor.GetEmbeddedLLMGuideWithModels(availableModels)
 
+		resolvedGenerationModel := modelForGeneration
+		if envConfig != nil {
+			if _, configuredModel, err := envConfig.ResolveConfiguredModel(modelForGeneration); err == nil && configuredModel != nil && configuredModel.Target != "" {
+				resolvedGenerationModel = configuredModel.Target
+			}
+		}
+
 		// Get the provider
-		provider := models.DetectProvider(modelForGeneration)
+		provider := models.DetectProvider(resolvedGenerationModel)
 		if provider == nil {
 			return fmt.Errorf("could not detect provider for model: %s", modelForGeneration)
 		}
@@ -437,7 +451,7 @@ overridden with --model.`,
 			}
 			spinner.Start(spinnerMsg)
 
-			generatedResponse, err := provider.SendPrompt(modelForGeneration, prompt)
+			generatedResponse, err := provider.SendPrompt(resolvedGenerationModel, prompt)
 			spinner.Stop()
 			if err != nil {
 				return fmt.Errorf("LLM execution failed for model '%s': %w", modelForGeneration, err)

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -256,6 +256,13 @@ consolidate_results:
 - `claude-code-sonnet` - Uses Claude Sonnet 4.5
 - `claude-code-haiku` - Uses Claude Haiku 4.5
 
+**llama.cpp GGUF models** (for local inference via `llama-cli`):
+- Use a direct `.gguf` file path as the model, e.g. `model: /models/qwen2.5-7b-instruct.gguf`
+- Or use an explicit prefix, e.g. `model: llama.cpp:/models/qwen2.5-7b-instruct.gguf`
+- `comanda configure` can register a GGUF file with a short alias, so workflows can use `model: qwen-local` instead of a full path
+- Set `LLAMA_CPP_BINARY` if `llama-cli` is not in `PATH`
+- Set `LLAMA_CPP_MODEL_DIR` or `LLAMA_CPP_MODEL_DIRS` to help `comanda configure` discover GGUF files
+
 ### Actions
 - Single instruction: `action: "Summarize this text."`
 - Multiple sequential instructions: `action: ["Action 1", "Action 2"]`

--- a/examples/model-examples/llama-cpp-gguf-example.yaml
+++ b/examples/model-examples/llama-cpp-gguf-example.yaml
@@ -1,0 +1,19 @@
+# Example: run a local GGUF model through llama.cpp
+#
+# Requirements:
+#   - llama.cpp installed with `llama-cli` available, or set LLAMA_CPP_BINARY
+#   - a local GGUF file on disk
+#
+# Usage:
+#   comanda process examples/model-examples/llama-cpp-gguf-example.yaml \
+#     --vars gguf_path=/absolute/path/to/model.gguf < prompt.txt
+#
+# Or configure an alias first with `comanda configure` and replace `{{gguf_path}}`
+# below with something short like `qwen-local`.
+
+summarize_with_llama_cpp:
+  input: STDIN
+  model: "{{gguf_path}}"
+  action: |
+    Summarize the input in 5 concise bullet points.
+  output: STDOUT

--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -46,9 +46,10 @@ type DatabaseConfig struct {
 
 // Model represents a single model configuration
 type Model struct {
-	Name  string      `yaml:"name"`
-	Type  string      `yaml:"type"`
-	Modes []ModelMode `yaml:"modes"`
+	Name   string      `yaml:"name"`
+	Target string      `yaml:"target,omitempty"`
+	Type   string      `yaml:"type"`
+	Modes  []ModelMode `yaml:"modes"`
 }
 
 // Provider represents a provider's configuration
@@ -543,10 +544,32 @@ func (c *EnvConfig) AddModelToProvider(providerName string, model Model) error {
 		return fmt.Errorf("provider %s not found", providerName)
 	}
 
-	// Check if model already exists
+	model.Name = strings.TrimSpace(model.Name)
+	model.Target = strings.TrimSpace(model.Target)
+	if model.Name == "" {
+		return fmt.Errorf("model name is required")
+	}
+	if model.Target == "" {
+		model.Target = model.Name
+	}
+
+	// Enforce globally unique configured names so aliases remain unambiguous.
+	for existingProviderName, existingProvider := range c.Providers {
+		for _, existingModel := range existingProvider.Models {
+			if existingModel.Name == model.Name {
+				return fmt.Errorf("model %s already exists for provider %s", model.Name, existingProviderName)
+			}
+		}
+	}
+
+	// Check if model target already exists for this provider.
 	for _, m := range provider.Models {
-		if m.Name == model.Name {
-			return fmt.Errorf("model %s already exists for provider %s", model.Name, providerName)
+		existingTarget := m.Target
+		if existingTarget == "" {
+			existingTarget = m.Name
+		}
+		if existingTarget == model.Target {
+			return fmt.Errorf("model target %s already exists for provider %s", model.Target, providerName)
 		}
 	}
 
@@ -572,14 +595,19 @@ func (c *EnvConfig) GetModelConfig(providerName, modelName string) (*Model, erro
 	var baseMatches []*Model
 
 	for _, model := range provider.Models {
+		target := model.Target
+		if target == "" {
+			target = model.Name
+		}
+
 		// Check for exact match first
-		if model.Name == modelName {
+		if model.Name == modelName || target == modelName {
 			exactMatch = &model
 			break
 		}
 
 		// Check if this model matches the base name (before any tag)
-		modelBaseName := strings.Split(model.Name, ":")[0]
+		modelBaseName := strings.Split(target, ":")[0]
 		if modelBaseName == modelName {
 			baseMatches = append(baseMatches, &model)
 		}
@@ -605,6 +633,39 @@ func (c *EnvConfig) GetModelConfig(providerName, modelName string) (*Model, erro
 	}
 
 	return nil, fmt.Errorf("model %s not found for provider %s", modelName, providerName)
+}
+
+// ResolveConfiguredModel finds a configured model by its user-facing name across all providers.
+func (c *EnvConfig) ResolveConfiguredModel(modelName string) (string, *Model, error) {
+	var matchedProvider string
+	var matchedModel *Model
+
+	for providerName, provider := range c.Providers {
+		for _, model := range provider.Models {
+			target := model.Target
+			if target == "" {
+				target = model.Name
+			}
+
+			if model.Name == modelName || target == modelName {
+				if matchedModel != nil {
+					return "", nil, fmt.Errorf("ambiguous configured model %s", modelName)
+				}
+				modelCopy := model
+				if modelCopy.Target == "" {
+					modelCopy.Target = modelCopy.Name
+				}
+				matchedProvider = providerName
+				matchedModel = &modelCopy
+			}
+		}
+	}
+
+	if matchedModel == nil {
+		return "", nil, fmt.Errorf("configured model %s not found", modelName)
+	}
+
+	return matchedProvider, matchedModel, nil
 }
 
 // UpdateAPIKey updates the API key for a specific provider

--- a/utils/config/env_test.go
+++ b/utils/config/env_test.go
@@ -275,3 +275,110 @@ func TestIsAgenticToolsAllowed(t *testing.T) {
 		})
 	}
 }
+
+func TestAddModelToProviderStoresTargetAndResolvesAlias(t *testing.T) {
+	cfg := &EnvConfig{
+		Providers: map[string]*Provider{
+			"llama.cpp": {
+				APIKey: "LOCAL",
+			},
+			"openai": {
+				APIKey: "test-key",
+			},
+		},
+	}
+
+	err := cfg.AddModelToProvider("llama.cpp", Model{
+		Name:   "qwen-local",
+		Target: "/models/Qwen2.5-7B-Instruct-Q4_K_M.gguf",
+		Type:   "local",
+		Modes:  []ModelMode{TextMode},
+	})
+	if err != nil {
+		t.Fatalf("AddModelToProvider() error = %v", err)
+	}
+
+	providerName, model, err := cfg.ResolveConfiguredModel("qwen-local")
+	if err != nil {
+		t.Fatalf("ResolveConfiguredModel() error = %v", err)
+	}
+
+	if providerName != "llama.cpp" {
+		t.Fatalf("ResolveConfiguredModel() provider = %s, want llama.cpp", providerName)
+	}
+
+	if model.Target != "/models/Qwen2.5-7B-Instruct-Q4_K_M.gguf" {
+		t.Fatalf("ResolveConfiguredModel() target = %s", model.Target)
+	}
+
+	modelConfig, err := cfg.GetModelConfig("llama.cpp", "qwen-local")
+	if err != nil {
+		t.Fatalf("GetModelConfig() error = %v", err)
+	}
+
+	if modelConfig.Target != "/models/Qwen2.5-7B-Instruct-Q4_K_M.gguf" {
+		t.Fatalf("GetModelConfig() target = %s", modelConfig.Target)
+	}
+}
+
+func TestAddModelToProviderRejectsDuplicateAliasAcrossProviders(t *testing.T) {
+	cfg := &EnvConfig{
+		Providers: map[string]*Provider{
+			"llama.cpp": {
+				APIKey: "LOCAL",
+			},
+			"ollama": {
+				APIKey: "LOCAL",
+			},
+		},
+	}
+
+	if err := cfg.AddModelToProvider("llama.cpp", Model{
+		Name:   "local-qwen",
+		Target: "/models/qwen.gguf",
+		Type:   "local",
+		Modes:  []ModelMode{TextMode},
+	}); err != nil {
+		t.Fatalf("first AddModelToProvider() error = %v", err)
+	}
+
+	err := cfg.AddModelToProvider("ollama", Model{
+		Name:   "local-qwen",
+		Target: "qwen2.5:7b",
+		Type:   "local",
+		Modes:  []ModelMode{TextMode},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate alias error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate alias error = %v, want already exists", err)
+	}
+}
+
+func TestResolveConfiguredModelFallsBackToNameAsTarget(t *testing.T) {
+	cfg := &EnvConfig{
+		Providers: map[string]*Provider{
+			"openai": {
+				APIKey: "test-key",
+				Models: []Model{
+					{Name: "gpt-5-mini", Type: "api", Modes: []ModelMode{TextMode}},
+				},
+			},
+		},
+	}
+
+	providerName, model, err := cfg.ResolveConfiguredModel("gpt-5-mini")
+	if err != nil {
+		t.Fatalf("ResolveConfiguredModel() error = %v", err)
+	}
+
+	if providerName != "openai" {
+		t.Fatalf("ResolveConfiguredModel() provider = %s, want openai", providerName)
+	}
+
+	if model.Target != "gpt-5-mini" {
+		t.Fatalf("ResolveConfiguredModel() target = %s, want gpt-5-mini", model.Target)
+	}
+}

--- a/utils/discovery/discovery.go
+++ b/utils/discovery/discovery.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
+	"github.com/kris-hansen/comanda/utils/models"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -16,6 +20,62 @@ type OllamaModel struct {
 	Name    string `json:"name"`
 	ModTime string `json:"modified_at"`
 	Size    int64  `json:"size"`
+}
+
+// CheckLlamaCPPInstalled checks if the llama.cpp CLI is installed and runnable.
+func CheckLlamaCPPInstalled() bool {
+	return models.IsLlamaCPPAvailable()
+}
+
+// GetLlamaCPPModels discovers GGUF models from LLAMA_CPP_MODEL_DIR or LLAMA_CPP_MODEL_DIRS.
+func GetLlamaCPPModels() ([]string, error) {
+	var roots []string
+
+	if single := strings.TrimSpace(os.Getenv("LLAMA_CPP_MODEL_DIR")); single != "" {
+		roots = append(roots, single)
+	}
+	if multi := strings.TrimSpace(os.Getenv("LLAMA_CPP_MODEL_DIRS")); multi != "" {
+		for _, root := range strings.Split(multi, string(os.PathListSeparator)) {
+			root = strings.TrimSpace(root)
+			if root != "" {
+				roots = append(roots, root)
+			}
+		}
+	}
+
+	if len(roots) == 0 {
+		return []string{}, nil
+	}
+
+	var modelsFound []string
+	seen := make(map[string]bool)
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(strings.ToLower(path), ".gguf") {
+				return nil
+			}
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return nil
+			}
+			if !seen[absPath] {
+				seen[absPath] = true
+				modelsFound = append(modelsFound, absPath)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error scanning GGUF models in %s: %v", root, err)
+		}
+	}
+
+	return modelsFound, nil
 }
 
 // GetOpenAIModels fetches the list of available models from the OpenAI API.
@@ -219,6 +279,8 @@ func GetAvailableModels(providerName string, apiKey string) ([]string, error) {
 			modelNames[i] = m.ID
 		}
 		return modelNames, nil
+	case "llama.cpp":
+		return GetLlamaCPPModels()
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", providerName)
 	}

--- a/utils/discovery/discovery.go
+++ b/utils/discovery/discovery.go
@@ -52,7 +52,7 @@ func GetLlamaCPPModels() ([]string, error) {
 	for _, root := range roots {
 		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
-				return nil
+				return err
 			}
 			if d.IsDir() {
 				return nil
@@ -62,7 +62,7 @@ func GetLlamaCPPModels() ([]string, error) {
 			}
 			absPath, err := filepath.Abs(path)
 			if err != nil {
-				return nil
+				return err
 			}
 			if !seen[absPath] {
 				seen[absPath] = true

--- a/utils/models/llamacpp.go
+++ b/utils/models/llamacpp.go
@@ -1,0 +1,249 @@
+package models
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kris-hansen/comanda/utils/fileutil"
+	"github.com/kris-hansen/comanda/utils/retry"
+)
+
+const (
+	llamaCPPPrefixA = "llama.cpp:"
+	llamaCPPPrefixB = "llamacpp:"
+)
+
+// LlamaCPPProvider handles local llama.cpp CLI execution against GGUF models.
+type LlamaCPPProvider struct {
+	verbose    bool
+	binaryPath string
+	mu         sync.Mutex
+}
+
+// NewLlamaCPPProvider creates a new llama.cpp provider instance.
+func NewLlamaCPPProvider() *LlamaCPPProvider {
+	return &LlamaCPPProvider{}
+}
+
+// Name returns the provider name.
+func (l *LlamaCPPProvider) Name() string {
+	return "llama.cpp"
+}
+
+// debugf prints debug information if verbose mode is enabled.
+func (l *LlamaCPPProvider) debugf(format string, args ...interface{}) {
+	if l.verbose {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		log.Printf("[DEBUG][llama.cpp] "+format+"\n", args...)
+	}
+}
+
+// SupportsModel accepts GGUF file paths directly, with optional llama.cpp:/llamacpp: prefixes.
+func (l *LlamaCPPProvider) SupportsModel(modelName string) bool {
+	normalized := normalizeLlamaCPPModel(modelName)
+	return strings.HasSuffix(strings.ToLower(normalized), ".gguf")
+}
+
+// Configure resolves the llama.cpp CLI binary.
+func (l *LlamaCPPProvider) Configure(apiKey string) error {
+	if apiKey != "" && apiKey != "LOCAL" {
+		return fmt.Errorf("invalid API key for llama.cpp: must be 'LOCAL' to indicate local execution")
+	}
+
+	binaryPath, err := findLlamaCPPBinary()
+	if err != nil {
+		return err
+	}
+	l.binaryPath = binaryPath
+	l.debugf("Found llama.cpp binary at: %s", binaryPath)
+	return nil
+}
+
+// SendPrompt executes llama.cpp against the requested GGUF model.
+func (l *LlamaCPPProvider) SendPrompt(modelName string, prompt string) (string, error) {
+	if l.binaryPath == "" {
+		if err := l.Configure("LOCAL"); err != nil {
+			return "", err
+		}
+	}
+
+	modelPath, err := l.resolveModelPath(modelName)
+	if err != nil {
+		return "", err
+	}
+
+	args := l.buildArgs(modelPath, prompt)
+	l.debugf("Executing: %s %v", l.binaryPath, args)
+
+	result, err := retry.WithRetry(
+		func() (interface{}, error) {
+			return l.executeCommand(args, "")
+		},
+		func(err error) bool {
+			return strings.Contains(err.Error(), "timeout")
+		},
+		retry.DefaultRetryConfig,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(result.(string)), nil
+}
+
+// SendPromptWithFile executes llama.cpp with file context embedded into the prompt.
+func (l *LlamaCPPProvider) SendPromptWithFile(modelName string, prompt string, file FileInput) (string, error) {
+	fileData, err := fileutil.SafeReadFile(file.Path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	combinedPrompt := fmt.Sprintf("File: %s\n\n```\n%s\n```\n\nTask: %s", file.Path, string(fileData), prompt)
+	return l.SendPrompt(modelName, combinedPrompt)
+}
+
+// SetVerbose enables or disables verbose mode.
+func (l *LlamaCPPProvider) SetVerbose(verbose bool) {
+	l.verbose = verbose
+}
+
+func (l *LlamaCPPProvider) buildArgs(modelPath, prompt string) []string {
+	args := []string{
+		"-m", modelPath,
+		"--no-display-prompt",
+		"--no-show-timings",
+		"-n", "1024",
+		"-st",
+		"-p", prompt,
+	}
+
+	if extra := strings.TrimSpace(os.Getenv("LLAMA_CPP_ARGS")); extra != "" {
+		args = append(args, strings.Fields(extra)...)
+	}
+
+	return args
+}
+
+func (l *LlamaCPPProvider) executeCommand(args []string, workDir string) (string, error) {
+	cmd := exec.Command(l.binaryPath, args...)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Run()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return "", fmt.Errorf("llama.cpp execution failed: %w\nstderr: %s", err, strings.TrimSpace(stderr.String()))
+		}
+	case <-time.After(2 * time.Minute):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return "", fmt.Errorf("llama.cpp execution timeout")
+	}
+
+	response := strings.TrimSpace(stdout.String())
+	if response == "" && stderr.Len() > 0 {
+		return "", fmt.Errorf("llama.cpp returned no output\nstderr: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	return response, nil
+}
+
+func (l *LlamaCPPProvider) resolveModelPath(modelName string) (string, error) {
+	modelPath := normalizeLlamaCPPModel(modelName)
+	if modelPath == "" {
+		return "", fmt.Errorf("llama.cpp model path is empty")
+	}
+
+	absPath, err := filepath.Abs(modelPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve GGUF path %q: %w", modelPath, err)
+	}
+
+	if !strings.HasSuffix(strings.ToLower(absPath), ".gguf") {
+		return "", fmt.Errorf("llama.cpp requires a .gguf model file, got %q", modelName)
+	}
+
+	if _, err := os.Stat(absPath); err != nil {
+		return "", fmt.Errorf("GGUF model file not found: %s", absPath)
+	}
+
+	return absPath, nil
+}
+
+func normalizeLlamaCPPModel(modelName string) string {
+	trimmed := strings.TrimSpace(modelName)
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasPrefix(lower, llamaCPPPrefixA):
+		return strings.TrimSpace(trimmed[len(llamaCPPPrefixA):])
+	case strings.HasPrefix(lower, llamaCPPPrefixB):
+		return strings.TrimSpace(trimmed[len(llamaCPPPrefixB):])
+	default:
+		return trimmed
+	}
+}
+
+func findLlamaCPPBinary() (string, error) {
+	if configured := strings.TrimSpace(os.Getenv("LLAMA_CPP_BINARY")); configured != "" {
+		if _, err := os.Stat(configured); err == nil {
+			return configured, nil
+		}
+	}
+
+	candidates := []string{
+		"llama-cli",
+		"llama",
+	}
+	for _, candidate := range candidates {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("llama.cpp binary not found and home directory unavailable: %w", err)
+	}
+
+	commonPaths := []string{
+		filepath.Join(homeDir, ".local", "bin", "llama-cli"),
+		filepath.Join(homeDir, "llama.cpp", "build", "bin", "llama-cli"),
+		filepath.Join(homeDir, "src", "llama.cpp", "build", "bin", "llama-cli"),
+		"/opt/homebrew/bin/llama-cli",
+		"/usr/local/bin/llama-cli",
+		"/usr/bin/llama-cli",
+	}
+
+	for _, path := range commonPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("llama.cpp binary not found; set LLAMA_CPP_BINARY or install llama-cli")
+}
+
+// IsLlamaCPPAvailable reports whether the llama.cpp CLI is available locally.
+func IsLlamaCPPAvailable() bool {
+	_, err := findLlamaCPPBinary()
+	return err == nil
+}

--- a/utils/models/llamacpp_test.go
+++ b/utils/models/llamacpp_test.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLlamaCPPProviderName(t *testing.T) {
+	provider := NewLlamaCPPProvider()
+	if provider.Name() != "llama.cpp" {
+		t.Fatalf("expected provider name llama.cpp, got %s", provider.Name())
+	}
+}
+
+func TestLlamaCPPSupportsModel(t *testing.T) {
+	provider := NewLlamaCPPProvider()
+
+	tests := []struct {
+		name     string
+		model    string
+		expected bool
+	}{
+		{"direct gguf path", "/models/tiny.gguf", true},
+		{"prefixed gguf path", "llama.cpp:/models/tiny.gguf", true},
+		{"alternate prefix", "llamacpp:./tiny.gguf", true},
+		{"non-gguf model name", "llama3.2", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := provider.SupportsModel(tt.model); got != tt.expected {
+				t.Fatalf("SupportsModel(%q) = %v, want %v", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeLlamaCPPModel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"llama.cpp:/tmp/model.gguf", "/tmp/model.gguf"},
+		{"llamacpp:./model.gguf", "./model.gguf"},
+		{"./model.gguf", "./model.gguf"},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeLlamaCPPModel(tt.input); got != tt.want {
+			t.Fatalf("normalizeLlamaCPPModel(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLlamaCPPBuildArgs(t *testing.T) {
+	provider := NewLlamaCPPProvider()
+	modelPath := filepath.Join("/tmp", "model.gguf")
+	args := provider.buildArgs(modelPath, "hello")
+
+	expected := []string{"-m", modelPath, "--no-display-prompt", "--no-show-timings", "-n", "1024", "-st", "-p", "hello"}
+	if len(args) < len(expected) {
+		t.Fatalf("buildArgs returned too few args: %v", args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Fatalf("args[%d] = %q, want %q", i, args[i], want)
+		}
+	}
+}

--- a/utils/models/provider.go
+++ b/utils/models/provider.go
@@ -195,6 +195,18 @@ func isModelAvailableOnVLLM(modelName string) bool {
 	return false
 }
 
+func isLlamaCPPModelAvailable(modelName string) bool {
+	provider := NewLlamaCPPProvider()
+	if !provider.SupportsModel(modelName) {
+		return false
+	}
+	if _, err := provider.resolveModelPath(modelName); err != nil {
+		config.DebugLog("[Provider] llama.cpp model not available: %v", err)
+		return false
+	}
+	return true
+}
+
 // DetectProviderFunc is the type for the provider detection function
 type DetectProviderFunc func(modelName string) Provider
 
@@ -226,6 +238,21 @@ func defaultDetectProvider(modelName string) Provider {
 			config.DebugLog("[Provider] Found local vLLM provider for model %s", modelName)
 			return vllmProvider
 		}
+	}
+
+	// Check llama.cpp
+	llamaCPPProvider := NewLlamaCPPProvider()
+	if llamaCPPProvider.SupportsModel(modelName) {
+		if !IsLlamaCPPAvailable() {
+			config.DebugLog("[Provider] Model %s requires llama.cpp but llama-cli was not found", modelName)
+			return nil
+		}
+		if isLlamaCPPModelAvailable(modelName) {
+			config.DebugLog("[Provider] Found local llama.cpp provider for model %s", modelName)
+			return llamaCPPProvider
+		}
+		config.DebugLog("[Provider] Model %s looks like llama.cpp/GGUF but the file was not found", modelName)
+		return nil
 	}
 
 	// Check Claude Code (local CLI)

--- a/utils/processor/action_handler.go
+++ b/utils/processor/action_handler.go
@@ -38,6 +38,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 
 	// For now, use the first model specified
 	modelName := modelNames[0]
+	resolvedModelName := p.resolveModelTarget(modelName)
 
 	// Special case: if model is NA, return the input content directly
 	if modelName == "NA" {
@@ -59,7 +60,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 	}
 
 	// Get provider by detecting it from the model name
-	provider := models.DetectProvider(modelName)
+	provider := models.DetectProvider(resolvedModelName)
 	if provider == nil {
 		return nil, fmt.Errorf("provider not found for model: %s", modelName)
 	}
@@ -70,7 +71,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 		return nil, fmt.Errorf("provider %s not configured", provider.Name())
 	}
 
-	p.debugf("Using model %s with provider %s", modelName, configuredProvider.Name())
+	p.debugf("Using model %s (resolved to %s) with provider %s", modelName, resolvedModelName, configuredProvider.Name())
 	p.debugf("Processing %d action(s)", len(actions))
 
 	// Check if we're in agentic mode (have allowed paths set in agentic loop)
@@ -134,7 +135,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 					}, nil
 				}
 			}
-			result, err := configuredProvider.SendPrompt(modelName, action)
+			result, err := configuredProvider.SendPrompt(resolvedModelName, action)
 			if err != nil {
 				return nil, err
 			}
@@ -226,7 +227,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 							claudeCode.SetWorktree(worktreeName)
 							defer claudeCode.ClearWorktree()
 						}
-						result, err := claudeCode.SendPromptAgentic(modelName, combinedPrompt,
+						result, err := claudeCode.SendPromptAgentic(resolvedModelName, combinedPrompt,
 							agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 						if debugWatcher != nil {
 							debugWatcher.Stop()
@@ -241,7 +242,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 					}
 				}
 				// Non-agentic mode: use SendPromptWithFile as before
-				result, err := configuredProvider.SendPromptWithFile(modelName, action, fileInputs[0])
+				result, err := configuredProvider.SendPromptWithFile(resolvedModelName, action, fileInputs[0])
 				if err != nil {
 					return nil, err
 				}
@@ -270,7 +271,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 					combinedPrompt += fmt.Sprintf("File %d (%s):\n%s\n\n", i+1, file.Path, string(content))
 				}
 				combinedPrompt += fmt.Sprintf("\nAction: %s", action)
-				result, err := configuredProvider.SendPrompt(modelName, combinedPrompt)
+				result, err := configuredProvider.SendPrompt(resolvedModelName, combinedPrompt)
 				if err != nil {
 					return nil, err
 				}
@@ -293,7 +294,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 				// Build a clean prompt that discourages metadata wrapping
 				// Detect output format from action to provide appropriate instructions
 				// Try to process each file individually
-				result, err := configuredProvider.SendPromptWithFile(modelName,
+				result, err := configuredProvider.SendPromptWithFile(resolvedModelName,
 					fmt.Sprintf("%sFor this file: %s", PromptPrefix, action), file)
 
 				if err != nil {
@@ -358,7 +359,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 						claudeCode.SetWorktree(worktreeName)
 						defer claudeCode.ClearWorktree()
 					}
-					result, err := claudeCode.SendPromptAgentic(modelName, combinedPrompt,
+					result, err := claudeCode.SendPromptAgentic(resolvedModelName, combinedPrompt,
 						agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 					// Stop the debug watcher
 					if debugWatcher != nil {
@@ -374,7 +375,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 				}
 			}
 
-			result, err := configuredProvider.SendPrompt(modelName, combinedPrompt)
+			result, err := configuredProvider.SendPrompt(resolvedModelName, combinedPrompt)
 			if err != nil {
 				return nil, err
 			}

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -1935,7 +1935,7 @@ IMPORTANT: When specifying models in the generated YAML, you MUST use one of the
 	// }
 
 	// Assuming provider is already configured via configureProviders() or similar mechanism
-	generatedResponse, err := provider.SendPrompt(genModelName, fullPrompt)
+	generatedResponse, err := provider.SendPrompt(p.resolveModelTarget(genModelName), fullPrompt)
 	if err != nil {
 		return "", fmt.Errorf("LLM execution failed for generate step '%s' with model '%s': %w", step.Name, genModelName, err)
 	}
@@ -2183,14 +2183,39 @@ func (p *Processor) validateGeneratedWorkflow(yamlContent string) error {
 		p.debugf("Checking if model '%s' in generated workflow is valid", modelName)
 
 		// Check if provider exists for this model
-		provider := models.DetectProvider(modelName)
+		resolvedModelName := p.resolveModelTarget(modelName)
+		provider := models.DetectProvider(resolvedModelName)
 		if provider == nil {
-			invalidModels = append(invalidModels, fmt.Sprintf("%s (no provider found)", modelName))
-			continue
+			if providerName, _, err := p.resolveConfiguredModel(modelName); err == nil {
+				switch providerName {
+				case "openai":
+					provider = models.NewOpenAIProvider()
+				case "anthropic":
+					provider = models.NewAnthropicProvider()
+				case "google":
+					provider = models.NewGoogleProvider()
+				case "xai":
+					provider = models.NewXAIProvider()
+				case "deepseek":
+					provider = models.NewDeepseekProvider()
+				case "moonshot":
+					provider = models.NewMoonshotProvider()
+				case "ollama":
+					provider = models.NewOllamaProvider()
+				case "vllm":
+					provider = models.NewVLLMProvider()
+				case "llama.cpp":
+					provider = models.NewLlamaCPPProvider()
+				}
+			}
+			if provider == nil {
+				invalidModels = append(invalidModels, fmt.Sprintf("%s (no provider found)", modelName))
+				continue
+			}
 		}
 
 		// Check if provider supports this model
-		if !provider.SupportsModel(modelName) {
+		if !provider.SupportsModel(resolvedModelName) {
 			invalidModels = append(invalidModels, fmt.Sprintf("%s (not supported by %s)", modelName, provider.Name()))
 			continue
 		}
@@ -2272,52 +2297,53 @@ func (p *Processor) handleDeferredStep() error {
 
 // getProviderForModel retrieves a model provider based on the model name
 func (p *Processor) getProviderForModel(modelName string) (models.Provider, error) {
+	resolvedModelName := p.resolveModelTarget(modelName)
+
 	// First, check if the provider is already initialized
 	for _, provider := range p.providers {
-		if provider.SupportsModel(modelName) {
+		if provider.SupportsModel(resolvedModelName) {
 			return provider, nil
 		}
 	}
 
-	// If not initialized, find the provider in the environment configuration
-	for providerName, providerConfig := range p.envConfig.Providers {
-		for _, model := range providerConfig.Models {
-			if model.Name == modelName {
-				// Initialize the provider if it's not already in the map
-				if _, ok := p.providers[providerName]; !ok {
-					var newProvider models.Provider
-					switch providerName {
-					case "openai":
-						newProvider = models.NewOpenAIProvider()
-					case "anthropic":
-						newProvider = models.NewAnthropicProvider()
-					case "google":
-						newProvider = models.NewGoogleProvider()
-					case "xai":
-						newProvider = models.NewXAIProvider()
-					case "deepseek":
-						newProvider = models.NewDeepseekProvider()
-					case "moonshot":
-						newProvider = models.NewMoonshotProvider()
-					case "ollama":
-						newProvider = models.NewOllamaProvider()
-					case "vllm":
-						newProvider = models.NewVLLMProvider()
-					default:
-						return nil, fmt.Errorf("unknown provider: %s", providerName)
-					}
-					if err := newProvider.Configure(providerConfig.APIKey); err != nil {
-						return nil, fmt.Errorf("failed to configure provider %s: %w", providerName, err)
-					}
-					newProvider.SetVerbose(p.verbose)
-					p.providers[providerName] = newProvider
-				}
-				return p.providers[providerName], nil
-			}
+	providerName, _, err := p.resolveConfiguredModel(modelName)
+	if err != nil {
+		return nil, fmt.Errorf("no provider configured or found for model %s", modelName)
+	}
+	providerConfig := p.envConfig.Providers[providerName]
+
+	if _, ok := p.providers[providerName]; !ok {
+		var newProvider models.Provider
+		switch providerName {
+		case "openai":
+			newProvider = models.NewOpenAIProvider()
+		case "anthropic":
+			newProvider = models.NewAnthropicProvider()
+		case "google":
+			newProvider = models.NewGoogleProvider()
+		case "xai":
+			newProvider = models.NewXAIProvider()
+		case "deepseek":
+			newProvider = models.NewDeepseekProvider()
+		case "moonshot":
+			newProvider = models.NewMoonshotProvider()
+		case "ollama":
+			newProvider = models.NewOllamaProvider()
+		case "vllm":
+			newProvider = models.NewVLLMProvider()
+		case "llama.cpp":
+			newProvider = models.NewLlamaCPPProvider()
+		default:
+			return nil, fmt.Errorf("unknown provider: %s", providerName)
 		}
+		if err := newProvider.Configure(providerConfig.APIKey); err != nil {
+			return nil, fmt.Errorf("failed to configure provider %s: %w", providerName, err)
+		}
+		newProvider.SetVerbose(p.verbose)
+		p.providers[providerName] = newProvider
 	}
 
-	return nil, fmt.Errorf("no provider configured or found for model %s", modelName)
+	return p.providers[providerName], nil
 }
 
 // processPreLoopSteps processes all steps (sequential, parallel, agentic loops) before multi-loop orchestration.

--- a/utils/processor/model_handler.go
+++ b/utils/processor/model_handler.go
@@ -12,6 +12,27 @@ import (
 	"github.com/kris-hansen/comanda/utils/models"
 )
 
+func (p *Processor) resolveConfiguredModel(modelName string) (string, *config.Model, error) {
+	if p.envConfig == nil {
+		return "", nil, fmt.Errorf("environment configuration is not available")
+	}
+	return p.envConfig.ResolveConfiguredModel(modelName)
+}
+
+func (p *Processor) resolveModelTarget(modelName string) string {
+	if p.envConfig == nil {
+		return modelName
+	}
+	_, model, err := p.envConfig.ResolveConfiguredModel(modelName)
+	if err != nil || model == nil {
+		return modelName
+	}
+	if model.Target != "" {
+		return model.Target
+	}
+	return model.Name
+}
+
 // --- Ollama specific types (copied from ollama.go for local check) ---
 
 // OllamaTagsResponse represents the top-level structure of Ollama's /api/tags response
@@ -108,24 +129,54 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 	for _, modelName := range modelNames {
 		p.debugf("Starting validation for model: %s", modelName)
 		p.debugf("Attempting provider detection for model: %s", modelName)
-		provider := models.DetectProvider(modelName)
+		resolvedModelName := p.resolveModelTarget(modelName)
+		provider := models.DetectProvider(resolvedModelName)
 		p.debugf("Provider detection result for %s: found=%v", modelName, provider != nil)
 		if provider == nil {
+			if providerName, _, err := p.resolveConfiguredModel(modelName); err == nil {
+				switch providerName {
+				case "openai":
+					provider = models.NewOpenAIProvider()
+				case "anthropic":
+					provider = models.NewAnthropicProvider()
+				case "google":
+					provider = models.NewGoogleProvider()
+				case "xai":
+					provider = models.NewXAIProvider()
+				case "deepseek":
+					provider = models.NewDeepseekProvider()
+				case "moonshot":
+					provider = models.NewMoonshotProvider()
+				case "ollama":
+					provider = models.NewOllamaProvider()
+				case "vllm":
+					provider = models.NewVLLMProvider()
+				case "llama.cpp":
+					provider = models.NewLlamaCPPProvider()
+				}
+			}
+		}
+		if provider == nil {
 			// Check if this is a Claude Code model - give specific error about missing CLI
-			if models.NewClaudeCodeProvider().SupportsModel(modelName) {
+			if models.NewClaudeCodeProvider().SupportsModel(resolvedModelName) {
 				errMsg := fmt.Sprintf("model %s requires Claude Code CLI, but 'claude' binary not found. Install Claude Code from https://claude.ai/download or ensure it's in your PATH", modelName)
 				p.debugf("Validation failed: %s", errMsg)
 				return fmt.Errorf("%s", errMsg)
 			}
 			// Check if this is a Gemini CLI model - give specific error about missing CLI
-			if models.NewGeminiCLIProvider().SupportsModel(modelName) {
+			if models.NewGeminiCLIProvider().SupportsModel(resolvedModelName) {
 				errMsg := fmt.Sprintf("model %s requires Gemini CLI, but 'gemini' binary not found. Install Gemini CLI via 'npm install -g @google/gemini-cli' or ensure it's in your PATH", modelName)
 				p.debugf("Validation failed: %s", errMsg)
 				return fmt.Errorf("%s", errMsg)
 			}
 			// Check if this is an OpenAI Codex model - give specific error about missing CLI
-			if models.NewOpenAICodexProvider().SupportsModel(modelName) {
+			if models.NewOpenAICodexProvider().SupportsModel(resolvedModelName) {
 				errMsg := fmt.Sprintf("model %s requires OpenAI Codex CLI, but 'codex' binary not found. Install OpenAI Codex CLI via 'npm install -g @openai/codex' or ensure it's in your PATH", modelName)
+				p.debugf("Validation failed: %s", errMsg)
+				return fmt.Errorf("%s", errMsg)
+			}
+			if models.NewLlamaCPPProvider().SupportsModel(resolvedModelName) {
+				errMsg := fmt.Sprintf("model %s requires llama.cpp with a local .gguf file, but 'llama-cli' was not found or the GGUF file does not exist. Install llama.cpp or set LLAMA_CPP_BINARY, and verify the model path is valid", modelName)
 				p.debugf("Validation failed: %s", errMsg)
 				return fmt.Errorf("%s", errMsg)
 			}
@@ -135,8 +186,8 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 		}
 
 		// Check if the provider actually supports this model
-		p.debugf("Checking if provider %s supports model %s", provider.Name(), modelName)
-		if !provider.SupportsModel(modelName) {
+		p.debugf("Checking if provider %s supports model %s", provider.Name(), resolvedModelName)
+		if !provider.SupportsModel(resolvedModelName) {
 			errMsg := fmt.Sprintf("unsupported model: %s (provider %s does not support it)", modelName, provider.Name())
 			p.debugf("Validation failed: %s", errMsg)
 			return fmt.Errorf("%s", errMsg)
@@ -149,7 +200,7 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 		// --- Add Ollama specific local check ---
 		if providerName == "ollama" {
 			p.debugf("Performing local check for Ollama model tag: %s", modelName)
-			exists, err := checkOllamaModelExists(modelName)
+			exists, err := checkOllamaModelExists(resolvedModelName)
 			if err != nil {
 				// Error occurred during check (e.g., connection refused, API error)
 				p.debugf("Ollama local check failed for %s: %v", modelName, err)
@@ -160,7 +211,7 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 				// The error from checkOllamaModelExists already contains the helpful message
 				p.debugf("Ollama model tag %s not found locally.", modelName)
 				// The error from checkOllamaModelExists includes the suggestion to pull
-				return fmt.Errorf("model tag '%s' not found locally via Ollama API", modelName)
+				return fmt.Errorf("model tag '%s' not found locally via Ollama API", resolvedModelName)
 			}
 			p.debugf("Ollama model tag %s confirmed to exist locally.", modelName)
 		}
@@ -198,6 +249,17 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 			continue
 		}
 		// --- End OpenAI Codex specific check ---
+
+		// --- Skip envConfig checks for llama.cpp provider ---
+		// llama.cpp uses a local GGUF model path directly and does not require API keys.
+		if providerName == "llama.cpp" {
+			p.debugf("Skipping envConfig check for llama.cpp provider (uses local GGUF path)")
+			provider.SetVerbose(p.verbose)
+			p.providers[provider.Name()] = provider
+			p.debugf("Model %s is supported by provider %s", modelName, provider.Name())
+			continue
+		}
+		// --- End llama.cpp specific check ---
 
 		// Get model configuration from environment
 		p.debugf("Getting model configuration for %s from provider %s", modelName, providerName)
@@ -252,6 +314,7 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 // Add new local provider names here as needed.
 var localProviders = map[string]bool{
 	"ollama":       true,
+	"llama.cpp":    true,
 	"claude-code":  true,
 	"gemini-cli":   true,
 	"openai-codex": true,

--- a/utils/processor/responses_handler.go
+++ b/utils/processor/responses_handler.go
@@ -371,17 +371,18 @@ func (p *Processor) processResponsesStep(step Step, isParallel bool, parallelID 
 		return "", fmt.Errorf("no model specified for openai-responses step")
 	}
 	modelName := modelNames[0]
+	resolvedModelName := p.resolveModelTarget(modelName)
 
 	// Get the OpenAI provider
-	provider := models.DetectProvider(modelName)
+	provider := models.DetectProvider(resolvedModelName)
 	if provider == nil || provider.Name() != "openai" {
 		return "", fmt.Errorf("openai-responses step requires an OpenAI model, got: %s", modelName)
 	}
 
 	// Check if this is a model that requires the responses API
-	isResponsesAPIModel := strings.HasPrefix(modelName, "o1-pro") ||
-		strings.HasPrefix(modelName, "o3-") ||
-		strings.HasPrefix(modelName, "o4-")
+	isResponsesAPIModel := strings.HasPrefix(resolvedModelName, "o1-pro") ||
+		strings.HasPrefix(resolvedModelName, "o3-") ||
+		strings.HasPrefix(resolvedModelName, "o4-")
 
 	// Log a warning if a model requires the responses API but doesn't have a response format
 	if isResponsesAPIModel && step.Config.ResponseFormat == nil {
@@ -488,7 +489,7 @@ func (p *Processor) processResponsesStep(step Step, isParallel bool, parallelID 
 
 	// Create ResponsesConfig
 	config := models.ResponsesConfig{
-		Model:              modelName,
+		Model:              resolvedModelName,
 		Input:              prompt,
 		Instructions:       step.Config.Instructions,
 		PreviousResponseID: step.Config.PreviousResponseID,

--- a/utils/server/generate_handler.go
+++ b/utils/server/generate_handler.go
@@ -96,8 +96,15 @@ func (s *Server) handleGenerate(w http.ResponseWriter, r *http.Request) {
 
 	dslGuide := processor.GetEmbeddedLLMGuideWithModels(availableModels)
 
+	resolvedGenerationModel := modelForGeneration
+	if s.envConfig != nil {
+		if _, configuredModel, err := s.envConfig.ResolveConfiguredModel(modelForGeneration); err == nil && configuredModel != nil && configuredModel.Target != "" {
+			resolvedGenerationModel = configuredModel.Target
+		}
+	}
+
 	// Get the provider
-	provider := models.DetectProvider(modelForGeneration)
+	provider := models.DetectProvider(resolvedGenerationModel)
 	if provider == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(GenerateResponse{
@@ -135,7 +142,7 @@ func (s *Server) handleGenerate(w http.ResponseWriter, r *http.Request) {
 
 		// Call the LLM
 		config.DebugLog("Sending prompt to LLM (attempt %d): model=%s, prompt_length=%d", attempt, modelForGeneration, len(prompt))
-		generatedResponse, err := provider.SendPrompt(modelForGeneration, prompt)
+		generatedResponse, err := provider.SendPrompt(resolvedGenerationModel, prompt)
 		if err != nil {
 			config.VerboseLog("LLM execution failed: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/utils/server/provider_handlers.go
+++ b/utils/server/provider_handlers.go
@@ -42,6 +42,7 @@ func (s *Server) handleGetProviders(w http.ResponseWriter, r *http.Request) {
 		{"xai", models.NewXAIProvider()},
 		{"ollama", models.NewOllamaProvider()},
 		{"vllm", models.NewVLLMProvider()},
+		{"llama.cpp", models.NewLlamaCPPProvider()},
 	}
 
 	// Get provider configurations
@@ -80,9 +81,10 @@ func (s *Server) handleGetConfiguredModels(w http.ResponseWriter, r *http.Reques
 	configuredModels := make([]ConfiguredModel, len(providerConfig.Models))
 	for i, m := range providerConfig.Models {
 		configuredModels[i] = ConfiguredModel{
-			Name:  m.Name,
-			Type:  m.Type,
-			Modes: m.Modes,
+			Name:   m.Name,
+			Target: m.Target,
+			Type:   m.Type,
+			Modes:  m.Modes,
 		}
 	}
 
@@ -105,7 +107,7 @@ func (s *Server) handleGetAvailableModels(w http.ResponseWriter, r *http.Request
 	apiKey := ""
 	if err == nil { // Provider exists, get its key
 		apiKey = providerConfig.APIKey
-	} else if providerName != "ollama" && providerName != "vllm" && providerName != "anthropic" && providerName != "google" && providerName != "xai" && providerName != "deepseek" {
+	} else if providerName != "ollama" && providerName != "vllm" && providerName != "llama.cpp" && providerName != "anthropic" && providerName != "google" && providerName != "xai" && providerName != "deepseek" {
 		// If provider doesn't exist and requires a key, we can't proceed
 		sendJSONError(w, http.StatusBadRequest, fmt.Sprintf("Provider '%s' not configured or requires an API key to list models", providerName))
 		return
@@ -162,14 +164,15 @@ func (s *Server) handleAddModel(w http.ResponseWriter, r *http.Request, provider
 
 	// Determine model type
 	modelType := "external"
-	if providerName == "ollama" || providerName == "vllm" {
+	if providerName == "ollama" || providerName == "vllm" || providerName == "llama.cpp" {
 		modelType = "local"
 	}
 
 	newModel := config.Model{
-		Name:  req.Name,
-		Type:  modelType,
-		Modes: req.Modes,
+		Name:   req.Name,
+		Target: req.Target,
+		Type:   modelType,
+		Modes:  req.Modes,
 	}
 
 	// Add model to config
@@ -322,6 +325,8 @@ func (s *Server) handleValidateProvider(w http.ResponseWriter, r *http.Request) 
 		provider = models.NewOllamaProvider()
 	case "vllm":
 		provider = models.NewVLLMProvider()
+	case "llama.cpp":
+		provider = models.NewLlamaCPPProvider()
 	default:
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]string{
@@ -406,6 +411,8 @@ func (s *Server) handleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 			provider = models.NewOllamaProvider()
 		case "vllm":
 			provider = models.NewVLLMProvider()
+		case "llama.cpp":
+			provider = models.NewLlamaCPPProvider()
 		default:
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{
@@ -429,8 +436,9 @@ func (s *Server) handleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 	if len(req.Models) > 0 {
 		for _, modelName := range req.Models {
 			model := config.Model{
-				Name:  modelName,
-				Modes: []config.ModelMode{config.TextMode}, // Default to text mode
+				Name:   modelName,
+				Target: modelName,
+				Modes:  []config.ModelMode{config.TextMode}, // Default to text mode
 			}
 			if err := s.envConfig.AddModelToProvider(req.Name, model); err != nil {
 				config.VerboseLog("Error adding model %s: %v", modelName, err)

--- a/utils/server/types.go
+++ b/utils/server/types.go
@@ -233,9 +233,10 @@ func (sw *sseWriter) SendData(data string) (n int, err error) {
 
 // ConfiguredModel represents a model as configured within Comanda
 type ConfiguredModel struct {
-	Name  string          `json:"name"`
-	Type  string          `json:"type"`  // e.g., "local", "external"
-	Modes []cfg.ModelMode `json:"modes"` // Use alias cfg
+	Name   string          `json:"name"`
+	Target string          `json:"target,omitempty"`
+	Type   string          `json:"type"`  // e.g., "local", "external"
+	Modes  []cfg.ModelMode `json:"modes"` // Use alias cfg
 }
 
 // AvailableModel represents a model available from the provider's service
@@ -260,8 +261,9 @@ type ConfiguredModelListResponse struct {
 
 // AddModelRequest is the request body for adding a model to a provider's configuration
 type AddModelRequest struct {
-	Name  string          `json:"name"`
-	Modes []cfg.ModelMode `json:"modes"` // Use alias cfg
+	Name   string          `json:"name"`
+	Target string          `json:"target,omitempty"`
+	Modes  []cfg.ModelMode `json:"modes"` // Use alias cfg
 }
 
 // UpdateModelRequest is the request body for updating a configured model's modes


### PR DESCRIPTION
## Summary
- add llama.cpp as a supported local provider with GGUF model execution through llama-cli
- add alias support for configured models so long GGUF paths can be referenced by short names
- wire provider, config, runtime, server, docs, and example flows for llama.cpp

## Testing
- go test ./utils/models/... ./utils/discovery/... ./utils/processor/... ./utils/server/... ./utils/config/... ./cmd/...