### PR TITLE
feat(models): kimi-code agentic loop support (Phase 2)

### DIFF
--- a/examples/kimi-code/README.md
+++ b/examples/kimi-code/README.md
@@ -50,6 +50,14 @@ analyze-project:
   independent accounts and keys; that path is comanda's `moonshot` provider,
   not this one.
 
+## Agentic Mode
+
+`kimi-code` supports comanda's agentic loops (see `agentic-loop.yaml`):
+`allowed_paths` map to `--add-dir` workspace directories and the loop's working
+directory becomes the session cwd. Note that kimi's `-p` mode auto-approves
+routine actions (writes, shell commands) and has no per-tool allowlist flag, so
+the loop `tools:` list is advisory only — scope access with `allowed_paths`.
+
 ## Configuration
 
 No special configuration needed in `.env`. The provider automatically detects

--- a/examples/kimi-code/agentic-loop.yaml
+++ b/examples/kimi-code/agentic-loop.yaml
@@ -1,0 +1,32 @@
+# Agentic Loop with Kimi Code
+# Uses the local kimi CLI with full tool access to iteratively build a script
+#
+# Usage: cd /tmp && comanda process examples/kimi-code/agentic-loop.yaml
+#
+# The loop's allowed_paths auto-infer to the directory you run comanda from;
+# set allowed_paths explicitly to scope the agent's workspace access.
+
+implement:
+  agentic_loop:
+    max_iterations: 3
+    exit_condition: pattern_match
+    exit_pattern: "DONE"
+  input: NA
+  model: kimi-code
+  action: |
+    You are building a simple shell script. This is iteration {{ loop.iteration }}.
+
+    Task: create a file hello.sh in the current directory that prints
+    "hello from kimi-code" when run.
+
+    Previous work:
+    {{ loop.previous_output }}
+
+    Iteration 1: create hello.sh using your file tools.
+    Iteration 2: verify the file and improve it if needed.
+    Iteration 3: finalize.
+
+    If hello.sh exists and is correct, start your response with exactly: DONE
+
+    Then describe what you did.
+  output: STDOUT

--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -55,6 +55,13 @@ type ClaudeCodeProvider struct {
 	mu                sync.Mutex
 }
 
