### PR TITLE
feat(codebaseindex): configurable per-directory file cap in layout tree

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -17,14 +17,15 @@ import (
 
 var (
 	// Capture flags
-	indexName         string
-	indexOutput       string
-	indexFormat       string
-	indexGlobal       bool
-	indexEncrypt      bool
-	indexForce        bool
-	indexEnhance      bool
-	indexEnhanceModel string
+	indexName           string
+	indexOutput         string
+	indexFormat         string
+	indexGlobal         bool
+	indexEncrypt        bool
+	indexForce          bool
+	indexEnhance        bool
+	indexEnhanceModel   string
+	indexMaxFilesPerDir int
 
 	// Update flags
 	updateFull bool
@@ -174,11 +175,13 @@ func init() {
 	captureCmd.Flags().BoolVar(&indexForce, "force", false, "Overwrite existing index")
 	captureCmd.Flags().BoolVar(&indexEnhance, "enhance", false, "Run a second-pass AI macro analysis using default_generation_model")
 	captureCmd.Flags().StringVar(&indexEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+	captureCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
 
 	// Update flags
 	updateCmd.Flags().BoolVar(&updateFull, "full", false, "Force full regeneration")
 	updateCmd.Flags().BoolVar(&indexEnhance, "enhance", false, "Run a second-pass AI macro analysis during update")
 	updateCmd.Flags().StringVar(&indexEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+	updateCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
 
 	// Diff flags
 	diffCmd.Flags().StringVar(&diffSince, "since", "", "Show changes since date (YYYY-MM-DD)")
@@ -224,6 +227,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	cfg := codebaseindex.DefaultConfig()
 	cfg.Root = absPath
 	cfg.Verbose = verbose
+	cfg.MaxFilesPerDir = indexMaxFilesPerDir
 
 	// Set format
 	switch indexFormat {
@@ -438,6 +442,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	cfg.Root = entry.Path
 	cfg.OutputPath = entry.IndexPath
 	cfg.Verbose = verbose
+	cfg.MaxFilesPerDir = indexMaxFilesPerDir
 
 	// Set format from entry
 	switch entry.Format {

--- a/utils/codebaseindex/synthesize.go
+++ b/utils/codebaseindex/synthesize.go
@@ -13,9 +13,13 @@ import (
 
 const (
 	maxTreeDepth      = 3
-	maxFilesPerDir    = 12
 	maxImportantFiles = 25
 	maxSymbolsPerFile = 8
+
+	// DefaultMaxFilesPerDir caps how many files are listed per directory in the
+	// Repository Layout tree. Overridable via Config.MaxFilesPerDir / the
+	// --max-files-per-dir CLI flag. 0 or negative means unlimited.
+	DefaultMaxFilesPerDir = 200
 )
 
 // synthesize generates the markdown index from scan results based on output format
@@ -437,18 +441,19 @@ func (m *Manager) writeTreeNode(sb *strings.Builder, node *DirNode, prefix strin
 		return node.Children[i].Name < node.Children[j].Name
 	})
 
-	// Write files first (limited)
+	// Write files first (capped per directory; 0 or negative means unlimited)
 	sort.Strings(node.Files)
 	fileCount := len(node.Files)
-	if fileCount > maxFilesPerDir {
-		for i := 0; i < maxFilesPerDir-1; i++ {
+	maxFiles := m.config.MaxFilesPerDir
+	if maxFiles > 0 && fileCount > maxFiles {
+		for i := 0; i < maxFiles-1; i++ {
 			sb.WriteString(prefix)
 			sb.WriteString("  ")
 			sb.WriteString(node.Files[i])
 			sb.WriteString("\n")
 		}
 		sb.WriteString(prefix)
-		sb.WriteString(fmt.Sprintf("  ... and %d more files\n", fileCount-maxFilesPerDir+1))
+		sb.WriteString(fmt.Sprintf("  ... and %d more files\n", fileCount-maxFiles+1))
 	} else {
 		for _, f := range node.Files {
 			sb.WriteString(prefix)

--- a/utils/codebaseindex/types.go
+++ b/utils/codebaseindex/types.go
@@ -73,6 +73,10 @@ type Config struct {
 	Incremental   bool
 	Verbose       bool
 
+	// MaxFilesPerDir caps how many files are listed per directory in the
+	// Repository Layout tree. 0 or negative means unlimited (list every file).
+	MaxFilesPerDir int
+
 	// Optional second-pass AI enhancement. The normal high-performance scan still
 	// runs first; when enabled, EnhancementFunc receives a bounded macro-analysis
 	// prompt and returns additional markdown insights for future agents.
@@ -283,5 +287,6 @@ func DefaultConfig() *Config {
 		HashAlgorithm:  DefaultHash,
 		Incremental:    false,
 		Verbose:        false,
+		MaxFilesPerDir: DefaultMaxFilesPerDir,
 	}
 }


### PR DESCRIPTION
## What changed

The Repository Layout tree previously truncated each directory to 11 files with a hardcoded `... and N more files` line, hiding most of the listing for larger directories (e.g. a 48-file directory showed only 11).

- Raised the per-directory cap to **200** (`DefaultMaxFilesPerDir`).
- Added a `--max-files-per-dir` flag to both `index capture` and `index update`; `0` means unlimited (list every file).
- Cap is threaded through `Config.MaxFilesPerDir`; all construction paths go through `DefaultConfig()`, so the 200 default applies everywhere (CLI + processor handler).

```
comanda index capture                          # cap at 200 per dir (default)
comanda index capture --max-files-per-dir 500  # raise the cap
comanda index capture --max-files-per-dir 0    # no limit
```

## Reviewer notes

- The **File Categories** section still has a separate hardcoded `maxFiles := 20` cap; intentionally left out of scope since the report was specifically about the layout tree.
- `go build ./...`, `go vet`, and the `utils/codebaseindex` test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)