### PR TITLE
Add model and provider listing to configure menu

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -830,6 +830,7 @@ func configureModelsAndProviders(reader *bufio.Reader, envConfig *config.EnvConf
 		log.Printf("│  4. Set Default Generation Model    │\n")
 		log.Printf("│  5. Remove a Model                  │\n")
 		log.Printf("│  6. Update API Key                  │\n")
+		log.Printf("│  7. List Models & Providers         │\n")
 		log.Printf("│  0. Back to Main Menu               │\n")
 		log.Printf("└─────────────────────────────────────┘\n")
 		log.Printf("\nEnter choice: ")
@@ -849,10 +850,49 @@ func configureModelsAndProviders(reader *bufio.Reader, envConfig *config.EnvConf
 			removeModelInteractive(reader, envConfig)
 		case "6":
 			updateAPIKeyInteractive(reader, envConfig)
+		case "7":
+			listModelsAndProviders(envConfig)
 		case "0":
 			return
 		default:
 			log.Printf("Invalid selection.\n")
+		}
+	}
+}
+
+// listModelsAndProviders displays the providers and models currently configured
+// in Comanda without leaving the Models & Providers menu.
+func listModelsAndProviders(envConfig *config.EnvConfig) {
+	log.Printf("\nConfigured Models & Providers\n")
+
+	if envConfig == nil || len(envConfig.Providers) == 0 {
+		log.Printf("  No providers configured.\n")
+		return
+	}
+
+	providerNames := make([]string, 0, len(envConfig.Providers))
+	for name := range envConfig.Providers {
+		providerNames = append(providerNames, name)
+	}
+	sort.Strings(providerNames)
+
+	for _, name := range providerNames {
+		provider := envConfig.Providers[name]
+		log.Printf("\n  %s\n", name)
+		if provider == nil || len(provider.Models) == 0 {
+			log.Printf("    No models configured.\n")
+			continue
+		}
+
+		for _, model := range provider.Models {
+			defaultMarker := ""
+			if model.Name == envConfig.DefaultGenerationModel {
+				defaultMarker = " (default)"
+			}
+			log.Printf("    - %s%s\n", model.Name, defaultMarker)
+			if model.Target != "" && model.Target != model.Name {
+				log.Printf("      Target: %s\n", model.Target)
+			}
 		}
 	}
 }

--- a/cmd/configure_default_test.go
+++ b/cmd/configure_default_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"log"
 	"os"
@@ -226,5 +227,77 @@ func TestListConfigurationWithDefaultModel(t *testing.T) {
 	// Verify default model is displayed (accounting for log timestamp prefix)
 	if !strings.Contains(output, "Default Generation Model: claude-3-opus") && !strings.Contains(output, "claude-3-opus") {
 		t.Errorf("Expected output to contain default generation model, got: %s", output)
+	}
+}
+
+func TestListModelsAndProviders(t *testing.T) {
+	testConfig := &config.EnvConfig{
+		DefaultGenerationModel: "friendly-gpt",
+		Providers: map[string]*config.Provider{
+			"openai": {
+				Models: []config.Model{
+					{Name: "friendly-gpt", Target: "gpt-4.1"},
+				},
+			},
+			"anthropic": {
+				Models: []config.Model{
+					{Name: "claude-sonnet"},
+				},
+			},
+			"ollama": nil,
+		},
+	}
+
+	var buf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(originalOutput)
+
+	listModelsAndProviders(testConfig)
+	output := buf.String()
+
+	for _, expected := range []string{
+		"Configured Models & Providers",
+		"anthropic",
+		"claude-sonnet",
+		"ollama",
+		"No models configured.",
+		"openai",
+		"friendly-gpt (default)",
+		"Target: gpt-4.1",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected output to contain %q, got:\n%s", expected, output)
+		}
+	}
+
+	if strings.Index(output, "anthropic") > strings.Index(output, "openai") {
+		t.Errorf("expected providers to be sorted alphabetically, got:\n%s", output)
+	}
+}
+
+func TestModelsAndProvidersMenuListsConfiguration(t *testing.T) {
+	testConfig := &config.EnvConfig{
+		Providers: map[string]*config.Provider{
+			"openai": {
+				Models: []config.Model{{Name: "gpt-4.1"}},
+			},
+		},
+	}
+	reader := bufio.NewReader(strings.NewReader("7\n0\n"))
+
+	var buf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(originalOutput)
+
+	configureModelsAndProviders(reader, testConfig)
+	output := buf.String()
+
+	if !strings.Contains(output, "7. List Models & Providers") {
+		t.Errorf("expected list action in submenu, got:\n%s", output)
+	}
+	if !strings.Contains(output, "gpt-4.1") {
+		t.Errorf("expected configured model to be listed, got:\n%s", output)
 	}
 }


### PR DESCRIPTION
## What changed

- Added a **List Models & Providers** action to the interactive Models & Providers configure submenu.
- Lists configured providers in deterministic alphabetical order.
- Shows each provider's configured models, aliases/targets, and the current default model.
- Handles empty and nil provider configurations gracefully.
- Added unit coverage for the formatter and interactive submenu flow.

## Why

Users could view the full configuration from the main menu, but there was no way to inspect configured models and providers while working inside the Models & Providers submenu. This adds that scoped view without forcing users to leave the submenu.

## Validation

- `go test ./cmd`
- `go test ./...`
- `git diff --check`