### PR TITLE
[fix] Fix cwd-relative workflow paths

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -132,31 +132,20 @@ Input can be provided via:
 				Enabled: false, // Disable server mode for CLI processing
 			}
 
-			// Default runtimeDir to workflow file's directory if not specified
-			// This ensures Claude Code runs in the project directory, not a temp folder
-			effectiveRuntimeDir := runtimeDir
-			if effectiveRuntimeDir == "" {
-				effectiveRuntimeDir = filepath.Dir(file)
-				if effectiveRuntimeDir == "." {
-					// Get absolute path for current directory
-					if cwd, err := os.Getwd(); err == nil {
-						effectiveRuntimeDir = cwd
-					}
-				} else {
-					// Resolve to absolute path
-					if absPath, err := filepath.Abs(effectiveRuntimeDir); err == nil {
-						effectiveRuntimeDir = absPath
-					}
-				}
+			effectiveRuntimeDir := resolveProcessRuntimeDir(runtimeDir)
+			if effectiveRuntimeDir != "" {
 				if verbose {
-					log.Printf("[DEBUG] No --runtime-dir specified, using workflow directory: %s\n", effectiveRuntimeDir)
+					log.Printf("[DEBUG] Using --runtime-dir: %s\n", effectiveRuntimeDir)
 				}
+			} else if verbose {
+				log.Printf("[DEBUG] No --runtime-dir specified, resolving relative file paths from current working directory\n")
 			}
 
 			// Parse CLI variables
 			cliVars := parseVarsFlags(varsFlags, stdinData)
 
 			proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, effectiveRuntimeDir, cliVars)
