### PR TITLE
fix(codebaseindex): detect manifest-less Go projects via source extensions

### DIFF
--- a/utils/codebaseindex/adapter.go
+++ b/utils/codebaseindex/adapter.go
@@ -125,6 +125,76 @@ func (r *Registry) detectAdapter(repoPath string, adapter Adapter) bool {
 			}
 		}
 	}
+
+	// Fallback: detect by source-file extension. Projects that predate or omit
+	// a manifest file (e.g. pre-modules Go using Godeps/GOPATH/dep/glide, or
+	// loose script directories) have no go.mod/package.json/etc. but are still
+	// indexable. If the repo contains source files matching this adapter's
+	// extensions, treat the adapter as applicable.
+	if r.detectByExtension(repoPath, adapter) {
+		return true
+	}
+	return false
+}
+
+// detectByExtension reports whether the repo contains any source file whose
+// extension is handled by the adapter. It searches the repo root and direct
+// subdirectories (matching the monorepo detection depth used above), skipping
+// hidden directories and the adapter's ignored directories so vendored
+// dependencies don't trigger a false positive.
+func (r *Registry) detectByExtension(repoPath string, adapter Adapter) bool {
+	exts := adapter.FileExtensions()
+	if len(exts) == 0 {
+		return false
+	}
+	extSet := make(map[string]bool, len(exts))
+	for _, e := range exts {
+		extSet[strings.ToLower(e)] = true
+	}
+
+	ignored := make(map[string]bool)
+	for _, d := range adapter.IgnoreDirs() {
+		ignored[d] = true
+	}
+
+	dirHasExt := func(dir string) bool {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return false
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if extSet[strings.ToLower(filepath.Ext(entry.Name()))] {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Root level.
+	if dirHasExt(repoPath) {
+		return true
+	}
+
+	// Direct subdirectories (skip hidden and ignored dirs).
+	entries, err := os.ReadDir(repoPath)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || ignored[name] {
+			continue
+		}
+		if dirHasExt(filepath.Join(repoPath, name)) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/utils/codebaseindex/manager_test.go
+++ b/utils/codebaseindex/manager_test.go
@@ -128,6 +128,67 @@ func TestMonorepoDetection(t *testing.T) {
 	}
 }
 
+// TestGoAdapterDetectionWithoutManifest covers pre-modules Go projects
+// (e.g. Godeps/GOPATH/dep/glide era) that have .go source files but no
+// go.mod or go.sum. These should still be detected via the source-file
+// extension fallback.
+func TestGoAdapterDetectionWithoutManifest(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// main.go at root, plus a package in a subdirectory — no go.mod/go.sum.
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"),
+		[]byte("package main\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	modelsDir := filepath.Join(tmpDir, "models")
+	if err := os.Mkdir(modelsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelsDir, "accounts.go"),
+		[]byte("package models\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := NewRegistry()
+	detected := registry.Detect(tmpDir)
+
+	foundGo := false
+	for _, a := range detected {
+		if a.Name() == "go" {
+			foundGo = true
+			break
+		}
+	}
+	if !foundGo {
+		t.Error("Go adapter should be detected for a manifest-less Go project via .go files")
+	}
+}
+
+// TestExtensionFallbackIgnoresVendored ensures the extension-based fallback
+// does not trigger on .go files that live only inside ignored directories
+// such as vendor/, which would otherwise produce false positives.
+func TestExtensionFallbackIgnoresVendored(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	vendorPkg := filepath.Join(tmpDir, "vendor", "example.com", "pkg")
+	if err := os.MkdirAll(vendorPkg, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vendorPkg, "lib.go"),
+		[]byte("package pkg\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := NewRegistry()
+	detected := registry.Detect(tmpDir)
+
+	for _, a := range detected {
+		if a.Name() == "go" {
+			t.Error("Go adapter should not be detected when .go files exist only in vendor/")
+		}
+	}
+}
+
 func TestExtractGoSymbols(t *testing.T) {
 	content := []byte(`package main
 


### PR DESCRIPTION
## Summary

- Adds a `detectByExtension` fallback in `adapter.go` so the codebase index detects Go projects that have `.go` source files but no `go.mod`/`go.sum` (e.g. pre-modules era projects using Godeps, GOPATH, dep, or glide)
- The fallback checks the repo root and direct subdirectories, skipping hidden dirs and adapter-declared ignored dirs (e.g. `vendor/`) to avoid false positives
- Applies generically to any adapter that declares file extensions, not just Go

## Test plan

- [x] `TestGoAdapterDetectionWithoutManifest` — verifies Go adapter is detected when `.go` files exist but no manifest is present
- [x] `TestExtensionFallbackIgnoresVendored` — verifies the fallback does not trigger when `.go` files exist only inside `vendor/`
- [x] Full `utils/codebaseindex` test suite passes (30/30 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)