+// ClaudeCodeProvider implements the agentic provider capabilities.
+var (
+	_ AgenticProvider = (*ClaudeCodeProvider)(nil)
+	_ DebugFileSetter = (*ClaudeCodeProvider)(nil)
+	_ WorktreeSetter  = (*ClaudeCodeProvider)(nil)
+)
+
 // NewClaudeCodeProvider creates a new Claude Code provider instance
 func NewClaudeCodeProvider() *ClaudeCodeProvider {
 	return &ClaudeCodeProvider{}

--- a/utils/models/kimicode.go
+++ b/utils/models/kimicode.go
@@ -82,6 +82,9 @@ type KimiCodeProvider struct {
 	mu         sync.Mutex
 }
 
+// KimiCodeProvider implements the agentic provider capability.
+var _ AgenticProvider = (*KimiCodeProvider)(nil)
+
 // NewKimiCodeProvider creates a new Kimi Code provider instance
 func NewKimiCodeProvider() *KimiCodeProvider {
 	return &KimiCodeProvider{}
@@ -289,6 +292,75 @@ func (k *KimiCodeProvider) SendPromptWithFile(modelName string, prompt string, f
 	return response, nil
 }
 
+// SendPromptAgentic sends a prompt with full tool access for agentic mode.
+//
+// Permission posture: kimi's non-interactive -p mode rejects --yolo/--auto
+// (verified on 0.27.0: "Cannot combine --prompt with --yolo") and instead
+// auto-approves routine actions (file writes, shell commands) by default, so
+// no permission flags are passed — the effective posture matches claude-code's
+// --dangerously-skip-permissions, which comanda always uses in agentic mode.
+// kimi has no per-tool allowlist flag, so comanda's tools allowlist cannot be
+// enforced by the CLI and is ignored here (agentic runs get full tool access).
+func (k *KimiCodeProvider) SendPromptAgentic(modelName string, prompt string, allowedPaths []string, tools []string, workDir string) (string, error) {
+	k.debugf("Preparing to send agentic prompt via Kimi Code")
+	k.debugf("Prompt length: %d characters, allowed paths: %v, tools: %v", len(prompt), allowedPaths, tools)
+	if len(tools) > 0 {
+		k.debugf("Note: kimi has no per-tool allowlist flag; tools %v are advisory only", tools)
+	}
+
+	// Expand paths (handle ~, $HOME, etc.) before validation
+	expandedPaths, err := fileutil.ExpandPaths(allowedPaths)
+	if err != nil {
+		return "", fmt.Errorf("failed to expand allowed_paths: %w", err)
+	}
+
+	// Validate all allowed paths exist (do this first to fail fast on bad config)
+	var missingPaths []string
+	for i, path := range expandedPaths {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			missingPaths = append(missingPaths, fmt.Sprintf("%s (expanded from %s)", path, allowedPaths[i]))
+		}
+	}
+	if len(missingPaths) > 0 {
+		return "", fmt.Errorf("allowed_path(s) do not exist:\n  • %s\n\n💡 Tip: If allowed_paths is empty, comanda will auto-infer from the workflow directory or cwd",
+			strings.Join(missingPaths, "\n  • "))
+	}
+
+	// Use expanded paths from here on
+	allowedPaths = expandedPaths
+
+	if k.binaryPath == "" {
+		if err := k.Configure("LOCAL"); err != nil {
+			return "", err
+		}
+	}
+
+	args := k.buildArgsAgentic(modelName, prompt, allowedPaths)
+
+	k.debugf("Executing agentic: %s %v", k.binaryPath, args)
+
+	// Use retry mechanism for execution
+	result, err := retry.WithRetry(
+		func() (interface{}, error) {
+			return k.executeCommand(args, workDir)
+		},
+		func(err error) bool {
+			// Retry on timeout or transient errors
+			return strings.Contains(err.Error(), "timeout") ||
+				strings.Contains(err.Error(), "connection")
+		},
+		retry.DefaultRetryConfig,
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	response := extractKimiCodeResult(result.(string))
+	k.debugf("Agentic command completed, response length: %d characters", len(response))
+	return response, nil
+}
+
 // getModelFlag returns the --model flag value for a given model name, or empty
 // string if none needed. kimi-code-<alias> maps to the model alias <alias> from
 // the user's ~/.kimi-code/config.toml; aliases are user-defined, so the variant
@@ -311,6 +383,19 @@ func (k *KimiCodeProvider) buildArgs(modelName string, prompt string) []string {
 		args = append(args, "--model", model)
 	}
 
+	return args
+}
+
+// buildArgsAgentic constructs the command line arguments for agentic mode:
+// buildArgs plus each allowed path as an additional workspace directory.
+func (k *KimiCodeProvider) buildArgsAgentic(modelName string, prompt string, allowedPaths []string) []string {
+	args := k.buildArgs(modelName, prompt)
+	for _, path := range allowedPaths {
+		// Resolve paths to absolute (expands ~ and converts relative to absolute)
+		resolvedPath := resolvePath(path)
+		k.debugf("Resolved allowed path: %s -> %s", path, resolvedPath)
+		args = append(args, "--add-dir", resolvedPath)
+	}
 	return args
 }
 

--- a/utils/models/kimicode_test.go
+++ b/utils/models/kimicode_test.go
@@ -305,6 +305,167 @@ func TestKimiCodeVerifyKimiBinary(t *testing.T) {
 	}
 }
 
