### PR TITLE
feat(index): raise and configure source file limit

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -25,6 +25,7 @@ var (
 	indexForce          bool
 	indexEnhance        bool
 	indexEnhanceModel   string
+	indexMaxFiles       int
 	indexMaxFilesPerDir int
 
 	// Update flags
@@ -175,12 +176,14 @@ func init() {
 	captureCmd.Flags().BoolVar(&indexForce, "force", false, "Overwrite existing index")
 	captureCmd.Flags().BoolVar(&indexEnhance, "enhance", false, "Run a second-pass AI macro analysis using default_generation_model")
 	captureCmd.Flags().StringVar(&indexEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+	captureCmd.Flags().IntVar(&indexMaxFiles, "max-files", codebaseindex.DefaultMaxFiles, "Max source files included in the index (0 = unlimited)")
 	captureCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
 
 	// Update flags
 	updateCmd.Flags().BoolVar(&updateFull, "full", false, "Force full regeneration")
 	updateCmd.Flags().BoolVar(&indexEnhance, "enhance", false, "Run a second-pass AI macro analysis during update")
 	updateCmd.Flags().StringVar(&indexEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+	updateCmd.Flags().IntVar(&indexMaxFiles, "max-files", codebaseindex.DefaultMaxFiles, "Max source files included in the index (0 = unlimited)")
 	updateCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
 
 	// Diff flags
@@ -227,6 +230,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	cfg := codebaseindex.DefaultConfig()
 	cfg.Root = absPath
 	cfg.Verbose = verbose
+	cfg.MaxFiles = indexMaxFiles
 	cfg.MaxFilesPerDir = indexMaxFilesPerDir
 
 	// Set format
@@ -442,6 +446,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	cfg.Root = entry.Path
 	cfg.OutputPath = entry.IndexPath
 	cfg.Verbose = verbose
+	cfg.MaxFiles = indexMaxFiles
 	cfg.MaxFilesPerDir = indexMaxFilesPerDir
 
 	// Set format from entry

--- a/examples/codebase-index/README.md
+++ b/examples/codebase-index/README.md
@@ -93,6 +93,7 @@ index_codebase:
         priority_files:
           - cmd/**/*.go
     max_output_kb: 100         # Limit output size
+    max_files: 10000            # Source files to index (0 = unlimited)
 ```
 
 ### Enhanced Monorepo / Macro Analysis
@@ -155,6 +156,9 @@ Per-language configuration overrides:
 
 ### `max_output_kb`
 Maximum size of generated index in KB (default: 100).
+
+### `max_files`
+Maximum source files selected for indexing (default: 10,000). Set to `0` for no source-file cap.
 
 ### `enhance` / `enhance_model`
 - `enhance`: Run the optional second-pass AI macro analysis (default: false).

--- a/utils/codebaseindex/manager_test.go
+++ b/utils/codebaseindex/manager_test.go
@@ -25,6 +25,44 @@ func TestNewManager(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigMaxFiles(t *testing.T) {
+	if got := DefaultConfig().MaxFiles; got != DefaultMaxFiles {
+		t.Fatalf("DefaultConfig().MaxFiles = %d, want %d", got, DefaultMaxFiles)
+	}
+}
+
+func TestSelectCandidatesHonorsMaxFiles(t *testing.T) {
+	newFiles := func() []*FileEntry {
+		return []*FileEntry{
+			{Path: "low.go", Score: 1},
+			{Path: "high.go", Score: 5},
+			{Path: "medium.go", Score: 3},
+			{Path: "higher.go", Score: 4},
+		}
+	}
+
+	for _, tt := range []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{name: "bounded", limit: 2, want: 2},
+		{name: "unlimited with zero", limit: 0, want: 4},
+		{name: "unlimited with negative", limit: -1, want: 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &Manager{config: &Config{MaxFiles: tt.limit}}
+			selected := manager.selectCandidates(newFiles())
+			if len(selected) != tt.want {
+				t.Fatalf("selected %d files, want %d", len(selected), tt.want)
+			}
+			if selected[0].Path != "high.go" {
+				t.Fatalf("highest scoring file = %q, want high.go", selected[0].Path)
+			}
+		})
+	}
+}
+
 func TestDeriveRepoSlugs(t *testing.T) {
 	tests := []struct {
 		input        string

--- a/utils/codebaseindex/scan.go
+++ b/utils/codebaseindex/scan.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	// maxCandidates is the maximum number of files to select for indexing
-	maxCandidates = 100
+	// DefaultMaxFiles is the number of source files included in an index unless
+	// callers override Config.MaxFiles. 0 or a negative value means unlimited.
+	DefaultMaxFiles = 10000
 
 	// maxHashReadSize is the maximum bytes to read for hashing (1MB)
 	maxHashReadSize = 1024 * 1024
@@ -236,9 +237,9 @@ func (m *Manager) selectCandidates(files []*FileEntry) []*FileEntry {
 		return files[i].Score > files[j].Score
 	})
 
-	// Select top N
-	limit := maxCandidates
-	if len(files) < limit {
+	// Select top N. A non-positive limit means include every candidate.
+	limit := m.config.MaxFiles
+	if limit <= 0 || len(files) < limit {
 		limit = len(files)
 	}
 

--- a/utils/codebaseindex/types.go
+++ b/utils/codebaseindex/types.go
@@ -77,6 +77,10 @@ type Config struct {
 	// Repository Layout tree. 0 or negative means unlimited (list every file).
 	MaxFilesPerDir int
 
+	// MaxFiles caps how many source files are selected for symbol extraction and
+	// inclusion in the index. 0 or negative means unlimited.
+	MaxFiles int
+
 	// Optional second-pass AI enhancement. The normal high-performance scan still
 	// runs first; when enabled, EnhancementFunc receives a bounded macro-analysis
 	// prompt and returns additional markdown insights for future agents.
@@ -288,5 +292,6 @@ func DefaultConfig() *Config {
 		Incremental:    false,
 		Verbose:        false,
 		MaxFilesPerDir: DefaultMaxFilesPerDir,
+		MaxFiles:       DefaultMaxFiles,
 	}
 }

--- a/utils/processor/codebase_index_handler.go
+++ b/utils/processor/codebase_index_handler.go
@@ -261,6 +261,10 @@ func (p *Processor) buildCodebaseIndexConfigWithError(stepConfig StepConfig) (*c
 			config.MaxOutputKB = ci.MaxOutputKB
 		}
 
+		if ci.MaxFiles != nil {
+			config.MaxFiles = *ci.MaxFiles
+		}
+
 		if ci.Enhance {
 			modelName, enhanceFunc, err := p.buildCodebaseIndexEnhancer(ci.EnhanceModel)
 			if err != nil {

--- a/utils/processor/dsl_test.go
+++ b/utils/processor/dsl_test.go
@@ -429,6 +429,47 @@ func TestBuildCodebaseIndexConfigEncryptionKey(t *testing.T) {
 	})
 }
 
+func TestBuildCodebaseIndexConfigMaxFiles(t *testing.T) {
+	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), createTestServerConfig(), false, "")
+
+	limit := 500
+	config := processor.buildCodebaseIndexConfig(StepConfig{
+		CodebaseIndex: &CodebaseIndexConfig{MaxFiles: &limit},
+	})
+	if config.MaxFiles != limit {
+		t.Errorf("MaxFiles = %d, want %d", config.MaxFiles, limit)
+	}
+
+	unlimited := 0
+	config = processor.buildCodebaseIndexConfig(StepConfig{
+		CodebaseIndex: &CodebaseIndexConfig{MaxFiles: &unlimited},
+	})
+	if config.MaxFiles != unlimited {
+		t.Errorf("MaxFiles = %d, want unlimited (%d)", config.MaxFiles, unlimited)
+	}
+}
+
+func TestCodebaseIndexMaxFilesYAML(t *testing.T) {
+	var config DSLConfig
+	err := yaml.Unmarshal([]byte(`
+index:
+  step_type: codebase-index
+  codebase_index:
+    root: .
+    max_files: 2500
+`), &config)
+	if err != nil {
+		t.Fatalf("unmarshal workflow: %v", err)
+	}
+	if len(config.Steps) != 1 || config.Steps[0].Config.CodebaseIndex == nil {
+		t.Fatal("codebase_index step was not parsed")
+	}
+	maxFiles := config.Steps[0].Config.CodebaseIndex.MaxFiles
+	if maxFiles == nil || *maxFiles != 2500 {
+		t.Fatalf("max_files = %v, want 2500", maxFiles)
+	}
+}
+
 func TestProcess(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -997,6 +997,7 @@ step_name:
         ignore_dirs: [vendor, testdata]
         priority_files: ["cmd/**/*.go"]
     max_output_kb: 100        # Maximum output size in KB
+    max_files: 10000           # Source files to index (0 = unlimited)
     enhance: false            # Optional second-pass AI macro analysis
     enhance_model: claude-code # Optional; defaults to default_generation_model
     qmd:                      # qmd integration (optional)
@@ -1016,6 +1017,7 @@ step_name:
 - ` + "`expose.memory.key`" + `: (string) Key name for memory access.
 - ` + "`adapters`" + `: (map, optional) Per-language configuration overrides.
 - ` + "`max_output_kb`" + `: (int, default: 100) Maximum size of generated index.
+- ` + "`max_files`" + `: (int, default: 10000) Maximum source files selected for indexing; ` + "`0`" + ` means unlimited.
 - ` + "`enhance`" + `: (bool, default: false) Run a second AI pass with the default generation model to add macro architecture analysis, component boundaries, frontend/backend patterns, and an agent change playbook.
 - ` + "`enhance_model`" + `: (string, optional) Model for ` + "`enhance`" + `; defaults to configured ` + "`default_generation_model`" + `.
 - ` + "`qmd.collection`" + `: (string, optional) Register index as a qmd collection with this name.

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -199,6 +199,7 @@ type CodebaseIndexConfig struct {
 	Expose       *CodebaseIndexExposeConfig  `yaml:"expose,omitempty"`        // Variable/memory exposure configuration
 	Adapters     map[string]*AdapterOverride `yaml:"adapters,omitempty"`      // Per-adapter overrides
 	MaxOutputKB  int                         `yaml:"max_output_kb,omitempty"` // Maximum output size in KB
+	MaxFiles     *int                        `yaml:"max_files,omitempty"`     // Maximum source files to include (0 = unlimited)
 	Enhance      bool                        `yaml:"enhance,omitempty"`       // Run second-pass AI macro analysis
 	EnhanceModel string                      `yaml:"enhance_model,omitempty"` // Model for enhancement (default_generation_model if empty)
 	Qmd          *QmdIntegrationConfig       `yaml:"qmd,omitempty"`           // qmd integration configuration


### PR DESCRIPTION
## Summary
- raise the codebase index source-file default from 100 to 10,000
- add `max_files` workflow configuration (`0` for unlimited)
- add `--max-files` to `comanda index capture` and `update`
- document and test the override paths

## Verification
- `go test ./...`
- `go vet ./...`