### PR TITLE
fix(claudecode): unwrap JSON envelope in agentic responses

### DIFF
--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -15,6 +16,34 @@ import (
 	"github.com/kris-hansen/comanda/utils/fileutil"
 	"github.com/kris-hansen/comanda/utils/retry"
 )
+
+// claudeCodeJSONEnvelope mirrors the shape returned by `claude --output-format json`.
+// Only the fields we actually consume are declared.
+type claudeCodeJSONEnvelope struct {
+	Result string `json:"result"`
+}
+
+// extractClaudeCodeResult unwraps the JSON envelope produced by `--output-format json`
+// and returns just the agent's `result` text. Returns the input unchanged if it doesn't
+// look like the envelope (so non-JSON callers and future format changes degrade safely).
+//
+// This matters because downstream pattern matching (loop exit conditions) and file
+// outputs would otherwise see metadata like `"contextWindow":200000` and treat it as
+// agent prose — yielding spurious exits and unreadable log files.
+func extractClaudeCodeResult(stdout string) string {
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" || trimmed[0] != '{' {
+		return stdout
+	}
+	var env claudeCodeJSONEnvelope
+	if err := json.Unmarshal([]byte(trimmed), &env); err != nil {
+		return stdout
+	}
+	if env.Result == "" {
+		return stdout
+	}
+	return env.Result
+}
 
 // ClaudeCodeProvider handles Claude Code CLI for agentic programming tasks
 type ClaudeCodeProvider struct {
@@ -245,7 +274,7 @@ func (c *ClaudeCodeProvider) SendPromptAgentic(modelName string, prompt string, 
 		return "", err
 	}
 
-	response := result.(string)
+	response := extractClaudeCodeResult(result.(string))
 	c.debugf("Agentic command completed, response length: %d characters", len(response))
 	return response, nil
 }

--- a/utils/models/claudecode_test.go
+++ b/utils/models/claudecode_test.go
@@ -6,6 +6,59 @@ import (
 	"testing"
 )
 
+func TestExtractClaudeCodeResult(t *testing.T) {
+	// Realistic envelope from `claude --output-format json`. Includes a
+	// `contextWindow` metadata field that previously triggered the loop's
+	// context-exhaustion regex and caused premature exits.
+	envelope := `{"type":"result","subtype":"success","is_error":false,"result":"## Iteration 2 Complete\n\nProgress made.","stop_reason":"end_turn","usage":{"contextWindow":200000,"input_tokens":44}}`
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "extracts result from JSON envelope",
+			in:   envelope,
+			want: "## Iteration 2 Complete\n\nProgress made.",
+		},
+		{
+			name: "passes through plain text",
+			in:   "just a plain reply",
+			want: "just a plain reply",
+		},
+		{
+			name: "passes through empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "passes through malformed JSON",
+			in:   `{"type":"result","result":`,
+			want: `{"type":"result","result":`,
+		},
+		{
+			name: "passes through envelope with empty result",
+			in:   `{"type":"result","result":""}`,
+			want: `{"type":"result","result":""}`,
+		},
+		{
+			name: "tolerates leading whitespace",
+			in:   "   " + envelope,
+			want: "## Iteration 2 Complete\n\nProgress made.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractClaudeCodeResult(tt.in)
+			if got != tt.want {
+				t.Errorf("extractClaudeCodeResult(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClaudeCodeProviderName(t *testing.T) {
 	provider := NewClaudeCodeProvider()
 	if provider.Name() != "claude-code" {


### PR DESCRIPTION
## Summary
Agentic loops were exiting after a single iteration with reason **\"Agent signaled context exhaustion or documented remaining work\"** even when the agent had clearly stated next-iteration plans.

Root cause: `SendPromptAgentic` calls the Claude CLI with `--output-format json` but returned the *entire* envelope as the response. The exit-condition regex then matched on metadata, not agent prose:

- `(?i)context[_\s]*(limit|exhaust|full|window)` matched `\"contextWindow\":200000` in the envelope's `usage` object.

Reproduced with the user's `jPOS` analysis loop — the agent's iteration 2 reply ended with \"Next iteration focus: ...\" yet the loop exited. Confirmed by replaying the patterns over the literal stdout in `.comanda/ANALYSIS_LOG.md`.

A secondary consequence: configured step output files received the JSON blob instead of the agent's prose, making activity logs unreadable.

## Fix
Add `extractClaudeCodeResult(stdout string) string` that JSON-decodes the envelope and returns just `result`. Pass-through cases (empty, non-JSON, malformed, empty `result`) return the input unchanged so:
- `SendPrompt`/`SendPromptWithFile` (no `--output-format json`) are unaffected.
- Future Claude CLI format changes degrade gracefully instead of erroring.

Wired into `SendPromptAgentic` only.

## Test plan
- [x] New `TestExtractClaudeCodeResult` covers: real envelope (incl. `contextWindow` metadata), plain text, empty, malformed JSON, envelope with empty `result`, leading whitespace
- [x] `go test ./utils/...` green
- [x] Replay of the original failing run's stdout through the extractor: zero exit-pattern matches against the resulting prose (was 1 false match before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)