+func TestKimiCodeBuildArgsAgentic(t *testing.T) {
+	provider := NewKimiCodeProvider()
+
+	tests := []struct {
+		name            string
+		model           string
+		allowedPaths    []string
+		contains        []string
+		notContains     []string
+		expectedPathCnt int
+	}{
+		{
+			name:            "basic agentic call",
+			model:           "kimi-code",
+			allowedPaths:    []string{"./"},
+			contains:        []string{"--prompt", "do the thing", "--output-format", "stream-json", "--add-dir"},
+			notContains:     []string{"--yolo", "--auto", "--model"},
+			expectedPathCnt: 1,
+		},
+		{
+			name:            "with model alias and multiple paths",
+			model:           "kimi-code-fast",
+			allowedPaths:    []string{"/tmp", "/var"},
+			contains:        []string{"--prompt", "--add-dir", "/tmp", "/var", "--model", "fast"},
+			notContains:     []string{"--yolo", "--auto"},
+			expectedPathCnt: 2,
+		},
+		{
+			name:            "no allowed paths",
+			model:           "kimi-code",
+			allowedPaths:    []string{},
+			contains:        []string{"--prompt", "--output-format", "stream-json"},
+			notContains:     []string{"--add-dir", "--yolo", "--auto"},
+			expectedPathCnt: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := provider.buildArgsAgentic(tt.model, "do the thing", tt.allowedPaths)
+
+			for _, expected := range tt.contains {
+				found := false
+				for _, arg := range args {
+					if arg == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("buildArgsAgentic() missing expected arg %q, got: %v", expected, args)
+				}
+			}
+
+			for _, notExpected := range tt.notContains {
+				for _, arg := range args {
+					if arg == notExpected {
+						t.Errorf("buildArgsAgentic() should not contain %q, got: %v", notExpected, args)
+					}
+				}
+			}
+
+			// Check that --add-dir paths are resolved to absolute paths
+			addDirCount := 0
+			for i, arg := range args {
+				if arg == "--add-dir" && i+1 < len(args) {
+					addDirCount++
+					if !strings.HasPrefix(args[i+1], "/") {
+						t.Errorf("buildArgsAgentic() --add-dir path should be absolute, got: %q", args[i+1])
+					}
+				}
+			}
+			if addDirCount != tt.expectedPathCnt {
+				t.Errorf("buildArgsAgentic() expected %d --add-dir flags, got %d", tt.expectedPathCnt, addDirCount)
+			}
+		})
+	}
+}
+
+// TestKimiCodeSendPromptAgentic verifies the agentic path end-to-end with a fake
+// kimi binary: allowed paths become --add-dir flags and the response is extracted
+// from the stream-json output.
+func TestKimiCodeSendPromptAgentic(t *testing.T) {
+	dir := t.TempDir()
+	capturePath := filepath.Join(dir, "capture.txt")
+
+	binaryPath := filepath.Join(dir, "fake-kimi")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"$FAKE_KIMI_CAPTURE\"\n" +
+		"printf '%s' '{\"role\":\"assistant\",\"content\":\"agentic ok\"}'\n"
+	if err := os.WriteFile(binaryPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake kimi: %v", err)
+	}
+	t.Setenv("FAKE_KIMI_CAPTURE", capturePath)
+
+	provider := NewKimiCodeProvider()
+	provider.binaryPath = binaryPath
+
+	got, err := provider.SendPromptAgentic("kimi-code", "do the thing", []string{dir}, []string{"Read", "Bash"}, dir)
+	if err != nil {
+		t.Fatalf("SendPromptAgentic() error: %v", err)
+	}
+	if got != "agentic ok" {
+		t.Fatalf("SendPromptAgentic() = %q, want %q", got, "agentic ok")
+	}
+
+	capture, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	if !strings.Contains(string(capture), "--add-dir") || !strings.Contains(string(capture), dir) {
+		t.Errorf("expected --add-dir %q in captured args: %q", dir, string(capture))
+	}
+}
+
+func TestKimiCodeSendPromptAgenticPathValidation(t *testing.T) {
+	provider := NewKimiCodeProvider()
+	// Point at a bogus binary so the valid-path case fails fast after path
+	// validation instead of invoking a real kimi CLI (slow, requires auth).
+	provider.binaryPath = "/nonexistent/kimi"
+
+	tests := []struct {
+		name          string
+		allowedPaths  []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:         "valid path",
+			allowedPaths: []string{"."},
+			expectError:  false,
+		},
+		{
+			name:          "invalid path",
+			allowedPaths:  []string{"/nonexistent/path/that/does/not/exist"},
+			expectError:   true,
+			errorContains: "do not exist",
+		},
+		{
+			name:          "mixed valid and invalid",
+			allowedPaths:  []string{".", "/nonexistent/path"},
+			expectError:   true,
+			errorContains: "do not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := provider.SendPromptAgentic("kimi-code", "test", tt.allowedPaths, nil, "")
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("SendPromptAgentic() expected error, got nil")
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("SendPromptAgentic() error = %v, want error containing %q", err, tt.errorContains)
+				}
+			}
+			// Note: valid paths may still fail if kimi binary not found, that's ok
+		})
+	}
+}
+
 func TestKimiCodeSetVerbose(t *testing.T) {
 	provider := NewKimiCodeProvider()
 

--- a/utils/models/provider.go
+++ b/utils/models/provider.go
@@ -65,6 +65,29 @@ type ResponsesProvider interface {
 	SendPromptWithResponsesStream(config ResponsesConfig, handler ResponsesStreamHandler) error
 }
 
+// AgenticProvider extends Provider for CLI-based providers that can run prompts
+// with full tool access (file edits, shell commands) for agentic mode.
+// allowedPaths scopes the agent's workspace access; tools is a provider-specific
+// tool allowlist (providers without per-tool granularity may ignore it);
+// workDir is the working directory for the subprocess.
+type AgenticProvider interface {
+	Provider
+	SendPromptAgentic(modelName string, prompt string, allowedPaths []string, tools []string, workDir string) (string, error)
+}
+
+// DebugFileSetter is an optional AgenticProvider capability for providers that
+// can stream debug output to a file (watched by the processor's DebugWatcher).
+type DebugFileSetter interface {
+	SetDebugFile(path string)
+}
+
+// WorktreeSetter is an optional AgenticProvider capability for providers that
+// support isolated execution in a git worktree.
+type WorktreeSetter interface {
+	SetWorktree(name string)
+	ClearWorktree()
+}
+
 // OllamaTagsResponse represents the response from Ollama's /api/tags endpoint
 type OllamaTagsResponse struct {
 	Models []OllamaModelTag `json:"models"`

--- a/utils/processor/action_handler.go
+++ b/utils/processor/action_handler.go
@@ -94,33 +94,37 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 		inputs := p.handler.GetInputs()
 		if len(inputs) == 0 {
 			// If there are no inputs, just send the action directly
-			// Check for agentic mode with Claude Code
+			// Check for agentic mode with an agentic-capable provider
 			if isAgenticMode {
-				if claudeCode, ok := configuredProvider.(*models.ClaudeCodeProvider); ok {
-					p.debugf("Using agentic mode with Claude Code (paths: %v, tools: %v)",
-						agenticConfig.AllowedPaths, agenticConfig.Tools)
-					// Pass stream log path to claude-code for debug visibility
+				if agentic, ok := configuredProvider.(models.AgenticProvider); ok {
+					p.debugf("Using agentic mode with %s (paths: %v, tools: %v)",
+						configuredProvider.Name(), agenticConfig.AllowedPaths, agenticConfig.Tools)
+					// Pass stream log path to the provider for debug visibility
 					streamLogPath := p.GetStreamLogPath()
 					p.debugf("Stream log path: %q", streamLogPath)
 					var debugWatcher *DebugWatcher
 					if streamLogPath != "" {
-						debugPath := streamLogPath + ".claude-debug"
-						p.debugf("Setting claude-code debug file: %s", debugPath)
-						claudeCode.SetDebugFile(debugPath)
-						// Start watching the debug file for context usage
-						if p.streamLog != nil {
-							debugWatcher = NewDebugWatcher(debugPath, p.streamLog)
-							debugWatcher.Start()
+						if df, ok := configuredProvider.(models.DebugFileSetter); ok {
+							debugPath := streamLogPath + ".claude-debug"
+							p.debugf("Setting provider debug file: %s", debugPath)
+							df.SetDebugFile(debugPath)
+							// Start watching the debug file for context usage
+							if p.streamLog != nil {
+								debugWatcher = NewDebugWatcher(debugPath, p.streamLog)
+								debugWatcher.Start()
+							}
 						}
 					}
 					// Set native worktree if provider supports it and step uses a worktree
 					worktreeName := p.getCurrentStepWorktree()
-					if worktreeName != "" && p.providerSupportsWorktrees("claude-code") {
-						p.debugf("Using native worktree support: %s", worktreeName)
-						claudeCode.SetWorktree(worktreeName)
-						defer claudeCode.ClearWorktree()
+					if worktreeName != "" && p.providerSupportsWorktrees(configuredProvider.Name()) {
+						if ws, ok := configuredProvider.(models.WorktreeSetter); ok {
+							p.debugf("Using native worktree support: %s", worktreeName)
+							ws.SetWorktree(worktreeName)
+							defer ws.ClearWorktree()
+						}
 					}
-					result, err := claudeCode.SendPromptAgentic(modelName, action,
+					result, err := agentic.SendPromptAgentic(modelName, action,
 						agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 					// Stop the debug watcher
 					if debugWatcher != nil {
@@ -197,8 +201,8 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 				// In agentic mode, read the file content and use SendPromptAgentic
 				// This ensures the correct working directory is used instead of the file's temp directory
 				if isAgenticMode {
-					if claudeCode, ok := configuredProvider.(*models.ClaudeCodeProvider); ok {
-						p.debugf("Using agentic mode with Claude Code for single file input")
+					if agentic, ok := configuredProvider.(models.AgenticProvider); ok {
+						p.debugf("Using agentic mode with %s for single file input", configuredProvider.Name())
 						// Read file content
 						fileContent, err := fileutil.SafeReadFile(fileInputs[0].Path)
 						if err != nil {
@@ -208,26 +212,30 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 						combinedPrompt := fmt.Sprintf("File: %s\n\n```\n%s\n```\n\nTask: %s",
 							fileInputs[0].Path, string(fileContent), action)
 
-						// Pass stream log path to claude-code for debug visibility
+						// Pass stream log path to the provider for debug visibility
 						streamLogPath := p.GetStreamLogPath()
 						var debugWatcher *DebugWatcher
 						if streamLogPath != "" {
-							debugPath := streamLogPath + ".claude-debug"
-							p.debugf("Setting claude-code debug file: %s", debugPath)
-							claudeCode.SetDebugFile(debugPath)
-							if p.streamLog != nil {
-								debugWatcher = NewDebugWatcher(debugPath, p.streamLog)
-								debugWatcher.Start()
+							if df, ok := configuredProvider.(models.DebugFileSetter); ok {
+								debugPath := streamLogPath + ".claude-debug"
+								p.debugf("Setting provider debug file: %s", debugPath)
+								df.SetDebugFile(debugPath)
+								if p.streamLog != nil {
+									debugWatcher = NewDebugWatcher(debugPath, p.streamLog)
+									debugWatcher.Start()
+								}
 							}
 						}
 						// Set native worktree if provider supports it
 						worktreeName := p.getCurrentStepWorktree()
-						if worktreeName != "" && p.providerSupportsWorktrees("claude-code") {
-							p.debugf("Using native worktree support: %s", worktreeName)
-							claudeCode.SetWorktree(worktreeName)
-							defer claudeCode.ClearWorktree()
+						if worktreeName != "" && p.providerSupportsWorktrees(configuredProvider.Name()) {
+							if ws, ok := configuredProvider.(models.WorktreeSetter); ok {
+								p.debugf("Using native worktree support: %s", worktreeName)
+								ws.SetWorktree(worktreeName)
+								defer ws.ClearWorktree()
+							}
 						}
-						result, err := claudeCode.SendPromptAgentic(resolvedModelName, combinedPrompt,
+						result, err := agentic.SendPromptAgentic(resolvedModelName, combinedPrompt,
 							agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 						if debugWatcher != nil {
 							debugWatcher.Stop()
@@ -334,32 +342,36 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 			combinedInput := strings.Join(nonFileInputs, "\n\n")
 			combinedPrompt := fmt.Sprintf("Input:\n%s\n\nAction: %s", combinedInput, action)
 
-			// Check for agentic mode with Claude Code
+			// Check for agentic mode with an agentic-capable provider
 			if isAgenticMode {
-				if claudeCode, ok := configuredProvider.(*models.ClaudeCodeProvider); ok {
-					p.debugf("Using agentic mode with Claude Code for non-file inputs")
-					// Pass stream log path to claude-code for debug visibility
+				if agentic, ok := configuredProvider.(models.AgenticProvider); ok {
+					p.debugf("Using agentic mode with %s for non-file inputs", configuredProvider.Name())
+					// Pass stream log path to the provider for debug visibility
 					streamLogPath := p.GetStreamLogPath()
 					p.debugf("Stream log path (non-file): %q", streamLogPath)
 					var debugWatcher *DebugWatcher
 					if streamLogPath != "" {
-						debugPath := streamLogPath + ".claude-debug"
-						p.debugf("Setting claude-code debug file: %s", debugPath)
-						claudeCode.SetDebugFile(debugPath)
-						// Start watching the debug file for context usage
-						if p.streamLog != nil {
-							debugWatcher = NewDebugWatcher(debugPath, p.streamLog)
-							debugWatcher.Start()
+						if df, ok := configuredProvider.(models.DebugFileSetter); ok {
+							debugPath := streamLogPath + ".claude-debug"
+							p.debugf("Setting provider debug file: %s", debugPath)
+							df.SetDebugFile(debugPath)
+							// Start watching the debug file for context usage
+							if p.streamLog != nil {
+								debugWatcher = NewDebugWatcher(debugPath, p.streamLog)
+								debugWatcher.Start()
+							}
 						}
 					}
 					// Set native worktree if provider supports it and step uses a worktree
 					worktreeName := p.getCurrentStepWorktree()
-					if worktreeName != "" && p.providerSupportsWorktrees("claude-code") {
-						p.debugf("Using native worktree support: %s", worktreeName)
-						claudeCode.SetWorktree(worktreeName)
-						defer claudeCode.ClearWorktree()
+					if worktreeName != "" && p.providerSupportsWorktrees(configuredProvider.Name()) {
+						if ws, ok := configuredProvider.(models.WorktreeSetter); ok {
+							p.debugf("Using native worktree support: %s", worktreeName)
+							ws.SetWorktree(worktreeName)
+							defer ws.ClearWorktree()
+						}
 					}
-					result, err := claudeCode.SendPromptAgentic(resolvedModelName, combinedPrompt,
+					result, err := agentic.SendPromptAgentic(resolvedModelName, combinedPrompt,
 						agenticConfig.AllowedPaths, agenticConfig.Tools, p.getEffectiveWorkDir())
 					// Stop the debug watcher
 					if debugWatcher != nil {


### PR DESCRIPTION
## Summary

Phase 2 follow-up to #232 (stacked on it): `kimi-code` now works in comanda's **agentic loops** (`agentic_loop:` / `agentic-loop:` steps with full tool access).

Per the design doc's recommendation, this is two reviewable commits:

1. **`refactor(processor): dispatch agentic mode via AgenticProvider interface`** — replaces the three concrete `*ClaudeCodeProvider` type assertions in `action_handler.go` with dispatch on a new `models.AgenticProvider` interface, plus optional `DebugFileSetter` / `WorktreeSetter` capability interfaces. Behavior for `claude-code` is unchanged; new CLI providers can now join agentic mode without more type switches.
2. **`feat(models): kimi-code agentic mode`** — `SendPromptAgentic` + `buildArgsAgentic` for the kimi provider, tests, and an `examples/kimi-code/agentic-loop.yaml` example.

## Argument mapping (and what probing changed)

The design doc proposed mapping `tools`/unattended intent to `--yolo` or `--auto`. Probing the real CLI (v0.27.0) showed that's not possible — and not needed:

- `kimi -p` **rejects both** `--yolo` and `--auto`: `error: Cannot combine --prompt with --yolo.`
- Default `-p` mode **auto-approves routine actions**: verified file writes (in- and out-of-workspace) and shell execution all run non-interactively with no flags. So the effective posture already matches `claude-code`'s `--dangerously-skip-permissions`, which comanda always passes in agentic mode.

Resulting mapping:

| comanda concept | kimi flag |
|---|---|
| `prompt` | `--prompt <prompt>` (argv; 128 KiB/arg ceiling on Linux — path-reference files instead) |
| `allowedPaths []string` | `--add-dir <dir>` repeated (resolved to absolute); `workDir` → `cmd.Dir` |
| `tools []string` | **ignored** — kimi has no per-tool allowlist flag; agentic runs get full tool access. Documented in code and in `examples/kimi-code/README.md` |
| output | `--output-format stream-json`, last assistant event extracted |
| debug streaming | not wired (the `DebugWatcher` consumes claude's debug-file format); left as follow-up |
| worktrees | kimi has no `--worktree` flag — `providerSupportsWorktrees("kimi-code")` stays false and comanda's workDir fallback applies |

`allowed_paths` are expanded (`~`, env vars) and validated to exist up front, mirroring claude-code's fail-fast behavior.

## Testing

- New unit tests: `buildArgsAgentic` shape (`--add-dir` absolutization, no `--yolo`/`--auto`, model alias passthrough), `SendPromptAgentic` end-to-end through a fake `kimi` binary, and allowed-paths validation.
- `go test ./...` green (also verified the refactor keeps existing processor/model/cmd suites passing).
- Live smoke test (logged-in CLI): `comanda process examples/kimi-code/agentic-loop.yaml` in a sandbox dir — the loop drove real file creation (`hello.sh`) and exited cleanly via `exit_pattern: DONE`.

## Notes

- Stacked on #232 — merge that first; GitHub will retarget this PR to `main` automatically.
- The first smoke run also surfaced that the block-style `output: $VAR` example in `examples/agentic-loop/code-improvement.yaml` appears to have a pre-existing variable-resolution quirk (`$PLAN` treated as a literal filename); this PR's example uses the proven inline `agentic_loop:` shape instead. Not touched here.
