### PR TITLE
Fix large Claude prompts in agentic loops

### DIFF
--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -147,15 +147,17 @@ func (c *ClaudeCodeProvider) SendPrompt(modelName string, prompt string) (string
 		}
 	}
 
-	// Build the command arguments
-	args := c.buildArgs(modelName, prompt, "")
+	// Keep prompt content on stdin rather than in argv. Besides avoiding prompt
+	// leakage in process listings, this allows indexes and other large inputs to
+	// exceed the operating system's command-line argument limit.
+	args := c.buildArgs(modelName)
 
 	c.debugf("Executing: %s %v", c.binaryPath, args)
 
 	// Use retry mechanism for execution
 	result, err := retry.WithRetry(
 		func() (interface{}, error) {
-			return c.executeCommand(args, "")
+			return c.executeCommand(args, prompt, "")
 		},
 		func(err error) bool {
 			// Retry on timeout or transient errors
@@ -197,13 +199,13 @@ func (c *ClaudeCodeProvider) SendPromptWithFile(modelName string, prompt string,
 	combinedPrompt := fmt.Sprintf("File: %s\n\n```\n%s\n```\n\nTask: %s", file.Path, fileContent, prompt)
 
 	// Build args - use the file's directory as working directory
-	args := c.buildArgs(modelName, combinedPrompt, filepath.Dir(file.Path))
+	args := c.buildArgs(modelName)
 
 	c.debugf("Executing with file context: %s", file.Path)
 
 	result, err := retry.WithRetry(
 		func() (interface{}, error) {
-			return c.executeCommand(args, filepath.Dir(file.Path))
+			return c.executeCommand(args, combinedPrompt, filepath.Dir(file.Path))
 		},
 		func(err error) bool {
 			return strings.Contains(err.Error(), "timeout") ||
@@ -253,15 +255,16 @@ func (c *ClaudeCodeProvider) SendPromptAgentic(modelName string, prompt string, 
 		}
 	}
 
-	// Build agentic args (no --print flag)
-	args := c.buildArgsAgentic(modelName, prompt, allowedPaths, tools)
+	// Build agentic args. Send the prompt on stdin, not as a positional
+	// argument, so large loop context does not exceed ARG_MAX.
+	args := c.buildArgsAgentic(modelName, allowedPaths, tools)
 
 	c.debugf("Executing agentic: %s %v", c.binaryPath, args)
 
 	// Use retry mechanism for execution
 	result, err := retry.WithRetry(
 		func() (interface{}, error) {
-			return c.executeCommand(args, workDir)
+			return c.executeCommand(args, prompt, workDir)
 		},
 		func(err error) bool {
 			return strings.Contains(err.Error(), "timeout") ||
@@ -300,8 +303,9 @@ func (c *ClaudeCodeProvider) getModelFlag(modelName string) string {
 	}
 }
 
-// buildArgs constructs the command line arguments for claude
-func (c *ClaudeCodeProvider) buildArgs(modelName string, prompt string, workDir string) []string {
+// buildArgs constructs command-line arguments for Claude's non-interactive
+// mode. The prompt is deliberately supplied on stdin by executeCommand.
+func (c *ClaudeCodeProvider) buildArgs(modelName string) []string {
 	args := []string{
 		"--print", // Non-interactive mode, just print the response
 	}
@@ -309,9 +313,6 @@ func (c *ClaudeCodeProvider) buildArgs(modelName string, prompt string, workDir 
 	if model := c.getModelFlag(modelName); model != "" {
 		args = append(args, "--model", model)
 	}
-
-	// Add the prompt as positional argument
-	args = append(args, prompt)
 
 	return args
 }
@@ -336,9 +337,10 @@ func resolvePath(path string) string {
 	return path
 }
 
-// buildArgsAgentic constructs command line arguments for agentic mode
-// Uses -p (print mode) with --bare and explicit tool permissions for deterministic subprocess behavior
-func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, allowedPaths []string, tools []string) []string {
+// buildArgsAgentic constructs command line arguments for agentic mode.
+// It uses -p (print mode) with explicit tool permissions for deterministic
+// subprocess behavior; executeCommand supplies the prompt on stdin.
+func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, allowedPaths []string, tools []string) []string {
 	// Start with -p for subprocess/one-shot mode and for subprocess mode
 	// Note: --bare was removed as it breaks auth on some Claude Code versions
 	args := []string{"-p"}
@@ -393,15 +395,15 @@ func (c *ClaudeCodeProvider) buildArgsAgentic(modelName string, prompt string, a
 		args = append(args, "--model", model)
 	}
 
-	// Add the prompt as the final positional argument
-	args = append(args, prompt)
-
 	return args
 }
 
 // executeCommand runs the claude binary and captures output
-func (c *ClaudeCodeProvider) executeCommand(args []string, workDir string) (string, error) {
+func (c *ClaudeCodeProvider) executeCommand(args []string, prompt string, workDir string) (string, error) {
 	cmd := exec.Command(c.binaryPath, args...)
+	// `claude --print` accepts piped input. Keeping prompts off argv avoids the
+	// OS command-line size cap for large file inputs and loop state.
+	cmd.Stdin = strings.NewReader(prompt)
 
 	if workDir != "" {
 		cmd.Dir = workDir

--- a/utils/models/claudecode_test.go
+++ b/utils/models/claudecode_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -103,42 +104,33 @@ func TestClaudeCodeBuildArgs(t *testing.T) {
 	tests := []struct {
 		name     string
 		model    string
-		prompt   string
 		contains []string
 	}{
 		{
 			name:     "base model",
 			model:    "claude-code",
-			prompt:   "hello",
-			contains: []string{"--print", "hello"},
+			contains: []string{"--print"},
 		},
 		{
 			name:     "opus variant",
 			model:    "claude-code-opus",
-			prompt:   "test",
-			contains: []string{"--print", "--model", "claude-opus-4-5-20251101", "test"},
+			contains: []string{"--print", "--model", "claude-opus-4-5-20251101"},
 		},
 		{
 			name:     "sonnet variant",
 			model:    "claude-code-sonnet",
-			prompt:   "test",
-			contains: []string{"--print", "--model", "claude-sonnet-4-5-20250929", "test"},
+			contains: []string{"--print", "--model", "claude-sonnet-4-5-20250929"},
 		},
 		{
 			name:     "haiku variant",
 			model:    "claude-code-haiku",
-			prompt:   "test",
-			contains: []string{"--print", "--model", "claude-haiku-4-5-20251001", "test"},
+			contains: []string{"--print", "--model", "claude-haiku-4-5-20251001"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := provider.buildArgs(tt.model, tt.prompt, "")
-			argsStr := ""
-			for _, arg := range args {
-				argsStr += arg + " "
-			}
+			args := provider.buildArgs(tt.model)
 			for _, expected := range tt.contains {
 				found := false
 				for _, arg := range args {
@@ -148,7 +140,7 @@ func TestClaudeCodeBuildArgs(t *testing.T) {
 					}
 				}
 				if !found {
-					t.Errorf("buildArgs(%q, %q) missing expected arg %q, got: %v", tt.model, tt.prompt, expected, args)
+					t.Errorf("buildArgs(%q) missing expected arg %q, got: %v", tt.model, expected, args)
 				}
 			}
 		})
@@ -234,7 +226,6 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 	tests := []struct {
 		name            string
 		model           string
-		prompt          string
 		allowedPaths    []string
 		tools           []string
 		contains        []string
@@ -245,10 +236,9 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 		{
 			name:            "basic agentic call",
 			model:           "claude-code-sonnet",
-			prompt:          "explore",
 			allowedPaths:    []string{"./"},
 			tools:           nil,
-			contains:        []string{"-p", "--add-dir", "--dangerously-skip-permissions", "--allowedTools", "Read,Write,Edit,Glob,Grep,Bash", "--output-format", "json", "--model", "claude-sonnet-4-5-20250929", "explore"},
+			contains:        []string{"-p", "--add-dir", "--dangerously-skip-permissions", "--allowedTools", "Read,Write,Edit,Glob,Grep,Bash", "--output-format", "json", "--model", "claude-sonnet-4-5-20250929"},
 			notContains:     []string{"--print"},
 			checkAbsPaths:   true,
 			expectedPathCnt: 1,
@@ -256,10 +246,9 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 		{
 			name:            "with tool restrictions",
 			model:           "claude-code",
-			prompt:          "test",
 			allowedPaths:    []string{"/tmp"},
 			tools:           []string{"Read", "Bash"},
-			contains:        []string{"-p", "--add-dir", "/tmp", "--dangerously-skip-permissions", "--allowedTools", "Read,Bash", "--output-format", "json", "test"},
+			contains:        []string{"-p", "--add-dir", "/tmp", "--dangerously-skip-permissions", "--allowedTools", "Read,Bash", "--output-format", "json"},
 			notContains:     []string{"--print", "--model"},
 			checkAbsPaths:   false, // /tmp is already absolute
 			expectedPathCnt: 1,
@@ -267,10 +256,9 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 		{
 			name:            "multiple paths",
 			model:           "claude-code-opus",
-			prompt:          "analyze",
 			allowedPaths:    []string{"./src", "./tests"},
 			tools:           nil,
-			contains:        []string{"-p", "--add-dir", "--dangerously-skip-permissions", "--allowedTools", "Read,Write,Edit,Glob,Grep,Bash", "--output-format", "json", "analyze"},
+			contains:        []string{"-p", "--add-dir", "--dangerously-skip-permissions", "--allowedTools", "Read,Write,Edit,Glob,Grep,Bash", "--output-format", "json"},
 			notContains:     []string{"--print"},
 			checkAbsPaths:   true,
 			expectedPathCnt: 2,
@@ -278,10 +266,9 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 		{
 			name:            "no allowed paths skips permission mode",
 			model:           "claude-code",
-			prompt:          "query",
 			allowedPaths:    []string{},
 			tools:           nil,
-			contains:        []string{"-p", "--output-format", "json", "query"},
+			contains:        []string{"-p", "--output-format", "json"},
 			notContains:     []string{"--print", "--add-dir", "--dangerously-skip-permissions", "--allowedTools"},
 			checkAbsPaths:   false,
 			expectedPathCnt: 0,
@@ -290,7 +277,7 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := provider.buildArgsAgentic(tt.model, tt.prompt, tt.allowedPaths, tt.tools)
+			args := provider.buildArgsAgentic(tt.model, tt.allowedPaths, tt.tools)
 
 			for _, expected := range tt.contains {
 				found := false
@@ -330,6 +317,26 @@ func TestClaudeCodeBuildArgsAgentic(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestClaudeCodeExecuteCommandSendsLargePromptOnStdin(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "fake-claude")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\n[ \"$#\" -eq 1 ] && [ \"$1\" = \"-p\" ] || exit 2\ncat\n"), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+
+	provider := NewClaudeCodeProvider()
+	provider.binaryPath = binaryPath
+	prompt := strings.Repeat("x", 300_000)
+
+	got, err := provider.executeCommand([]string{"-p"}, prompt, "")
+	if err != nil {
+		t.Fatalf("executeCommand() error: %v", err)
+	}
+	if got != prompt {
+		t.Fatalf("executeCommand() returned %d bytes, want %d", len(got), len(prompt))
 	}
 }
 


### PR DESCRIPTION
Claude Code prompts are currently passed as a positional argument, which reaches macOS ARG_MAX when a loop expands a large index or previous output.

This sends all Claude prompts through stdin (supported by `claude --print`) while retaining the existing command flags. It also keeps prompt content out of process argv.

Tests cover a 300 KB prompt reaching the child process over stdin; `go test ./...` and `go vet ./...` pass.