### PR TITLE
ci: bump release workflow Go to 1.25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
@@ -116,7 +116,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Summary
- Bump both `setup-go` steps in `.github/workflows/release.yml` from `1.24` → `1.25` to match `go.mod` (`go 1.25.0`).
- Fixes the `Create Release` workflow failures since fce73a8: `golangci-lint` is `go install`'d at runtime, gets built against the workflow's Go 1.24, then refuses to lint a 1.25 module — blocking every push-to-main release run (and explaining why `VERSION` is stuck at `0.0.178` and Homebrew hasn't updated).
- `pr-checks.yml` was already on 1.25, which is why PR-time CI keeps passing.

## Test plan
- [x] PR CI green (golangci-lint must pass against 1.25 module)
- [ ] After merge, the `Create Release` run on main bumps `VERSION` to `0.0.179`, tags `v0.0.179`, and goreleaser pushes the Homebrew tap update

🤖 Generated with [Claude Code](https://claude.com/claude-code)