### PR TITLE
[feat] add Sakana Fugu provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cat main.go | comanda process multi-agent.yaml
 ## Features
 
 - **Multi-agent** — Claude Code, Gemini CLI, OpenAI Codex in parallel
+- **API providers** — OpenAI, Anthropic, Google, X.AI, Deepseek, Moonshot, Sakana
 - **Agentic loops** — Iterative refinement with tool use
 - **Codebase indexing** — Persistent code context across workflows  
 - **Git worktrees** — Parallel execution in isolated branches

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -254,6 +254,12 @@ func getMoonshotModels() []string {
 	return registry.GetModels("moonshot")
 }
 
+func getSakanaModels() []string {
+	// Get models from the central registry
+	registry := models.GetRegistry()
+	return registry.GetModels("sakana")
+}
+
 func getOllamaModels() ([]OllamaModel, error) {
 	resp, err := http.Get("http://localhost:11434/api/tags")
 	if err != nil {
@@ -849,12 +855,12 @@ func configureModelsAndProviders(reader *bufio.Reader, envConfig *config.EnvConf
 
 // configureAPIProvider handles adding API-based providers
 func configureAPIProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
-	log.Printf("\nAvailable API providers: openai, anthropic, google, xai, deepseek, moonshot\n")
+	log.Printf("\nAvailable API providers: openai, anthropic, google, xai, deepseek, moonshot, sakana\n")
 	log.Printf("Enter provider name: ")
 	provider, _ := reader.ReadString('\n')
 	provider = strings.TrimSpace(provider)
 
-	validProviders := []string{"openai", "anthropic", "google", "xai", "deepseek", "moonshot"}
+	validProviders := []string{"openai", "anthropic", "google", "xai", "deepseek", "moonshot", "sakana"}
 	isValid := false
 	for _, vp := range validProviders {
 		if provider == vp {
@@ -914,6 +920,8 @@ func configureAPIProvider(reader *bufio.Reader, envConfig *config.EnvConfig) {
 		selectedModels, selectErr = promptForModelSelection(getDeepseekModels())
 	case "moonshot":
 		selectedModels, selectErr = promptForModelSelection(getMoonshotModels())
+	case "sakana":
+		selectedModels, selectErr = promptForModelSelection(getSakanaModels())
 	}
 
 	if selectErr != nil {
@@ -1511,7 +1519,7 @@ Running without flags starts interactive configuration mode, which guides you
 through setting up providers (Anthropic, OpenAI, Ollama, etc.) and their models.
 
 Comanda supports two types of providers:
-  API-based:  OpenAI, Anthropic, Google, X.AI, Deepseek, Moonshot (require API keys)
+  API-based:  OpenAI, Anthropic, Google, X.AI, Deepseek, Moonshot, Sakana (require API keys)
   Local:      Ollama, vLLM (require running servers)
   CLI Agents: Claude Code, Gemini CLI, OpenAI Codex (require installed binaries)
 
@@ -1854,13 +1862,13 @@ Flag Groups:
 			for {
 				log.Printf("\n")
 				log.Printf("Available provider types:\n")
-				log.Printf("  API-based:   openai, anthropic, google, xai, deepseek, moonshot\n")
+				log.Printf("  API-based:   openai, anthropic, google, xai, deepseek, moonshot, sakana\n")
 				log.Printf("  Local:       ollama, vllm, llama.cpp\n")
 				log.Printf("  CLI Agents:  claude-code, gemini-cli, openai-codex\n")
 				log.Printf("\nEnter provider: ")
 				provider, _ = reader.ReadString('\n')
 				provider = strings.TrimSpace(provider)
-				validProviders := []string{"openai", "anthropic", "ollama", "vllm", "llama.cpp", "google", "xai", "deepseek", "moonshot", "claude-code", "gemini-cli", "openai-codex"}
+				validProviders := []string{"openai", "anthropic", "ollama", "vllm", "llama.cpp", "google", "xai", "deepseek", "moonshot", "sakana", "claude-code", "gemini-cli", "openai-codex"}
 				isValid := false
 				for _, vp := range validProviders {
 					if provider == vp {
@@ -2036,6 +2044,18 @@ Flag Groups:
 					return
 				}
 				models := getMoonshotModels()
+				selectedModels, err = promptForModelSelection(models)
+				if err != nil {
+					log.Printf("Error selecting models: %v\n", err)
+					return
+				}
+
+			case "sakana":
+				if apiKey == "" {
+					log.Printf("Error: API key is required for Sakana")
+					return
+				}
+				models := getSakanaModels()
 				selectedModels, err = promptForModelSelection(models)
 				if err != nil {
 					log.Printf("Error selecting models: %v\n", err)

--- a/docs/adding-new-model-guide.md
+++ b/docs/adding-new-model-guide.md
@@ -1,6 +1,6 @@
 # Adding a New Model to COMandA
 
-This guide outlines the steps for adding support for a new Large Language Model (LLM) to COMandA, assuming the provider (e.g., Anthropic, OpenAI) is already integrated.
+This guide outlines the steps for adding support for a new Large Language Model (LLM) to COMandA, assuming the provider (e.g., Anthropic, OpenAI, Sakana) is already integrated.
 
 ## Prerequisites
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -629,7 +629,7 @@ paths:
               properties:
                 name:
                   type: string
-                  description: Provider name (e.g., openai, anthropic, google, xai, ollama)
+                  description: Provider name (e.g., openai, anthropic, google, xai, sakana, ollama)
                 apiKey:
                   type: string
                   description: API key to validate

--- a/examples/README.md
+++ b/examples/README.md
@@ -137,6 +137,7 @@ Examples demonstrating integration with different AI models:
 - `anthropic-pdf-example.yaml` - Using Anthropic's Claude model with PDF processing
 - `google-example.yaml` - Integration with Google's AI models
 - `xai-example.yaml` - X.AI model integration example
+- `sakana-example.yaml` - Sakana Fugu API integration example
 
 ### File Processing (`file-processing/`)
 Examples of file manipulation and processing:
@@ -233,6 +234,7 @@ Each example includes comments explaining its functionality and any specific req
    - `model-examples/anthropic-pdf-example.yaml` (PDF processing)
    - `model-examples/google-example.yaml` (Google AI integration)
    - `model-examples/xai-example.yaml` (X.AI integration)
+   - `model-examples/sakana-example.yaml` (Sakana Fugu integration)
 
 4. **Multi-Agent Examples**: Combine multiple agentic coding tools
    - `multi-agent/architecture-planning.yaml` (parallel analysis + synthesis)

--- a/examples/model-examples/sakana-example.yaml
+++ b/examples/model-examples/sakana-example.yaml
@@ -1,0 +1,23 @@
+# Sakana Fugu Example
+# Configure Sakana with `comanda configure`, then select `sakana` and add `fugu` or `fugu-ultra`.
+# Sakana API keys can be created in the Sakana console.
+
+draft_plan:
+  input:
+    - NA
+  model:
+    - fugu
+  action:
+    - Draft a concise launch checklist for a developer tool release. Group the checklist into build, docs, and release validation.
+  output:
+    - STDOUT
+
+review_plan:
+  input:
+    - STDIN
+  model:
+    - fugu-ultra
+  action:
+    - Review the checklist for missing release risks and add the three highest leverage improvements.
+  output:
+    - STDOUT

--- a/utils/discovery/discovery.go
+++ b/utils/discovery/discovery.go
@@ -130,6 +130,12 @@ func GetDeepseekModels() []string {
 	}
 }
 
+// GetSakanaModels returns a hardcoded list of known Sakana models.
+func GetSakanaModels() []string {
+	registry := models.GetRegistry()
+	return registry.GetModels("sakana")
+}
+
 // GetGoogleModels returns a hardcoded list of known Google models.
 func GetGoogleModels() []string {
 	// This list should be updated periodically based on Google's offerings.
@@ -259,6 +265,8 @@ func GetAvailableModels(providerName string, apiKey string) ([]string, error) {
 		return GetXAIModels(), nil
 	case "deepseek":
 		return GetDeepseekModels(), nil
+	case "sakana":
+		return GetSakanaModels(), nil
 	case "ollama":
 		ollamaModels, err := GetOllamaModels()
 		if err != nil {

--- a/utils/models/provider.go
+++ b/utils/models/provider.go
@@ -314,6 +314,7 @@ func defaultDetectProvider(modelName string) Provider {
 		NewXAIProvider(),       // Handles grok- models
 		NewDeepseekProvider(),  // Handles deepseek- models
 		NewMoonshotProvider(),  // Handles moonshot- models
+		NewSakanaProvider(),    // Handles fugu models
 		NewOpenAIProvider(),    // Handles gpt- models
 	}
 

--- a/utils/models/registry.go
+++ b/utils/models/registry.go
@@ -139,6 +139,15 @@ func (r *ModelRegistry) initializeDefaultModels() {
 		"moonshot-",
 	})
 
+	// Sakana Fugu models
+	r.RegisterModels("sakana", []string{
+		"fugu",
+		"fugu-ultra",
+	})
+	r.RegisterFamilies("sakana", []string{
+		"fugu-",
+	})
+
 	// Claude Code models (local CLI)
 	r.RegisterModels("claude-code", []string{
 		"claude-code",

--- a/utils/models/sakana.go
+++ b/utils/models/sakana.go
@@ -1,0 +1,258 @@
+package models
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kris-hansen/comanda/utils/fileutil"
+	"github.com/kris-hansen/comanda/utils/retry"
+	openai "github.com/sashabaranov/go-openai"
+)
+
+const sakanaRequestTimeout = 120 * time.Second
+
+// SakanaProvider handles Sakana Fugu models through Sakana's OpenAI-compatible API.
+type SakanaProvider struct {
+	apiKey  string
+	config  ModelConfig
+	verbose bool
+	mu      sync.Mutex
+}
+
+// NewSakanaProvider creates a new Sakana provider instance.
+func NewSakanaProvider() *SakanaProvider {
+	return &SakanaProvider{
+		config: ModelConfig{
+			Temperature:         0.7,
+			MaxTokens:           2000,
+			MaxCompletionTokens: 2000,
+			TopP:                1.0,
+		},
+	}
+}
+
+// Name returns the provider name.
+func (s *SakanaProvider) Name() string {
+	return "sakana"
+}
+
+// debugf prints debug information if verbose mode is enabled.
+func (s *SakanaProvider) debugf(format string, args ...interface{}) {
+	if s.verbose {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		log.Printf("[DEBUG][Sakana] "+format+"\n", args...)
+	}
+}
+
+// SupportsModel checks if the given model name is supported by Sakana.
+func (s *SakanaProvider) SupportsModel(modelName string) bool {
+	s.debugf("Checking if model is supported: %s", modelName)
+	modelName = strings.ToLower(strings.TrimSpace(modelName))
+
+	registry := GetRegistry()
+	for _, model := range registry.GetModels("sakana") {
+		if modelName == strings.ToLower(model) {
+			s.debugf("Model %s is supported (exact match)", modelName)
+			return true
+		}
+	}
+
+	for _, prefix := range registry.GetFamilies("sakana") {
+		if strings.HasPrefix(modelName, prefix) {
+			s.debugf("Model %s is supported (matches prefix %s)", modelName, prefix)
+			return true
+		}
+	}
+
+	s.debugf("Model %s is not supported by Sakana provider", modelName)
+	return false
+}
+
+// Configure sets up the provider with necessary credentials.
+func (s *SakanaProvider) Configure(apiKey string) error {
+	s.debugf("Configuring Sakana provider")
+	if apiKey == "" {
+		return fmt.Errorf("API key is required for Sakana provider")
+	}
+	s.apiKey = apiKey
+	s.debugf("API key configured successfully")
+	return nil
+}
+
+func (s *SakanaProvider) client() *openai.Client {
+	config := openai.DefaultConfig(s.apiKey)
+	config.BaseURL = "https://api.sakana.ai/v1"
+	return openai.NewClientWithConfig(config)
+}
+
+func (s *SakanaProvider) createChatCompletionRequest(modelName string, messages []openai.ChatCompletionMessage) openai.ChatCompletionRequest {
+	req := openai.ChatCompletionRequest{
+		Model:       modelName,
+		Messages:    messages,
+		MaxTokens:   s.config.MaxTokens,
+		Temperature: float32(s.config.Temperature),
+		TopP:        float32(s.config.TopP),
+	}
+
+	return req
+}
+
+// SendPrompt sends a prompt to the specified model and returns the response.
+func (s *SakanaProvider) SendPrompt(modelName string, prompt string) (string, error) {
+	s.debugf("Preparing to send prompt to model: %s", modelName)
+	s.debugf("Prompt length: %d characters", len(prompt))
+
+	if s.apiKey == "" {
+		return "", fmt.Errorf("Sakana provider not configured: missing API key")
+	}
+
+	if !s.SupportsModel(modelName) {
+		return "", fmt.Errorf("invalid Sakana model: %s", modelName)
+	}
+
+	client := s.client()
+	result, err := retry.WithRetry(
+		func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), sakanaRequestTimeout)
+			defer cancel()
+
+			req := s.createChatCompletionRequest(modelName, []openai.ChatCompletionMessage{
+				{
+					Role:    openai.ChatMessageRoleUser,
+					Content: prompt,
+				},
+			})
+
+			resp, err := client.CreateChatCompletion(ctx, req)
+			if err != nil {
+				if ctx.Err() == context.DeadlineExceeded {
+					return "", fmt.Errorf("Sakana API request timed out after %v", sakanaRequestTimeout)
+				}
+				return "", fmt.Errorf("Sakana API error: %v", err)
+			}
+
+			if len(resp.Choices) == 0 {
+				return "", fmt.Errorf("no response choices returned from Sakana")
+			}
+
+			return resp.Choices[0].Message.Content, nil
+		},
+		retry.Is429Error,
+		retry.DefaultRetryConfig,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	response := result.(string)
+	s.debugf("API call completed, response length: %d characters", len(response))
+	return response, nil
+}
+
+// SendPromptWithFile sends a prompt along with a file to the specified model and returns the response.
+func (s *SakanaProvider) SendPromptWithFile(modelName string, prompt string, file FileInput) (string, error) {
+	s.debugf("Preparing to send prompt with file to model: %s", modelName)
+	s.debugf("File path: %s", file.Path)
+
+	if s.apiKey == "" {
+		return "", fmt.Errorf("Sakana provider not configured: missing API key")
+	}
+
+	if !s.SupportsModel(modelName) {
+		return "", fmt.Errorf("invalid Sakana model: %s", modelName)
+	}
+
+	fileData, err := fileutil.SafeReadFile(file.Path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %v", err)
+	}
+
+	client := s.client()
+	if strings.HasPrefix(file.MimeType, "image/") {
+		return s.sendVisionPrompt(client, modelName, prompt, file.MimeType, fileData)
+	}
+
+	combinedPrompt := fmt.Sprintf("File content:\n%s\n\nUser prompt: %s", string(fileData), prompt)
+	return s.SendPrompt(modelName, combinedPrompt)
+}
+
+func (s *SakanaProvider) sendVisionPrompt(client *openai.Client, modelName string, prompt string, mimeType string, fileData []byte) (string, error) {
+	result, err := retry.WithRetry(
+		func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), sakanaRequestTimeout)
+			defer cancel()
+
+			content := []openai.ChatMessagePart{
+				{
+					Type: openai.ChatMessagePartTypeText,
+					Text: prompt,
+				},
+				{
+					Type: openai.ChatMessagePartTypeImageURL,
+					ImageURL: &openai.ChatMessageImageURL{
+						URL: fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(fileData)),
+					},
+				},
+			}
+
+			req := s.createChatCompletionRequest(modelName, []openai.ChatCompletionMessage{
+				{
+					Role:         openai.ChatMessageRoleUser,
+					MultiContent: content,
+				},
+			})
+
+			resp, err := client.CreateChatCompletion(ctx, req)
+			if err != nil {
+				if ctx.Err() == context.DeadlineExceeded {
+					return "", fmt.Errorf("Sakana Vision API request timed out after %v", sakanaRequestTimeout)
+				}
+				return "", fmt.Errorf("Sakana Vision API error: %v", err)
+			}
+
+			if len(resp.Choices) == 0 {
+				return "", fmt.Errorf("no response choices returned from Sakana Vision")
+			}
+
+			return resp.Choices[0].Message.Content, nil
+		},
+		retry.Is429Error,
+		retry.DefaultRetryConfig,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return result.(string), nil
+}
+
+// SetConfig updates the provider configuration.
+func (s *SakanaProvider) SetConfig(config ModelConfig) {
+	s.debugf("Updating provider configuration")
+	s.config = config
+}
+
+// GetConfig returns the current provider configuration.
+func (s *SakanaProvider) GetConfig() ModelConfig {
+	return s.config
+}
+
+// ValidateModel checks if the specific Sakana model variant is valid.
+func (s *SakanaProvider) ValidateModel(modelName string) bool {
+	isValid := GetRegistry().ValidateModel("sakana", modelName)
+	if !isValid {
+		isValid = s.SupportsModel(modelName)
+	}
+	return isValid
+}
+
+// SetVerbose enables or disables verbose mode.
+func (s *SakanaProvider) SetVerbose(verbose bool) {
+	s.verbose = verbose
+}

--- a/utils/models/sakana_test.go
+++ b/utils/models/sakana_test.go
@@ -1,0 +1,68 @@
+package models
+
+import "testing"
+
+func TestSakanaSupportsModel(t *testing.T) {
+	provider := NewSakanaProvider()
+
+	tests := []struct {
+		name     string
+		model    string
+		expected bool
+	}{
+		{"fugu", "fugu", true},
+		{"fugu-ultra", "fugu-ultra", true},
+		{"future fugu family model", "fugu-next", true},
+		{"case insensitive", "FUGU-ULTRA", true},
+		{"empty string", "", false},
+		{"invalid prefix", "invalid-model", false},
+		{"partial match", "not-fugu", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.SupportsModel(tt.model)
+			if result != tt.expected {
+				t.Errorf("SupportsModel(%q) = %v, want %v", tt.model, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSakanaProviderConfig(t *testing.T) {
+	provider := NewSakanaProvider()
+
+	if provider.Name() != "sakana" {
+		t.Errorf("Name() = %q, want sakana", provider.Name())
+	}
+
+	if err := provider.Configure(""); err == nil {
+		t.Fatal("Configure(\"\") succeeded, want error")
+	}
+
+	if err := provider.Configure("test-key"); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	newConfig := ModelConfig{
+		Temperature:         0.2,
+		MaxTokens:           1234,
+		MaxCompletionTokens: 1234,
+		TopP:                0.9,
+	}
+	provider.SetConfig(newConfig)
+
+	req := provider.createChatCompletionRequest("fugu", nil)
+	if req.Model != "fugu" {
+		t.Errorf("request model = %q, want fugu", req.Model)
+	}
+	if req.MaxTokens != newConfig.MaxTokens {
+		t.Errorf("request MaxTokens = %d, want %d", req.MaxTokens, newConfig.MaxTokens)
+	}
+	if req.Temperature != float32(newConfig.Temperature) {
+		t.Errorf("request Temperature = %v, want %v", req.Temperature, newConfig.Temperature)
+	}
+	if req.TopP != float32(newConfig.TopP) {
+		t.Errorf("request TopP = %v, want %v", req.TopP, newConfig.TopP)
+	}
+}

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -2207,6 +2207,8 @@ func (p *Processor) validateGeneratedWorkflow(yamlContent string) error {
 					provider = models.NewDeepseekProvider()
 				case "moonshot":
 					provider = models.NewMoonshotProvider()
+				case "sakana":
+					provider = models.NewSakanaProvider()
 				case "ollama":
 					provider = models.NewOllamaProvider()
 				case "vllm":
@@ -2334,6 +2336,8 @@ func (p *Processor) getProviderForModel(modelName string) (models.Provider, erro
 			newProvider = models.NewDeepseekProvider()
 		case "moonshot":
 			newProvider = models.NewMoonshotProvider()
+		case "sakana":
+			newProvider = models.NewSakanaProvider()
 		case "ollama":
 			newProvider = models.NewOllamaProvider()
 		case "vllm":

--- a/utils/processor/model_handler.go
+++ b/utils/processor/model_handler.go
@@ -147,6 +147,8 @@ func (p *Processor) validateModel(modelNames []string, inputs []string) error {
 					provider = models.NewDeepseekProvider()
 				case "moonshot":
 					provider = models.NewMoonshotProvider()
+				case "sakana":
+					provider = models.NewSakanaProvider()
 				case "ollama":
 					provider = models.NewOllamaProvider()
 				case "vllm":
@@ -365,6 +367,8 @@ func (p *Processor) configureProviders() error {
 			providerConfig, err = p.envConfig.GetProviderConfig("deepseek")
 		case "moonshot":
 			providerConfig, err = p.envConfig.GetProviderConfig("moonshot")
+		case "sakana":
+			providerConfig, err = p.envConfig.GetProviderConfig("sakana")
 		default:
 			return fmt.Errorf("unknown provider: %s", providerName)
 		}

--- a/utils/server/provider_handlers.go
+++ b/utils/server/provider_handlers.go
@@ -40,6 +40,7 @@ func (s *Server) handleGetProviders(w http.ResponseWriter, r *http.Request) {
 		{"anthropic", models.NewAnthropicProvider()},
 		{"google", models.NewGoogleProvider()},
 		{"xai", models.NewXAIProvider()},
+		{"sakana", models.NewSakanaProvider()},
 		{"ollama", models.NewOllamaProvider()},
 		{"vllm", models.NewVLLMProvider()},
 		{"llama.cpp", models.NewLlamaCPPProvider()},
@@ -107,7 +108,7 @@ func (s *Server) handleGetAvailableModels(w http.ResponseWriter, r *http.Request
 	apiKey := ""
 	if err == nil { // Provider exists, get its key
 		apiKey = providerConfig.APIKey
-	} else if providerName != "ollama" && providerName != "vllm" && providerName != "llama.cpp" && providerName != "anthropic" && providerName != "google" && providerName != "xai" && providerName != "deepseek" {
+	} else if providerName != "ollama" && providerName != "vllm" && providerName != "llama.cpp" && providerName != "anthropic" && providerName != "google" && providerName != "xai" && providerName != "deepseek" && providerName != "sakana" {
 		// If provider doesn't exist and requires a key, we can't proceed
 		sendJSONError(w, http.StatusBadRequest, fmt.Sprintf("Provider '%s' not configured or requires an API key to list models", providerName))
 		return
@@ -321,6 +322,8 @@ func (s *Server) handleValidateProvider(w http.ResponseWriter, r *http.Request) 
 		provider = models.NewGoogleProvider()
 	case "xai":
 		provider = models.NewXAIProvider()
+	case "sakana":
+		provider = models.NewSakanaProvider()
 	case "ollama":
 		provider = models.NewOllamaProvider()
 	case "vllm":
@@ -407,6 +410,8 @@ func (s *Server) handleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 			provider = models.NewGoogleProvider()
 		case "xai":
 			provider = models.NewXAIProvider()
+		case "sakana":
+			provider = models.NewSakanaProvider()
 		case "ollama":
 			provider = models.NewOllamaProvider()
 		case "vllm":


### PR DESCRIPTION
## Summary

Adds Sakana Fugu as an API-based provider in Comanda. The implementation uses Sakana's OpenAI-compatible API at `https://api.sakana.ai/v1`, supports the documented `fugu` and `fugu-ultra` models, and wires the provider through model detection, workflow validation, processor configuration, interactive `comanda configure`, discovery, and server provider handlers.

Also adds a Sakana model example plus provider docs/index updates.

## Why

Sakana documents Fugu as usable like a standard LLM through the Sakana API, including the Chat Completions endpoint and bearer-token authentication. This lets Comanda workflows use `model: fugu` / `model: fugu-ultra` after users configure a Sakana API key.

Docs: https://console.sakana.ai/get-started

## Validation

- `gofmt -w .`
- `go test ./...`
- `go vet ./...`

## Notes

The provider follows the existing OpenAI-compatible provider style used by Deepseek and Moonshot. It uses a 120-second request timeout because Sakana notes complex Fugu tasks can require higher client-side timeouts.