+			proc.SetWorkflowFile(file)
 
 			// Set up stream logging if requested
 			if streamLogFile != "" {
@@ -408,22 +397,10 @@ func runWorkflowWithStreamLog(workflowFile, streamLogPath string, disableSpinner
 	serverConfig := &config.ServerConfig{Enabled: false}
 	cliVars := parseVarsFlags(varsFlags, "")
 
-	// Default runtimeDir to workflow file's directory if not specified
-	effectiveRuntimeDir := runtimeDir
-	if effectiveRuntimeDir == "" {
-		effectiveRuntimeDir = filepath.Dir(workflowFile)
-		if effectiveRuntimeDir == "." {
-			if cwd, err := os.Getwd(); err == nil {
-				effectiveRuntimeDir = cwd
-			}
-		} else {
-			if absPath, err := filepath.Abs(effectiveRuntimeDir); err == nil {
-				effectiveRuntimeDir = absPath
-			}
-		}
-	}
+	effectiveRuntimeDir := resolveProcessRuntimeDir(runtimeDir)
 
 	proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, verbose, effectiveRuntimeDir, cliVars)
+	proc.SetWorkflowFile(workflowFile)
 
 	// Disable spinner and progress display if requested (TUI mode handles progress display)
 	if len(disableSpinner) > 0 && disableSpinner[0] {
@@ -439,6 +416,16 @@ func runWorkflowWithStreamLog(workflowFile, streamLogPath string, disableSpinner
 
 	// Run processor
 	return proc.Process()
+}
+
+func resolveProcessRuntimeDir(flagValue string) string {
+	if flagValue == "" {
+		return ""
+	}
+	if absPath, err := filepath.Abs(flagValue); err == nil {
+		return absPath
+	}
+	return flagValue
 }
 
 // ensureComandaDirIfNeeded checks if the workflow uses .comanda paths and

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParseVarsFlags(t *testing.T) {
 	tests := []struct {
@@ -75,5 +79,30 @@ func TestParseVarsFlags(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveProcessRuntimeDir(t *testing.T) {
+	if got := resolveProcessRuntimeDir(""); got != "" {
+		t.Fatalf("empty runtime dir = %q, want empty", got)
+	}
+
+	tmpDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveProcessRuntimeDir(".comanda")
+	want, err := filepath.Abs(".comanda")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("relative runtime dir = %q, want %q", got, want)
 	}
 }

--- a/docs/comanda-llm-guide.md
+++ b/docs/comanda-llm-guide.md
@@ -521,8 +521,7 @@ document_codebase:
 ### Simplified Path Configuration
 
 **If `allowed_paths` is empty or omitted**, comanda automatically infers sensible defaults:
-1. Uses the workflow file's directory (if the workflow was loaded from a file)
-2. Falls back to the current working directory
+1. Uses the current working directory where `comanda process <workflow.yaml>` was invoked
 
 **Auto-expansion:** When allowed paths are set, comanda automatically adds:
 - Output directories (from step `output` paths)

--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -828,35 +828,20 @@ func (p *Processor) extractOutputPath(output interface{}) string {
 }
 
 // inferDefaultAllowedPaths returns sensible default paths when none are specified.
-// Priority:
-// 1. Workflow file's directory (if provided)
-// 2. Current working directory
+// In CLI mode, workflow-relative paths are resolved from the invocation cwd,
+// so the default agentic access path should match that same cwd.
 func (p *Processor) inferDefaultAllowedPaths(workflowFile string) []string {
-	var basePath string
-
-	// If we have a workflow file, use its directory as the base
-	if workflowFile != "" {
-		absPath, err := filepath.Abs(workflowFile)
-		if err == nil {
-			basePath = filepath.Dir(absPath)
-			p.debugf("Using workflow file directory as default allowed_path: %s", basePath)
-		}
-	}
-
-	// Fall back to current working directory
-	if basePath == "" {
-		cwd, err := os.Getwd()
-		if err == nil {
-			basePath = cwd
-			p.debugf("Using current working directory as default allowed_path: %s", basePath)
-		}
-	}
-
-	if basePath == "" {
+	cwd, err := os.Getwd()
+	if err != nil {
 		return nil
 	}
 
-	return []string{basePath}
+	if workflowFile != "" {
+		p.debugf("Using current working directory as default allowed_path for workflow %s: %s", workflowFile, cwd)
+	} else {
+		p.debugf("Using current working directory as default allowed_path: %s", cwd)
+	}
+	return []string{cwd}
 }
 
 // expandWithCommonProjectDirs adds common project subdirectories to allowed_paths

--- a/utils/processor/agentic_loop_test.go
+++ b/utils/processor/agentic_loop_test.go
@@ -527,23 +527,45 @@ func containsHelper(s, substr string) bool {
 func TestInferDefaultAllowedPaths(t *testing.T) {
 	p := &Processor{}
 
-	// Test with workflow file
 	tmpDir := t.TempDir()
-	workflowFile := filepath.Join(tmpDir, "test.yaml")
-	os.WriteFile(workflowFile, []byte("test"), 0644)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	expectedCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test with workflow file in a subdirectory. Defaults should still use cwd.
+	workflowDir := filepath.Join(tmpDir, ".comanda")
+	if err := os.MkdirAll(workflowDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	workflowFile := filepath.Join(workflowDir, "test.yaml")
+	if err := os.WriteFile(workflowFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	paths := p.inferDefaultAllowedPaths(workflowFile)
 	if len(paths) != 1 {
 		t.Errorf("Expected 1 path, got %d", len(paths))
 	}
-	if paths[0] != tmpDir {
-		t.Errorf("Expected %s, got %s", tmpDir, paths[0])
+	if paths[0] != expectedCwd {
+		t.Errorf("Expected %s, got %s", expectedCwd, paths[0])
 	}
 
-	// Test with empty workflow file (should fall back to cwd)
+	// Test with empty workflow file
 	paths = p.inferDefaultAllowedPaths("")
 	if len(paths) != 1 {
 		t.Errorf("Expected 1 path for cwd fallback, got %d", len(paths))
+	}
+	if paths[0] != expectedCwd {
+		t.Errorf("Expected %s, got %s", expectedCwd, paths[0])
 	}
 }
 

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -59,6 +59,7 @@ type Processor struct {
 	streamLogPath        string             // Path to stream log file (for passing to sub-processes)
 	worktreeHandler      *WorktreeHandler   // Handler for Git worktrees (parallel Claude Code execution)
 	currentStepWorktree  string             // Current step's worktree name (if any)
+	workflowFile         string             // Workflow file that created this processor, for loop state/checksums
 }
 
 // getEffectiveWorkDir returns the working directory for the current step
@@ -429,6 +430,13 @@ func NewProcessor(dslConfig *DSLConfig, envConfig *config.EnvConfig, serverConfi
 func (p *Processor) SetProgressWriter(w ProgressWriter) {
 	p.progress = w
 	p.spinner.SetProgressWriter(w)
+}
+
+// SetWorkflowFile records the workflow file used to create this processor.
+// It is intentionally separate from runtimeDir: CLI file paths are resolved
+// relative to the user's cwd unless --runtime-dir is explicitly provided.
+func (p *Processor) SetWorkflowFile(path string) {
+	p.workflowFile = path
 }
 
 // DisableSpinner disables the CLI spinner (use when running in TUI mode)
@@ -2026,9 +2034,8 @@ func (p *Processor) processProcessStep(step Step, isParallel bool, parallelID st
 
 	// 2. Create a new Processor for the sub-workflow
 	//    It inherits verbose settings and envConfig, but has its own DSLConfig and variables.
-	//    The runtimeDir for the sub-processor could be the directory of the sub-workflow file or inherited.
-	//    For now, let's assume it inherits the parent's runtimeDir.
 	subProcessor := NewProcessor(&subDSLConfig, p.envConfig, p.serverConfig, p.verbose, p.runtimeDir)
+	subProcessor.SetWorkflowFile(subWorkflowPath)
 	if p.progress != nil { // Propagate progress writer if available
 		subProcessor.SetProgressWriter(p.progress)
 	}
@@ -2475,13 +2482,15 @@ func (p *Processor) processMultiLoopOrchestration() error {
 
 	// Show workflow header with progress display
 	workflowName := "Multi-Loop Orchestration"
-	if p.runtimeDir != "" {
+	if p.workflowFile != "" {
+		workflowName = p.workflowFile
+	} else if p.runtimeDir != "" {
 		workflowName = p.runtimeDir
 	}
 	p.progressDisplay.StartWorkflow(workflowName, len(loopsToExecute))
 
 	// Create orchestrator
-	orchestrator := NewLoopOrchestrator(p, loopsToExecute, p.runtimeDir)
+	orchestrator := NewLoopOrchestrator(p, loopsToExecute, p.workflowFile)
 	orchestrator.SetProgressDisplay(p.progressDisplay)
 
 	// Build dependency graph and show execution order
@@ -2642,7 +2651,7 @@ func (p *Processor) prepareWorkflowNodeInput(config *AgenticLoopConfig, outputs 
 // executeWorkflowLoop executes a single loop in the workflow
 func (p *Processor) executeWorkflowLoop(loopName string, config *AgenticLoopConfig, input string) (*LoopOutput, error) {
 	startTime := time.Now()
-	result, err := p.processAgenticLoopWithFile(loopName, config, input, p.runtimeDir)
+	result, err := p.processAgenticLoopWithFile(loopName, config, input, p.workflowFile)
 	endTime := time.Now()
 
 	output := &LoopOutput{

--- a/utils/processor/input_handler.go
+++ b/utils/processor/input_handler.go
@@ -257,6 +257,8 @@ func (p *Processor) isOutputInOtherSteps(path string) bool {
 
 // processRegularInput handles regular file and directory inputs, respecting runtimeDir and globs
 func (p *Processor) processRegularInput(inputPath string) error {
+	serverMode := p.serverConfig != nil && p.serverConfig.Enabled
+
 	// Debug server and runtime directory configuration
 	p.debugf("Server and runtime directory configuration:")
 	p.debugf("- Runtime directory: %s (empty: %v)", p.runtimeDir, p.runtimeDir == "")
@@ -266,11 +268,15 @@ func (p *Processor) processRegularInput(inputPath string) error {
 		p.debugf("- Data directory: %s", p.serverConfig.DataDir)
 	}
 
-	// Force server mode with runtime directory if available
 	if p.runtimeDir != "" {
-		p.debugf("IMPORTANT: Server mode with runtime directory is active")
-		p.debugf("All relative paths will be resolved relative to: %s",
-			filepath.Join(p.serverConfig.DataDir, p.runtimeDir))
+		if serverMode {
+			p.debugf("Server mode with runtime directory is active")
+			p.debugf("All relative paths will be resolved relative to: %s",
+				filepath.Join(p.serverConfig.DataDir, p.runtimeDir))
+		} else {
+			p.debugf("CLI mode with runtime directory is active")
+			p.debugf("All relative paths will be resolved relative to: %s", p.runtimeDir)
+		}
 	}
 
 	// --- Step 1: Check for Glob Pattern ---
@@ -282,7 +288,7 @@ func (p *Processor) processRegularInput(inputPath string) error {
 		if filepath.IsAbs(inputPath) {
 			globPattern = inputPath // Absolute path glob
 			p.debugf("Using absolute glob pattern: %s", globPattern)
-		} else if p.runtimeDir != "" && p.serverConfig != nil {
+		} else if p.runtimeDir != "" && serverMode {
 			// In server mode with runtime directory, join with DataDir
 			runtimeDirPath := filepath.Join(p.serverConfig.DataDir, p.runtimeDir)
 			if err := os.MkdirAll(runtimeDirPath, 0755); err != nil {
@@ -291,7 +297,7 @@ func (p *Processor) processRegularInput(inputPath string) error {
 			p.debugf("Ensured runtime directory exists: %s", runtimeDirPath)
 			globPattern = filepath.Join(runtimeDirPath, inputPath)
 			p.debugf("Resolving glob '%s' relative to DataDir/runtimeDir: %s", inputPath, globPattern)
-		} else if p.serverConfig != nil && p.serverConfig.Enabled {
+		} else if serverMode {
 			// Server mode, no runtimeDir, use DataDir
 			globPattern = filepath.Join(p.serverConfig.DataDir, inputPath)
 			p.debugf("Resolving glob '%s' relative to DataDir '%s': %s", inputPath, p.serverConfig.DataDir, globPattern)
@@ -321,7 +327,7 @@ func (p *Processor) processRegularInput(inputPath string) error {
 
 	if !filepath.IsAbs(inputPath) {
 		// Input is a relative path
-		if p.runtimeDir != "" && p.serverConfig != nil {
+		if p.runtimeDir != "" && serverMode {
 			// In server mode with runtime directory, check relative to DataDir/runtimeDir
 			resolvedPath := filepath.Join(p.serverConfig.DataDir, p.runtimeDir, inputPath)
 			pathSource = fmt.Sprintf("runtime directory '%s' in data directory", p.runtimeDir)
@@ -356,7 +362,7 @@ func (p *Processor) processRegularInput(inputPath string) error {
 				}
 				// Keep filePath empty, will trigger "not found" error later if needed
 			}
-		} else if p.serverConfig != nil && p.serverConfig.Enabled {
+		} else if serverMode {
 			// Server mode, no runtimeDir, check relative to DataDir
 			resolvedPath := filepath.Join(p.serverConfig.DataDir, inputPath)
 			pathSource = fmt.Sprintf("data directory '%s'", p.serverConfig.DataDir)
@@ -401,7 +407,7 @@ func (p *Processor) processRegularInput(inputPath string) error {
 		}
 		// Return specific "not found" error based on where we looked
 		p.debugf("File not found and is not marked as an output in any step")
-		if p.runtimeDir != "" && p.serverConfig != nil {
+		if p.runtimeDir != "" && serverMode {
 			// In server mode with runtime directory, use the resolved path in the error message
 			resolvedPath := filepath.Join(p.serverConfig.DataDir, p.runtimeDir, inputPath)
 			return fmt.Errorf("input file '%s' not found (checked path: %s)", inputPath, resolvedPath)
@@ -420,7 +426,7 @@ func (p *Processor) processRegularInput(inputPath string) error {
 				return nil // Allow processing to continue
 			}
 			// Final "not found" error, referencing the path we actually checked
-			if p.runtimeDir != "" && p.serverConfig != nil {
+			if p.runtimeDir != "" && serverMode {
 				// In server mode with runtime directory, use the resolved path in the error message
 				resolvedPath := filepath.Join(p.serverConfig.DataDir, p.runtimeDir, inputPath)
 				return fmt.Errorf("input file '%s' not found (checked path: %s)", inputPath, resolvedPath)

--- a/utils/processor/input_test.go
+++ b/utils/processor/input_test.go
@@ -146,3 +146,42 @@ func TestGetProcessedInputs(t *testing.T) {
 		t.Errorf("Expected content 'test content', got '%s'", string(inputs[0].Contents))
 	}
 }
+
+func TestProcessRegularInputCLIDisabledServerConfigUsesCWD(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(".comanda", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(".comanda", "INDEX.md"), []byte("index content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	processor := NewProcessor(
+		&DSLConfig{},
+		createTestEnvConfig(),
+		&config.ServerConfig{Enabled: false},
+		false,
+		"",
+	)
+
+	if err := processor.processInputs([]string{".comanda/INDEX.md"}); err != nil {
+		t.Fatalf("processInputs() error = %v", err)
+	}
+
+	inputs := processor.GetProcessedInputs()
+	if len(inputs) != 1 {
+		t.Fatalf("expected 1 processed input, got %d", len(inputs))
+	}
+	if string(inputs[0].Contents) != "index content" {
+		t.Fatalf("processed content = %q, want %q", string(inputs[0].Contents), "index content")
+	}
+}

--- a/utils/processor/output_handler.go
+++ b/utils/processor/output_handler.go
@@ -35,12 +35,14 @@ func (p *Processor) loadIncrementalContext(stepConfig *StepConfig) string {
 	}
 
 	// Resolve the path
-	if p.serverConfig != nil {
+	if p.serverConfig != nil && p.serverConfig.Enabled {
 		if p.runtimeDir != "" {
 			outputPath = filepath.Join(p.serverConfig.DataDir, p.runtimeDir, outputPath)
 		} else {
 			outputPath = filepath.Join(p.serverConfig.DataDir, outputPath)
 		}
+	} else if p.runtimeDir != "" && !filepath.IsAbs(outputPath) {
+		outputPath = filepath.Join(p.runtimeDir, outputPath)
 	}
 
 	// Read existing content
@@ -244,7 +246,7 @@ func (p *Processor) handleOutputWithOptions(modelName string, response string, o
 		} else {
 			// Determine the output path based on server mode and runtime directory
 			outputPath := output
-			if p.serverConfig != nil {
+			if p.serverConfig != nil && p.serverConfig.Enabled {
 				if p.runtimeDir != "" {
 					// When runtime directory is set, treat all output paths as relative to it
 					p.debugf("Using runtime directory: %s, output path: %s", p.runtimeDir, output)
@@ -253,6 +255,10 @@ func (p *Processor) handleOutputWithOptions(modelName string, response string, o
 					// No runtime directory, use DataDir directly
 					outputPath = filepath.Join(p.serverConfig.DataDir, output)
 				}
+				p.debugf("Resolved output path: %s", outputPath)
+			} else if p.runtimeDir != "" && !filepath.IsAbs(output) {
+				p.debugf("CLI mode with runtime directory: using path '%s' in %s", output, p.runtimeDir)
+				outputPath = filepath.Join(p.runtimeDir, output)
 				p.debugf("Resolved output path: %s", outputPath)
 			}
 

--- a/utils/processor/output_handler_test.go
+++ b/utils/processor/output_handler_test.go
@@ -178,3 +178,38 @@ func TestHandleOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleOutputCLIDisabledServerConfigUsesCWD(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := &Processor{
+		serverConfig: &config.ServerConfig{Enabled: false},
+		verbose:      true,
+	}
+
+	if err := proc.handleOutput("test-model", "analysis content", []string{".comanda/ANALYSIS.md"}, nil); err != nil {
+		t.Fatalf("handleOutput failed: %v", err)
+	}
+
+	wantPath := filepath.Join(tempDir, ".comanda", "ANALYSIS.md")
+	content, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("failed to read output %s: %v", wantPath, err)
+	}
+	if string(content) != "analysis content" {
+		t.Fatalf("output content = %q, want %q", string(content), "analysis content")
+	}
+
+	doublePath := filepath.Join(tempDir, ".comanda", ".comanda", "ANALYSIS.md")
+	if _, err := os.Stat(doublePath); !os.IsNotExist(err) {
+		t.Fatalf("unexpected double-prefixed output path exists: %s", doublePath)
+	}
+}

--- a/utils/processor/output_handler_test.go
+++ b/utils/processor/output_handler_test.go
@@ -109,6 +109,11 @@ func TestHandleOutput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create working directory for CLI mode tests
 			if !tt.expectInDataDir {
+				oldWd, err := os.Getwd()
+				if err != nil {
+					t.Fatalf("Failed to get working directory: %v", err)
+				}
+				defer os.Chdir(oldWd)
 				if err := os.Chdir(tempDir); err != nil {
 					t.Fatalf("Failed to change working directory: %v", err)
 				}

--- a/utils/server/provider_handlers_test.go
+++ b/utils/server/provider_handlers_test.go
@@ -4,10 +4,21 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/kris-hansen/comanda/utils/config"
 )
+
+func setTestComandaEnv(t *testing.T, envConfig *config.EnvConfig) {
+	t.Helper()
+
+	envPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.SaveEnvConfig(envPath, envConfig); err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
+	}
+	t.Setenv("COMANDA_ENV", envPath)
+}
 
 func TestHandleDeleteProvider(t *testing.T) {
 	// Create test configuration
@@ -27,6 +38,7 @@ func TestHandleDeleteProvider(t *testing.T) {
 			},
 		},
 	}
+	setTestComandaEnv(t, testConfig)
 
 	// Create server instance
 	server := &Server{
@@ -152,6 +164,7 @@ func TestProviderRouteHandling(t *testing.T) {
 			},
 		},
 	}
+	setTestComandaEnv(t, testConfig)
 
 	// Create server instance
 	server := &Server{


### PR DESCRIPTION
## Summary

Fix CLI workflow path resolution so `comanda process <workflow.yaml>` treats the invocation current working directory as the base for relative paths, rather than the workflow file's directory.

## Root Cause

The CLI defaulted `runtimeDir` to the workflow file's directory. When running a workflow from `.comanda/specification.yaml`, an input like `.comanda/jpos_INDEX.md` was resolved under `.comanda`, producing `.comanda/.comanda/jpos_INDEX.md`.

## Changes

- Stop defaulting CLI `runtimeDir` to the workflow file directory.
- Track the source workflow file separately for agentic loop state and checksums.
- Resolve CLI input/output paths from cwd unless `--runtime-dir` is explicitly provided.
- Default omitted agentic `allowed_paths` to cwd for consistency with CLI path semantics.
- Update docs and add regression tests for cwd-relative `.comanda/...` paths.

## Validation

- `env GOCACHE=/tmp/comanda-go-build-cache GOMODCACHE=/tmp/comanda-go-mod-cache go test ./...`