### PR TITLE
feat(mcp): add MCP server exposing workflows as tools and skills as prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ cat notes.md | comanda process summarize.yaml
 - Codebase indexes for persistent project context
 - Git worktree workflows for parallel isolated implementation
 - Server-backed workflows callable over HTTP
+- MCP server mode exposing workflows as tools and skills as prompts
 
 ## More Examples
 
@@ -89,6 +90,17 @@ Most examples and walkthroughs live on [comanda.sh](https://comanda.sh):
 - [Agentic loops](examples/agentic-loop/)
 - [Tool use](examples/tool-use/README.md)
 - [Server API](docs/server-api.md)
+- [MCP server](docs/mcp-server.md)
+
+## MCP Server
+
+Run comanda as an MCP server so agent clients (Claude Code, Kimi Code, Codex) can call workflows as tools and use skills as prompts:
+
+```bash
+comanda mcp
+```
+
+Each discovered workflow file (from `~/.comanda/workflows/`, `.comanda/workflows/`, `--dir`, or `--workflow`) becomes one MCP tool; each skill becomes an MCP prompt. See [docs/mcp-server.md](docs/mcp-server.md) and [examples/mcp/](examples/mcp/README.md) for client setup and a walkthrough.
 
 ## Development
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	comandamcp "github.com/kris-hansen/comanda/utils/mcp"
+	"github.com/kris-hansen/comanda/utils/skills"
+)
+
+var (
+	mcpDirs     []string
+	mcpFiles    []string
+	mcpHTTPAddr string
+	mcpNoSkills bool
+	mcpName     string
+)
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Run an MCP server exposing workflows as tools and skills as prompts",
+	Long: `Start a Model Context Protocol (MCP) server so MCP-native agents
+(Claude Code, Kimi Code, Codex, Cursor) can run comanda workflows as tools
+and use comanda skills as prompts.
+
+Workflows are discovered from ~/.comanda/workflows/ and .comanda/workflows/
+when those directories exist; use --dir and --workflow to add more. Each
+discovered workflow file becomes one MCP tool; each skill becomes one MCP
+prompt. The server speaks MCP over stdio by default; use --http to serve
+the streamable HTTP transport instead (localhost-trusted, no authentication).`,
+	Example: `  # Serve workflows from the default directories over stdio
+  comanda mcp
+
+  # Serve specific workflow files
+  comanda mcp --workflow summarize.yaml --workflow review.yaml
+
+  # Add a directory of workflows and disable skills
+  comanda mcp --dir ./workflows --no-skills
+
+  # Serve over HTTP on localhost port 8080
+  comanda mcp --http :8080`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// In stdio mode stdout carries MCP protocol frames only; all logging
+		// and stray workflow output must go to stderr.
+		log.SetOutput(os.Stderr)
+
+		dirs := append(comandamcp.DefaultWorkflowDirs(), mcpDirs...)
+		defs, err := comandamcp.DiscoverWorkflows(dirs, mcpFiles)
+		if err != nil {
+			return err
+		}
+
+		var allSkills []*skills.Skill
+		if !mcpNoSkills {
+			skillIdx := skills.NewIndex()
+			if err := skillIdx.Load(); err != nil {
+				log.Printf("[WARN] Failed to load skills: %v\n", err)
+			} else {
+				allSkills = skillIdx.All()
+			}
+		}
+
+		if len(defs) == 0 && len(allSkills) == 0 {
+			return fmt.Errorf("no workflows or skills discovered; create %s or point at workflows with --dir/--workflow", "~/.comanda/workflows/")
+		}
+
+		server, err := comandamcp.NewServer(comandamcp.Options{
+			Name:      mcpName,
+			Version:   getVersion(),
+			Verbose:   verbose,
+			EnvConfig: envConfig,
+			Workflows: defs,
+			Skills:    allSkills,
+		})
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] MCP server %q starting: %d workflow tool(s), %d skill prompt(s)\n", mcpName, len(defs), len(allSkills))
+		if verbose {
+			for _, def := range defs {
+				log.Printf("[DEBUG][MCP] Tool %s -> %s (vars: %v)\n", def.Name, def.Path, def.Vars)
+			}
+			for _, skill := range allSkills {
+				log.Printf("[DEBUG][MCP] Prompt %s (%s)\n", skill.DisplayName(), skill.FilePath)
+			}
+		}
+
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		if mcpHTTPAddr != "" {
+			return comandamcp.ServeHTTP(ctx, server, mcpHTTPAddr)
+		}
+		return comandamcp.ServeStdio(ctx, server)
+	},
+}
+
+func init() {
+	mcpCmd.Flags().StringArrayVar(&mcpDirs, "dir", []string{}, "Directory to scan for workflow .yaml/.yml files (repeatable; adds to default directories)")
+	mcpCmd.Flags().StringArrayVar(&mcpFiles, "workflow", []string{}, "Workflow file to expose as a tool (repeatable)")
+	mcpCmd.Flags().StringVar(&mcpHTTPAddr, "http", "", "Serve MCP over streamable HTTP on this address (e.g. :8080) instead of stdio")
+	mcpCmd.Flags().BoolVar(&mcpNoSkills, "no-skills", false, "Do not expose skills as MCP prompts")
+	mcpCmd.Flags().StringVar(&mcpName, "name", "comanda", "MCP server name reported to clients")
+	rootCmd.AddCommand(mcpCmd)
+}

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -1,0 +1,109 @@
+# Comanda MCP Server - Design Document
+
+**Author:** Claude
+**Date:** 2026-07-18
+**Status:** Implemented (v1)
+
+## Overview
+
+Add a top-level `comanda mcp` command that runs a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server. The server exposes comanda **workflows as MCP tools** and **skills as MCP prompts**, so MCP-native agents (Claude Code, Kimi Code, Codex, Cursor) can trigger comanda pipelines as first-class tools instead of shelling out to `comanda process`.
+
+## Motivation
+
+Today, an agent that wants to run a comanda workflow must invoke the CLI (`comanda process workflow.yaml`), parse human-oriented console output, and manage input passing itself. MCP is the standard tool/prompt interface for agent clients. Serving comanda over MCP provides:
+
+- Discoverability: clients list tools/prompts and see names, descriptions, and input schemas
+- Structured invocation: typed arguments instead of `--vars` string munging
+- Clean output capture: the workflow's final output is returned as tool content
+- Skill reuse: comanda skills map naturally onto MCP prompt templates
+
+## Mapping Model
+
+### Workflows → Tools
+
+Each discovered `.yaml`/`.yml` workflow file becomes one MCP tool.
+
+| Aspect | Rule |
+|--------|------|
+| Name | Sanitized file base: `code-review.yaml` → `code_review`; must match `^[a-zA-Z0-9_-]{1,64}$` |
+| Description | First `#` comment line in the file, else `Run comanda workflow '<base>'` |
+| Input schema | One optional string property per `{{ var }}` placeholder, plus a reserved optional `input` string |
+| Result | The workflow's final output (`proc.LastOutput()`) as text content |
+| Errors | Workflow failures → tool-error results (`IsError: true`), never JSON-RPC failures |
+
+Placeholder extraction reuses the CLI variable substitution pattern from `utils/processor/dsl.go` (`\{\{\s*([^}]+?)\s*\}\}`). Processor-reserved names are filtered out: `loop.*`, `current_chunk`, `chunk_index`, `total_chunks`, `file_index`, `total_files`.
+
+Execution reuses the programmatic path shared with the HTTP server handlers: read file → `yaml.Unmarshal` into `processor.DSLConfig` → `processor.NewProcessor(&dslConfig, envConfig, &config.ServerConfig{Enabled: false}, verbose, runtimeDir, cliVars)` → optional `proc.SetLastOutput(input)` → `proc.Process()` → `proc.LastOutput()`. Tool arguments other than the reserved `input` are passed as CLI variables; `input` is fed via `SetLastOutput` (STDIN-style). Duplicate tool names across directories are a startup error listing both paths.
+
+### Skills → Prompts
+
+MCP prompts are argumented prompt templates, which is exactly what comanda skills are: `skills.Prepare()` renders the body and never calls an LLM.
+
+| Aspect | Rule |
+|--------|------|
+| Name | Skill display name (frontmatter `name` or file base) |
+| Description | Frontmatter `description`, else `Comanda skill '<name>'` |
+| Arguments | Frontmatter `arguments` list; `argument-hint` becomes each argument's description |
+| Handler | Returns a single user message containing the rendered body |
+
+Skills are loaded through the existing `skills.Index` (priority: `~/.comanda/skills/` → `.comanda/skills/` → bundled). `--no-skills` disables prompt registration.
+
+## Command Structure
+
+```
+comanda mcp [flags]
+
+Flags:
+  --dir strings       Directory to scan for workflows (repeatable; adds to defaults)
+  --workflow strings  Individual workflow file to expose (repeatable)
+  --http string       Serve streamable HTTP on this address (e.g. :8080) instead of stdio
+  --no-skills         Do not expose skills as MCP prompts
+  --name string       Server name reported to clients (default "comanda")
+```
+
+Discovery defaults: `~/.comanda/workflows/` and `.comanda/workflows/` when they exist. The server exits with a clear error when nothing (neither workflows nor skills) is discovered.
+
+## Transports
+
+- **stdio** (default): `mcp.StdioTransport` from the official SDK. This is how MCP clients launch local servers as child processes.
+- **HTTP** (`--http :port`): the SDK's streamable HTTP handler (`mcp.NewStreamableHTTPHandler`). No authentication — documented as localhost-trusted only.
+
+The server is built on the official SDK `github.com/modelcontextprotocol/go-sdk`, pinned to v1.6.1. Dynamic registration uses `Server.AddTool`/`Server.AddPrompt` with explicit schemas (`map[string]any` input schemas), which bypasses the generic `AddTool[In, Out]` path so argument unmarshaling stays under our control (`json.RawMessage` → `map[string]string`).
+
+## Stdio Hygiene
+
+In stdio mode, stdout carries MCP protocol frames exclusively:
+
+1. `cmd/mcp.go` sets `log.SetOutput(os.Stderr)` at command start, covering all `log.Printf` output (per `.rules/logging.md`, everything goes through `log`).
+2. The spinner and progress display are disabled on the processor.
+3. During each `proc.Process()` call, `utils/mcp/execute.go` reassigns the `os.Stdout` variable to an `os.Pipe` whose read end is copied to `os.Stderr`, restoring it afterward. Go's `fmt.Print*` reads `os.Stdout` dynamically, so stray workflow output is redirected. The SDK captured the real stdout when the transport connected, so protocol frames are unaffected. A mutex serializes the redirection across concurrent tool calls (HTTP mode).
+
+## Implementation Layout
+
+```
+cmd/mcp.go              Command, flags, discovery wiring, log redirection
+utils/mcp/workflows.go  Discovery, name sanitization, var/description extraction
+utils/mcp/execute.go    Runner (workflow execution adapter), stdout guard
+utils/mcp/server.go     Server construction, tool registration, transports
+utils/mcp/prompts.go    Skill → prompt registration
+```
+
+## Testing
+
+- `workflows_test.go`: sanitization, var extraction (incl. reserved-name filtering), description extraction, directory/file discovery, duplicate-name startup error
+- `execute_test.go`: execution adapter with `model: NA` workflows (no provider keys needed), variable substitution, error paths
+- `server_test.go`: smoke tests over the SDK's in-memory transport — initialize, `tools/list`, `tools/call` (success and tool-error paths), `prompts/list`, `prompts/get`
+- Manual: initialize handshake + `tools/call` over real stdio, verifying stdout contains only JSON-RPC frames; HTTP initialize over the streamable transport
+
+## Future Work
+
+- `server.mcp` config block and `comanda server mcp on|off` subcommands, mirroring `openai_compat`
+- MCP resources (e.g. codebase indexes exposed as resources)
+- Workflow `capture_outputs` support for richer tool results
+- Authentication for HTTP mode (bearer token), enabling non-localhost binding
+
+## Non-Goals (v1)
+
+- Config-file persistence (`server.mcp` block)
+- MCP resources, elicitation, and sampling
+- Remote authentication for `--http` mode

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,125 @@
+# Comanda MCP Server
+
+## Overview
+
+`comanda mcp` starts a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that exposes comanda to MCP-native agents such as Claude Code, Kimi Code, Codex, and Cursor:
+
+- **Workflows become MCP tools** — each discovered `.yaml`/`.yml` workflow file becomes one callable tool.
+- **Skills become MCP prompts** — each comanda skill becomes an argumented prompt template.
+
+The server speaks MCP over stdio by default (how MCP clients launch local servers) or over the streamable HTTP transport with `--http`.
+
+## Starting the Server
+
+```bash
+# Serve workflows from the default directories over stdio
+comanda mcp
+
+# Serve specific workflow files
+comanda mcp --workflow summarize.yaml --workflow review.yaml
+
+# Add a directory of workflows
+comanda mcp --dir ./workflows
+
+# Disable skill prompts
+comanda mcp --no-skills
+
+# Serve over HTTP on localhost port 8080
+comanda mcp --http :8080
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--dir` | Directory to scan for workflow `.yaml`/`.yml` files (repeatable) | — |
+| `--workflow` | Individual workflow file to expose (repeatable) | — |
+| `--http` | Serve the streamable HTTP transport on this address instead of stdio | stdio |
+| `--no-skills` | Do not expose skills as MCP prompts | skills on |
+| `--name` | Server name reported to MCP clients | `comanda` |
+
+## Workflow Discovery
+
+Workflow files are discovered from:
+
+1. `~/.comanda/workflows/` (user level), when it exists
+2. `.comanda/workflows/` (project level), when it exists
+3. Any directories added with `--dir`
+4. Any files added with `--workflow`
+
+If no workflows and no skills are discovered, the server exits with a clear error.
+
+Each discovered file becomes one tool:
+
+- **Name**: the sanitized file base — `code-review.yaml` becomes `code_review`. Names must match `^[a-zA-Z0-9_-]{1,64}$`. Two files that sanitize to the same name produce a startup error listing both paths.
+- **Description**: the first `#` comment line in the file, or `Run comanda workflow '<base>'` as a fallback.
+
+## Tools: Calling Workflows
+
+A tool's input schema is built from the workflow's `{{ var }}` placeholders:
+
+- Each placeholder becomes an optional string argument. Processor-reserved names (`loop.*`, `current_chunk`, `chunk_index`, `total_chunks`, `file_index`, `total_files`) are never exposed.
+- A reserved optional `input` string is always available; it is fed to the workflow as STDIN-style input (equivalent to `echo "..." | comanda process workflow.yaml`).
+
+Example: a workflow containing `Summarize {{ filename }} in {{ style }} style` produces a tool with the optional string arguments `filename`, `style`, and `input`.
+
+The tool result is the workflow's final output (`LastOutput`), returned as text content. Workflow failures are reported as tool errors, so the MCP session stays alive.
+
+## Prompts: Using Skills
+
+Each skill (from `~/.comanda/skills/`, `.comanda/skills/`, or the bundled set) becomes an MCP prompt:
+
+- **Name** and **description** come from the skill's frontmatter.
+- **Arguments** come from the skill's `arguments` list; the skill's `argument-hint` is used as the argument description.
+- Getting the prompt renders the skill body with the supplied arguments (no LLM is called) and returns it as a single user message.
+
+## Client Setup
+
+### Claude Code
+
+```bash
+claude mcp add comanda -- comanda mcp
+```
+
+Or with specific workflows:
+
+```bash
+claude mcp add comanda -- comanda mcp --dir ~/workflows
+```
+
+### Kimi Code
+
+Add an entry to `~/.kimi-code/mcp.json` (user level) or `.kimi-code/mcp.json` (project level):
+
+```json
+{
+  "mcpServers": {
+    "comanda": {
+      "command": "comanda",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Codex
+
+```bash
+codex mcp add comanda -- comanda mcp
+```
+
+Or add to `~/.codex/config.toml` directly:
+
+```toml
+[mcp_servers.comanda]
+command = "comanda"
+args = ["mcp"]
+```
+
+## HTTP Mode
+
+`comanda mcp --http :8080` serves the MCP streamable HTTP transport. There is no authentication — bind to localhost and treat it as trusted-local only. Point HTTP-capable clients at `http://localhost:8080/`.
+
+## Security Notes
+
+- In stdio mode, stdout carries MCP protocol frames only; all logging and workflow console output is redirected to stderr.
+- Workflows run with the permissions of the user launching the server, including any `tool:` shell steps the workflow defines. Only expose workflows from trusted sources, and prefer explicit `tool.allowlist` entries in workflows.
+- Project-level workflow directories (`.comanda/workflows/`) are picked up from the server's working directory. Review them before connecting a client.

--- a/examples/README.md
+++ b/examples/README.md
@@ -266,6 +266,13 @@ Each example includes comments explaining its functionality and any specific req
    - `tool-use/beads-workflow-example.yaml` (integrate with external CLIs)
    - `tool-use/beads-walkthrough.yaml` (spec → issues workflow)
 
+8. **MCP Examples**: Serve workflows as MCP tools for agent clients
+   - `mcp/echo.yaml` (no provider needed, good first smoke test)
+   - `mcp/summarize.yaml` (variable substitution via tool arguments)
+   ```bash
+   comanda mcp --workflow examples/mcp/echo.yaml
+   ```
+
 ### Test Environment
 
 A Docker environment is provided for testing database operations:

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,0 +1,84 @@
+# MCP Server Example
+
+This example demonstrates `comanda mcp`, which runs a Model Context Protocol (MCP) server that exposes comanda workflows as MCP tools and comanda skills as MCP prompts. MCP-native agents (Claude Code, Kimi Code, Codex, Cursor) can then call your workflows as first-class tools.
+
+## Files
+
+- `echo.yaml` — echoes its input back using `model: NA`, so it works without any configured LLM provider. Good for a first smoke test.
+- `summarize.yaml` — summarizes STDIN input using a `{{ style }}` variable. Requires a configured model (edit the `model:` field to one you have set up).
+
+## How it Works
+
+1. Each discovered `.yaml`/`.yml` workflow file becomes one MCP tool, named after the sanitized file base (`echo.yaml` → `echo`).
+2. The tool's input schema is derived from the workflow's `{{ var }}` placeholders, plus a reserved `input` argument that is fed to the workflow as STDIN-style input.
+3. Calling the tool runs the workflow and returns its final output as text content.
+4. Skills from `~/.comanda/skills/`, `.comanda/skills/`, and the bundled set become MCP prompts (disable with `--no-skills`).
+
+## Running the Server
+
+Serve these two workflows over stdio:
+
+```bash
+comanda mcp --workflow examples/mcp/echo.yaml --workflow examples/mcp/summarize.yaml
+```
+
+Or copy them into one of the default discovery directories (`~/.comanda/workflows/` or `.comanda/workflows/`) and simply run:
+
+```bash
+comanda mcp
+```
+
+## Connecting a Client
+
+Claude Code:
+
+```bash
+claude mcp add comanda -- comanda mcp --workflow examples/mcp/echo.yaml
+```
+
+Kimi Code (`~/.kimi-code/mcp.json` or `.kimi-code/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "comanda": {
+      "command": "comanda",
+      "args": ["mcp", "--workflow", "examples/mcp/echo.yaml"]
+    }
+  }
+}
+```
+
+Codex:
+
+```bash
+codex mcp add comanda -- comanda mcp --workflow examples/mcp/echo.yaml
+```
+
+## Trying It Out
+
+Once connected, ask the agent to use the `echo` tool — it returns whatever `input` you pass, no API keys required:
+
+> Call the comanda `echo` tool with input "hello from MCP"
+
+The agent invokes `tools/call` with `{"input": "hello from MCP"}` and gets `hello from MCP` back as the tool result.
+
+For `summarize`, the agent can pass both arguments, e.g. `{"input": "<long text>", "style": "bullet-point"}`; `style` is substituted into the action's `{{ style }}` placeholder before the workflow runs.
+
+## Verifying Stdio Manually
+
+You can drive the raw protocol yourself to see the framing:
+
+```bash
+{
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"demo","version":"0.1"}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"input":"hello"}}}'
+  sleep 1
+} | comanda mcp --workflow examples/mcp/echo.yaml
+```
+
+Stdout carries only JSON-RPC frames; all logging and workflow console output goes to stderr.
+
+See [docs/mcp-server.md](../../docs/mcp-server.md) for the full reference, including HTTP mode and security notes.

--- a/examples/mcp/echo.yaml
+++ b/examples/mcp/echo.yaml
@@ -1,0 +1,8 @@
+# Echo input back, optionally uppercased. Works without any LLM provider
+# (model: NA), so it is a good first MCP smoke test.
+echo:
+  input: STDIN
+  model: NA
+  action:
+    - Echo the input
+  output: STDOUT

--- a/examples/mcp/summarize.yaml
+++ b/examples/mcp/summarize.yaml
@@ -1,0 +1,9 @@
+# Summarize input text in a given style.
+# Exposed over MCP as the "summarize" tool with arguments: style, input.
+# Requires a configured model; swap the model below for one you have set up.
+summarize:
+  input: STDIN
+  model: gpt-4o
+  action:
+    - "Summarize the input in {{ style }} style. Be concise."
+  output: STDOUT

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/generative-ai-go v0.20.1
 	github.com/kbinani/screenshot v0.0.0-20250624051815-089614a94018
 	github.com/lib/pq v1.10.9
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/shirou/gopsutil/v3 v3.24.5
@@ -71,6 +72,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
@@ -92,12 +94,15 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/temoto/robotstxt v1.1.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.64.0 // indirect
@@ -107,7 +112,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/oauth2 v0.34.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/gocolly/colly/v2 v2.3.0 h1:HSFh0ckbgVd2CSGRE+Y/iA4goUhGROJwyQDCMXGFBW
 github.com/gocolly/colly/v2 v2.3.0/go.mod h1:Qp54s/kQbwCQvFVx8KzKCSTXVJ1wWT4QeAKEu33x1q8=
 github.com/godbus/dbus/v5 v5.2.0 h1:3WexO+U+yg9T70v9FdHr9kCxYlazaAXUhx2VMkbfax8=
 github.com/godbus/dbus/v5 v5.2.0/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
@@ -124,6 +126,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -158,6 +162,8 @@ github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2J
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
@@ -183,6 +189,10 @@ github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
 github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -207,6 +217,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
@@ -257,8 +269,8 @@ golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
-golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -320,6 +332,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=

--- a/utils/mcp/execute.go
+++ b/utils/mcp/execute.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/processor"
+)
+
+// Runner executes workflows on behalf of MCP tool calls.
+type Runner struct {
+	envConfig *config.EnvConfig
+	verbose   bool
+}
+
+// NewRunner creates a Runner that executes workflows with the given
+// environment configuration.
+func NewRunner(envConfig *config.EnvConfig, verbose bool) *Runner {
+	return &Runner{envConfig: envConfig, verbose: verbose}
+}
+
+// Run executes the workflow defined by def with the given tool arguments and
+// returns the workflow's final output. All arguments except the reserved
+// "input" argument are passed as CLI variables ({{ var }} substitution);
+// "input" is fed to the workflow as STDIN-style input via SetLastOutput.
+func (r *Runner) Run(ctx context.Context, def WorkflowDef, args map[string]string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	yamlFile, err := os.ReadFile(def.Path)
+	if err != nil {
+		return "", err
+	}
+
+	var dslConfig processor.DSLConfig
+	if err := yaml.Unmarshal(yamlFile, &dslConfig); err != nil {
+		return "", err
+	}
+
+	cliVars := make(map[string]string, len(args))
+	for key, value := range args {
+		if key == "input" {
+			continue
+		}
+		cliVars[key] = value
+	}
+
+	// No --runtime-dir flag in MCP mode: replicate the resolveProcessRuntimeDir
+	// default from cmd/process.go ("" means relative paths resolve from cwd).
+	runtimeDir := ""
+
+	proc := processor.NewProcessor(&dslConfig, r.envConfig, &config.ServerConfig{Enabled: false}, r.verbose, runtimeDir, cliVars)
+	proc.SetWorkflowFile(def.Path)
+	// Spinner and progress display write directly to the console; disable them
+	// so they cannot interleave with MCP protocol frames.
+	proc.DisableSpinner()
+	proc.DisableProgressDisplay()
+
+	if input := args["input"]; input != "" {
+		proc.SetLastOutput(input)
+	}
+
+	if r.verbose {
+		log.Printf("[DEBUG][MCP] Running workflow %s (%s) with %d var(s)\n", def.Name, def.Path, len(cliVars))
+	}
+
+	// Redirect os.Stdout to stderr while the processor runs so that any
+	// fmt.Print* output from workflow steps cannot corrupt the stdio transport.
+	if err := runWithStdoutGuard(proc.Process); err != nil {
+		return "", err
+	}
+
+	return proc.LastOutput(), nil
+}
+
+// stdoutGuard serializes stdout redirection across concurrent tool calls.
+var stdoutGuard sync.Mutex
+
+// runWithStdoutGuard executes fn while the os.Stdout variable points at a pipe
+// whose contents are copied to os.Stderr, then restores it. This keeps the
+// stdio MCP transport channel clean: the SDK captured the original os.Stdout
+// when the transport connected, so protocol frames are unaffected, while Go
+// code that reads os.Stdout dynamically (fmt.Print* in the processor) is
+// redirected. If the pipe cannot be created, fn runs without redirection.
+func runWithStdoutGuard(fn func() error) error {
+	stdoutGuard.Lock()
+	defer stdoutGuard.Unlock()
+
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		log.Printf("[WARN][MCP] Failed to create stdout guard pipe, running without redirection: %v\n", err)
+		return fn()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(os.Stderr, reader)
+		close(done)
+	}()
+
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = original
+		_ = writer.Close()
+		<-done
+		_ = reader.Close()
+	}()
+
+	return fn()
+}

--- a/utils/mcp/execute_test.go
+++ b/utils/mcp/execute_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+)
+
+// naEchoWorkflow echoes its STDIN input without needing any LLM provider.
+const naEchoWorkflow = `# Echo input back
+echo:
+  input: STDIN
+  model: NA
+  action:
+    - Echo the input
+  output: STDOUT
+`
+
+// naFileWorkflow reads the file named by the {{ filepath }} variable.
+const naFileWorkflow = `# Read a file
+readfile:
+  input: "{{ filepath }}"
+  model: NA
+  action:
+    - Return the file contents
+  output: STDOUT
+`
+
+func TestRunWorkflowEchoesInput(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflow(t, dir, "echo.yaml", naEchoWorkflow)
+
+	defs, err := DiscoverWorkflows(nil, []string{path})
+	if err != nil {
+		t.Fatalf("DiscoverWorkflows() error: %v", err)
+	}
+
+	runner := NewRunner(&config.EnvConfig{}, false)
+	output, err := runner.Run(context.Background(), defs[0], map[string]string{"input": "hello mcp"})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if !strings.Contains(output, "hello mcp") {
+		t.Errorf("Run() output = %q, want it to contain %q", output, "hello mcp")
+	}
+}
+
+func TestRunWorkflowSubstitutesVars(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflow(t, dir, "readfile.yaml", naFileWorkflow)
+
+	inputFile := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(inputFile, []byte("secret file contents"), 0644); err != nil {
+		t.Fatalf("writing input file: %v", err)
+	}
+
+	defs, err := DiscoverWorkflows(nil, []string{path})
+	if err != nil {
+		t.Fatalf("DiscoverWorkflows() error: %v", err)
+	}
+	if len(defs[0].Vars) != 1 || defs[0].Vars[0] != "filepath" {
+		t.Fatalf("def vars = %v, want [filepath]", defs[0].Vars)
+	}
+
+	runner := NewRunner(&config.EnvConfig{}, false)
+	output, err := runner.Run(context.Background(), defs[0], map[string]string{"filepath": inputFile})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if !strings.Contains(output, "secret file contents") {
+		t.Errorf("Run() output = %q, want it to contain %q", output, "secret file contents")
+	}
+}
+
+func TestRunWorkflowErrors(t *testing.T) {
+	runner := NewRunner(&config.EnvConfig{}, false)
+
+	// Missing workflow file.
+	missing := WorkflowDef{Name: "missing", Path: filepath.Join(t.TempDir(), "missing.yaml")}
+	if _, err := runner.Run(context.Background(), missing, nil); err == nil {
+		t.Error("Run() with missing workflow file: expected error, got nil")
+	}
+
+	// Workflow whose input file does not exist.
+	dir := t.TempDir()
+	path := writeWorkflow(t, dir, "readfile.yaml", naFileWorkflow)
+	defs, err := DiscoverWorkflows(nil, []string{path})
+	if err != nil {
+		t.Fatalf("DiscoverWorkflows() error: %v", err)
+	}
+	_, err = runner.Run(context.Background(), defs[0], map[string]string{"filepath": filepath.Join(dir, "nope.txt")})
+	if err == nil {
+		t.Error("Run() with missing input file: expected error, got nil")
+	}
+
+	// Cancelled context.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := runner.Run(cancelled, defs[0], map[string]string{"filepath": "x"}); err == nil {
+		t.Error("Run() with cancelled context: expected error, got nil")
+	}
+}

--- a/utils/mcp/execute_test.go
+++ b/utils/mcp/execute_test.go
@@ -97,10 +97,10 @@ func TestRunWorkflowErrors(t *testing.T) {
 		t.Error("Run() with missing input file: expected error, got nil")
 	}
 
-	// Cancelled context.
-	cancelled, cancel := context.WithCancel(context.Background())
+	// Canceled context.
+	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
-	if _, err := runner.Run(cancelled, defs[0], map[string]string{"filepath": "x"}); err == nil {
-		t.Error("Run() with cancelled context: expected error, got nil")
+	if _, err := runner.Run(canceled, defs[0], map[string]string{"filepath": "x"}); err == nil {
+		t.Error("Run() with canceled context: expected error, got nil")
 	}
 }

--- a/utils/mcp/prompts.go
+++ b/utils/mcp/prompts.go
@@ -1,0 +1,76 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kris-hansen/comanda/utils/skills"
+)
+
+// registerPrompt exposes a comanda skill as an MCP prompt. The prompt returns
+// the skill's rendered body as a single user message; skills.Prepare performs
+// the variable substitution without calling any LLM.
+func registerPrompt(s *mcpsdk.Server, skill *skills.Skill, verbose bool) {
+	name := skill.DisplayName()
+	if name == "" {
+		log.Printf("[WARN][MCP] Skipping skill with no name (%s)\n", skill.FilePath)
+		return
+	}
+
+	description := skill.Description
+	if description == "" {
+		description = fmt.Sprintf("Comanda skill '%s'", name)
+	}
+
+	prompt := &mcpsdk.Prompt{
+		Name:        name,
+		Description: description,
+		Arguments:   promptArguments(skill),
+	}
+
+	s.AddPrompt(prompt, func(ctx context.Context, req *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+		args := make(map[string]string)
+		if req.Params != nil {
+			args = req.Params.Arguments
+		}
+		if verbose {
+			log.Printf("[DEBUG][MCP] Rendering skill prompt %s with %d argument(s)\n", name, len(args))
+		}
+		result, err := skills.Prepare(skill, skills.ExecuteOptions{Args: args})
+		if err != nil {
+			return nil, fmt.Errorf("failed to render skill %q: %w", name, err)
+		}
+		return &mcpsdk.GetPromptResult{
+			Description: description,
+			Messages: []*mcpsdk.PromptMessage{
+				{
+					Role:    "user",
+					Content: &mcpsdk.TextContent{Text: result.RenderedBody},
+				},
+			},
+		}, nil
+	})
+}
+
+// promptArguments maps a skill's declared arguments to MCP prompt arguments.
+// The skill's argument-hint, when present, is used as the argument description.
+func promptArguments(skill *skills.Skill) []*mcpsdk.PromptArgument {
+	if len(skill.Arguments) == 0 {
+		return nil
+	}
+	args := make([]*mcpsdk.PromptArgument, 0, len(skill.Arguments))
+	for _, argName := range skill.Arguments {
+		description := skill.ArgumentHint
+		if description == "" {
+			description = fmt.Sprintf("Value for the %s argument", argName)
+		}
+		args = append(args, &mcpsdk.PromptArgument{
+			Name:        argName,
+			Description: description,
+		})
+	}
+	return args
+}

--- a/utils/mcp/server.go
+++ b/utils/mcp/server.go
@@ -17,9 +17,9 @@ import (
 
 // Options configures the MCP server.
 type Options struct {
-	Name      string          // Server name reported to MCP clients
-	Version   string          // Server version reported to MCP clients
-	Verbose   bool            // Enable debug logging (to stderr)
+	Name      string // Server name reported to MCP clients
+	Version   string // Server version reported to MCP clients
+	Verbose   bool   // Enable debug logging (to stderr)
 	EnvConfig *config.EnvConfig
 	Workflows []WorkflowDef   // Workflows to expose as tools
 	Skills    []*skills.Skill // Skills to expose as prompts (nil/empty disables)
@@ -110,7 +110,7 @@ func toolError(err error) *mcpsdk.CallToolResult {
 }
 
 // ServeStdio serves the MCP server over stdin/stdout until the client
-// disconnects or ctx is cancelled. Nothing except MCP protocol frames may be
+// disconnects or ctx is canceled. Nothing except MCP protocol frames may be
 // written to stdout while this runs; cmd sets log output to stderr.
 func ServeStdio(ctx context.Context, s *mcpsdk.Server) error {
 	log.Printf("[INFO][MCP] Serving MCP over stdio\n")
@@ -122,8 +122,9 @@ func ServeStdio(ctx context.Context, s *mcpsdk.Server) error {
 func ServeHTTP(ctx context.Context, s *mcpsdk.Server, addr string) error {
 	handler := mcpsdk.NewStreamableHTTPHandler(func(*http.Request) *mcpsdk.Server { return s }, nil)
 	httpServer := &http.Server{
-		Addr:    addr,
-		Handler: handler,
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {

--- a/utils/mcp/server.go
+++ b/utils/mcp/server.go
@@ -1,0 +1,142 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/skills"
+)
+
+// Options configures the MCP server.
+type Options struct {
+	Name      string          // Server name reported to MCP clients
+	Version   string          // Server version reported to MCP clients
+	Verbose   bool            // Enable debug logging (to stderr)
+	EnvConfig *config.EnvConfig
+	Workflows []WorkflowDef   // Workflows to expose as tools
+	Skills    []*skills.Skill // Skills to expose as prompts (nil/empty disables)
+}
+
+// NewServer builds an MCP server exposing each workflow as a tool and each
+// skill as a prompt.
+func NewServer(opts Options) (*mcpsdk.Server, error) {
+	name := opts.Name
+	if name == "" {
+		name = "comanda"
+	}
+	s := mcpsdk.NewServer(&mcpsdk.Implementation{Name: name, Version: opts.Version}, nil)
+
+	runner := NewRunner(opts.EnvConfig, opts.Verbose)
+	for _, def := range opts.Workflows {
+		registerTool(s, runner, def)
+	}
+	for _, skill := range opts.Skills {
+		registerPrompt(s, skill, opts.Verbose)
+	}
+	return s, nil
+}
+
+// registerTool exposes a single workflow as an MCP tool.
+func registerTool(s *mcpsdk.Server, runner *Runner, def WorkflowDef) {
+	tool := &mcpsdk.Tool{
+		Name:        def.Name,
+		Description: def.Description,
+		InputSchema: toolInputSchema(def),
+	}
+	s.AddTool(tool, func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		return runToolCall(ctx, runner, def, req), nil
+	})
+}
+
+// toolInputSchema builds a JSON Schema object with one optional string
+// property per workflow variable plus the reserved "input" property.
+func toolInputSchema(def WorkflowDef) map[string]any {
+	properties := make(map[string]any, len(def.Vars)+1)
+	for _, v := range def.Vars {
+		if v == "input" {
+			// "input" is always the reserved STDIN-style argument; a workflow
+			// variable named "input" cannot be set separately.
+			continue
+		}
+		properties[v] = map[string]any{
+			"type":        "string",
+			"description": fmt.Sprintf("Value for the {{ %s }} workflow variable", v),
+		}
+	}
+	properties["input"] = map[string]any{
+		"type":        "string",
+		"description": "Input text passed to the workflow as STDIN-style input",
+	}
+	return map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+}
+
+// runToolCall executes a workflow for one tools/call request. Workflow and
+// argument errors are reported as tool-error results (IsError) rather than
+// JSON-RPC protocol errors.
+func runToolCall(ctx context.Context, runner *Runner, def WorkflowDef, req *mcpsdk.CallToolRequest) *mcpsdk.CallToolResult {
+	args := make(map[string]string)
+	if req.Params != nil && len(req.Params.Arguments) > 0 {
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return toolError(fmt.Errorf("invalid arguments for tool %q: %w", def.Name, err))
+		}
+	}
+
+	output, err := runner.Run(ctx, def, args)
+	if err != nil {
+		return toolError(fmt.Errorf("workflow %q failed: %w", def.Name, err))
+	}
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: output}},
+	}
+}
+
+// toolError wraps err as a tool-error result.
+func toolError(err error) *mcpsdk.CallToolResult {
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Error()}},
+		IsError: true,
+	}
+}
+
+// ServeStdio serves the MCP server over stdin/stdout until the client
+// disconnects or ctx is cancelled. Nothing except MCP protocol frames may be
+// written to stdout while this runs; cmd sets log output to stderr.
+func ServeStdio(ctx context.Context, s *mcpsdk.Server) error {
+	log.Printf("[INFO][MCP] Serving MCP over stdio\n")
+	return s.Run(ctx, &mcpsdk.StdioTransport{})
+}
+
+// ServeHTTP serves the MCP server over the streamable HTTP transport. It is
+// intended for localhost use only; no authentication is applied.
+func ServeHTTP(ctx context.Context, s *mcpsdk.Server, addr string) error {
+	handler := mcpsdk.NewStreamableHTTPHandler(func(*http.Request) *mcpsdk.Server { return s }, nil)
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = httpServer.Shutdown(shutdownCtx)
+	}()
+
+	log.Printf("[INFO][MCP] Serving MCP over HTTP on %s (localhost-trusted, no authentication)\n", addr)
+	err := httpServer.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}

--- a/utils/mcp/server_test.go
+++ b/utils/mcp/server_test.go
@@ -1,0 +1,187 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/skills"
+)
+
+const testSkill = `---
+name: test-skill
+description: A skill for testing
+arguments:
+  - topic
+argument-hint: The topic to write about
+---
+
+Write a haiku about ${topic}.
+`
+
+// connectTestServer builds an MCP server over the in-memory transport and
+// returns a connected client session.
+func connectTestServer(t *testing.T, opts Options) *mcpsdk.ClientSession {
+	t.Helper()
+
+	server, err := NewServer(opts)
+	if err != nil {
+		t.Fatalf("NewServer() error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	serverTransport, clientTransport := mcpsdk.NewInMemoryTransports()
+	go func() {
+		_ = server.Run(ctx, serverTransport)
+	}()
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect() error: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+func TestServerToolsListAndCall(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflow(t, dir, "echo.yaml", naEchoWorkflow)
+	defs, err := DiscoverWorkflows(nil, []string{path})
+	if err != nil {
+		t.Fatalf("DiscoverWorkflows() error: %v", err)
+	}
+
+	cs := connectTestServer(t, Options{
+		Name:      "comanda-test",
+		Version:   "v0.0.1",
+		EnvConfig: &config.EnvConfig{},
+		Workflows: defs,
+	})
+	ctx := context.Background()
+
+	tools, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools() error: %v", err)
+	}
+	if len(tools.Tools) != 1 {
+		t.Fatalf("ListTools() returned %d tools, want 1", len(tools.Tools))
+	}
+	tool := tools.Tools[0]
+	if tool.Name != "echo" {
+		t.Errorf("tool name = %q, want %q", tool.Name, "echo")
+	}
+	if tool.Description != "Echo input back" {
+		t.Errorf("tool description = %q, want %q", tool.Description, "Echo input back")
+	}
+
+	result, err := cs.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "echo",
+		Arguments: map[string]any{"input": "hello over mcp"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool() error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("CallTool() returned tool error: %+v", result.Content)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("CallTool() returned no content")
+	}
+	text, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("CallTool() content type = %T, want *TextContent", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "hello over mcp") {
+		t.Errorf("CallTool() output = %q, want it to contain %q", text.Text, "hello over mcp")
+	}
+}
+
+func TestServerToolCallError(t *testing.T) {
+	// A def pointing at a file that no longer exists exercises the tool-error
+	// path (IsError result rather than a JSON-RPC failure).
+	broken := WorkflowDef{
+		Name:        "broken",
+		Path:        filepath.Join(t.TempDir(), "gone.yaml"),
+		Description: "Broken workflow",
+	}
+
+	cs := connectTestServer(t, Options{
+		Name:      "comanda-test",
+		Version:   "v0.0.1",
+		EnvConfig: &config.EnvConfig{},
+		Workflows: []WorkflowDef{broken},
+	})
+
+	result, err := cs.CallTool(context.Background(), &mcpsdk.CallToolParams{Name: "broken"})
+	if err != nil {
+		t.Fatalf("CallTool() protocol error (expected tool error instead): %v", err)
+	}
+	if !result.IsError {
+		t.Errorf("CallTool() IsError = false, want true")
+	}
+}
+
+func TestServerPrompts(t *testing.T) {
+	skill, err := skills.ParseSkill(testSkill)
+	if err != nil {
+		t.Fatalf("ParseSkill() error: %v", err)
+	}
+
+	cs := connectTestServer(t, Options{
+		Name:      "comanda-test",
+		Version:   "v0.0.1",
+		EnvConfig: &config.EnvConfig{},
+		Skills:    []*skills.Skill{skill},
+	})
+	ctx := context.Background()
+
+	prompts, err := cs.ListPrompts(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListPrompts() error: %v", err)
+	}
+	if len(prompts.Prompts) != 1 {
+		t.Fatalf("ListPrompts() returned %d prompts, want 1", len(prompts.Prompts))
+	}
+	prompt := prompts.Prompts[0]
+	if prompt.Name != "test-skill" {
+		t.Errorf("prompt name = %q, want %q", prompt.Name, "test-skill")
+	}
+	if prompt.Description != "A skill for testing" {
+		t.Errorf("prompt description = %q, want %q", prompt.Description, "A skill for testing")
+	}
+	if len(prompt.Arguments) != 1 || prompt.Arguments[0].Name != "topic" {
+		t.Fatalf("prompt arguments = %+v, want one 'topic' argument", prompt.Arguments)
+	}
+	if prompt.Arguments[0].Description != "The topic to write about" {
+		t.Errorf("argument description = %q, want argument hint", prompt.Arguments[0].Description)
+	}
+
+	result, err := cs.GetPrompt(ctx, &mcpsdk.GetPromptParams{
+		Name:      "test-skill",
+		Arguments: map[string]string{"topic": "moss"},
+	})
+	if err != nil {
+		t.Fatalf("GetPrompt() error: %v", err)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("GetPrompt() returned %d messages, want 1", len(result.Messages))
+	}
+	msg := result.Messages[0]
+	if msg.Role != "user" {
+		t.Errorf("message role = %q, want %q", msg.Role, "user")
+	}
+	text, ok := msg.Content.(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("message content type = %T, want *TextContent", msg.Content)
+	}
+	if !strings.Contains(text.Text, "Write a haiku about moss.") {
+		t.Errorf("prompt body = %q, want it to contain %q", text.Text, "Write a haiku about moss.")
+	}
+}

--- a/utils/mcp/workflows.go
+++ b/utils/mcp/workflows.go
@@ -1,0 +1,189 @@
+// Package mcp implements comanda's Model Context Protocol (MCP) server mode,
+// exposing workflows as MCP tools and skills as MCP prompts.
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// WorkflowDef describes a discovered workflow file exposed as an MCP tool.
+type WorkflowDef struct {
+	Name        string   // MCP tool name (sanitized workflow file base)
+	Path        string   // Path to the workflow YAML file
+	Description string   // Tool description (first comment line or fallback)
+	Vars        []string // {{ var }} placeholders discovered in the file
+}
+
+// toolNamePattern is the MCP-safe tool name pattern: ^[a-zA-Z0-9_-]{1,64}$.
+var toolNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+// invalidToolNameChars matches characters that are replaced with underscores
+// when deriving tool names (e.g. "code-review" -> "code_review").
+var invalidToolNameChars = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
+// placeholderPattern matches {{ var }} placeholders, mirroring the CLI variable
+// substitution pattern in utils/processor/dsl.go (SubstituteCLIVariables).
+var placeholderPattern = regexp.MustCompile(`\{\{\s*([^}]+?)\s*\}\}`)
+
+// reservedVars are placeholder names populated by the processor itself; they
+// are never exposed as tool arguments.
+var reservedVars = map[string]bool{
+	"current_chunk": true,
+	"chunk_index":   true,
+	"total_chunks":  true,
+	"file_index":    true,
+	"total_files":   true,
+}
+
+// DefaultWorkflowDirs returns the default workflow directories that exist:
+// ~/.comanda/workflows/ (user level) and .comanda/workflows/ (project level).
+func DefaultWorkflowDirs() []string {
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil {
+		userDir := filepath.Join(home, ".comanda", "workflows")
+		if info, err := os.Stat(userDir); err == nil && info.IsDir() {
+			dirs = append(dirs, userDir)
+		}
+	}
+	projectDir := filepath.Join(".comanda", "workflows")
+	if info, err := os.Stat(projectDir); err == nil && info.IsDir() {
+		dirs = append(dirs, projectDir)
+	}
+	return dirs
+}
+
+// DiscoverWorkflows scans dirs for *.yaml/*.yml workflow files and combines
+// them with the explicit files, building one WorkflowDef per file. It returns
+// an error if two files map to the same tool name, if a file cannot be read,
+// or if a file base cannot be sanitized into a valid tool name.
+func DiscoverWorkflows(dirs, files []string) ([]WorkflowDef, error) {
+	var paths []string
+
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("reading workflow directory %s: %w", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !isWorkflowFile(entry.Name()) {
+				continue
+			}
+			paths = append(paths, filepath.Join(dir, entry.Name()))
+		}
+	}
+	// Sort directory scan results for deterministic ordering.
+	sort.Strings(paths)
+
+	for _, file := range files {
+		if !isWorkflowFile(filepath.Base(file)) {
+			return nil, fmt.Errorf("workflow file %s must have a .yaml or .yml extension", file)
+		}
+		if _, err := os.Stat(file); err != nil {
+			return nil, fmt.Errorf("workflow file %s: %w", file, err)
+		}
+		paths = append(paths, file)
+	}
+
+	var defs []WorkflowDef
+	seen := make(map[string]string) // tool name -> first path
+	for _, path := range paths {
+		def, err := workflowDefFromFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if firstPath, dup := seen[def.Name]; dup {
+			return nil, fmt.Errorf("duplicate MCP tool name %q: %s and %s; rename one of the files", def.Name, firstPath, path)
+		}
+		seen[def.Name] = path
+		defs = append(defs, def)
+	}
+	return defs, nil
+}
+
+// isWorkflowFile reports whether name has a .yaml or .yml extension.
+func isWorkflowFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// workflowDefFromFile builds a WorkflowDef from a workflow YAML file.
+func workflowDefFromFile(path string) (WorkflowDef, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return WorkflowDef{}, fmt.Errorf("reading workflow file %s: %w", path, err)
+	}
+
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	name := sanitizeToolName(base)
+	if name == "" {
+		return WorkflowDef{}, fmt.Errorf("workflow file %s: cannot derive an MCP-safe tool name from %q", path, base)
+	}
+
+	return WorkflowDef{
+		Name:        name,
+		Path:        path,
+		Description: extractDescription(string(content), base),
+		Vars:        extractVars(string(content)),
+	}, nil
+}
+
+// sanitizeToolName converts a workflow file base into an MCP-safe tool name
+// (e.g. "code-review" -> "code_review"), replacing unsupported characters with
+// underscores and truncating to 64 characters.
+func sanitizeToolName(base string) string {
+	name := invalidToolNameChars.ReplaceAllString(base, "_")
+	name = strings.Trim(name, "_")
+	if len(name) > 64 {
+		name = strings.Trim(name[:64], "_")
+	}
+	if !toolNamePattern.MatchString(name) {
+		return ""
+	}
+	return name
+}
+
+// extractVars returns the sorted, deduplicated {{ var }} placeholder names in
+// content, excluding processor-reserved names (loop.*, current_chunk, ...).
+func extractVars(content string) []string {
+	seen := make(map[string]bool)
+	var vars []string
+	for _, match := range placeholderPattern.FindAllStringSubmatch(content, -1) {
+		name := strings.TrimSpace(match[1])
+		if name == "" || seen[name] || isReservedVar(name) {
+			continue
+		}
+		seen[name] = true
+		vars = append(vars, name)
+	}
+	sort.Strings(vars)
+	return vars
+}
+
+// isReservedVar reports whether a placeholder name is populated by the
+// processor and therefore not exposed as a tool argument.
+func isReservedVar(name string) bool {
+	if reservedVars[name] {
+		return true
+	}
+	return strings.HasPrefix(name, "loop.")
+}
+
+// extractDescription returns the first '#' comment line in the workflow file,
+// or a fallback description naming the workflow.
+func extractDescription(content, base string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			desc := strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+			if desc != "" {
+				return desc
+			}
+		}
+	}
+	return fmt.Sprintf("Run comanda workflow '%s'", base)
+}

--- a/utils/mcp/workflows_test.go
+++ b/utils/mcp/workflows_test.go
@@ -1,0 +1,152 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeToolName(t *testing.T) {
+	tests := []struct {
+		base string
+		want string
+	}{
+		{"code-review", "code_review"},
+		{"summarize", "summarize"},
+		{"my workflow.v2", "my_workflow_v2"},
+		{"__leading_and_trailing__", "leading_and_trailing"},
+		{"!!!", ""},
+		{strings.Repeat("a", 100), strings.Repeat("a", 64)},
+	}
+	for _, tt := range tests {
+		if got := sanitizeToolName(tt.base); got != tt.want {
+			t.Errorf("sanitizeToolName(%q) = %q, want %q", tt.base, got, tt.want)
+		}
+	}
+}
+
+func TestExtractVars(t *testing.T) {
+	content := `
+step1:
+  input: "{{ filename }}"
+  model: gpt-4o
+  action:
+    - "Summarize {{ topic }} for {{audience}}"
+    - "Chunk {{ chunk_index }} of {{ total_chunks }} ({{ current_chunk }})"
+    - "File {{ file_index }} of {{ total_files }}"
+    - "Loop counter {{ loop.counter }} and {{loop.max_iterations}}"
+  output: STDOUT
+`
+	got := extractVars(content)
+	want := []string{"audience", "filename", "topic"}
+	if len(got) != len(want) {
+		t.Fatalf("extractVars() = %v, want %v", got, want)
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("extractVars()[%d] = %q, want %q (full result: %v)", i, got[i], v, got)
+		}
+	}
+}
+
+func TestExtractDescription(t *testing.T) {
+	withComment := "# Summarize a document\n# second line\nstep:\n  input: NA\n"
+	if got := extractDescription(withComment, "summarize"); got != "Summarize a document" {
+		t.Errorf("extractDescription() = %q, want %q", got, "Summarize a document")
+	}
+
+	noComment := "step:\n  input: NA\n"
+	want := "Run comanda workflow 'summarize'"
+	if got := extractDescription(noComment, "summarize"); got != want {
+		t.Errorf("extractDescription() = %q, want %q", got, want)
+	}
+
+	emptyComment := "#\nstep:\n  input: NA\n"
+	if got := extractDescription(emptyComment, "summarize"); got != want {
+		t.Errorf("extractDescription() = %q, want fallback %q", got, want)
+	}
+}
+
+func writeWorkflow(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing workflow %s: %v", path, err)
+	}
+	return path
+}
+
+func TestDiscoverWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "summarize.yaml", "# Summarize input\nstep:\n  input: STDIN\n  model: NA\n  action:\n    - echo\n  output: STDOUT\n")
+	writeWorkflow(t, dir, "code-review.yml", "step:\n  input: \"{{ filename }}\"\n  model: NA\n  action:\n    - echo\n  output: STDOUT\n")
+	writeWorkflow(t, dir, "notes.txt", "not a workflow")
+
+	defs, err := DiscoverWorkflows([]string{dir}, nil)
+	if err != nil {
+		t.Fatalf("DiscoverWorkflows() error: %v", err)
+	}
+	if len(defs) != 2 {
+		t.Fatalf("DiscoverWorkflows() found %d defs, want 2: %v", len(defs), defs)
+	}
+
+	// Sorted by path: code-review.yml before summarize.yaml
+	if defs[0].Name != "code_review" {
+		t.Errorf("defs[0].Name = %q, want %q", defs[0].Name, "code_review")
+	}
+	if defs[0].Description != "Run comanda workflow 'code-review'" {
+		t.Errorf("defs[0].Description = %q", defs[0].Description)
+	}
+	if len(defs[0].Vars) != 1 || defs[0].Vars[0] != "filename" {
+		t.Errorf("defs[0].Vars = %v, want [filename]", defs[0].Vars)
+	}
+
+	if defs[1].Name != "summarize" {
+		t.Errorf("defs[1].Name = %q, want %q", defs[1].Name, "summarize")
+	}
+	if defs[1].Description != "Summarize input" {
+		t.Errorf("defs[1].Description = %q, want %q", defs[1].Description, "Summarize input")
+	}
+}
+
+func TestDiscoverWorkflowsExplicitFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflow(t, dir, "echo.yaml", "step:\n  input: STDIN\n  model: NA\n  action:\n    - echo\n  output: STDOUT\n")
+
+	defs, err := DiscoverWorkflows(nil, []string{path})
+	if err != nil {
+		t.Fatalf("DiscoverWorkflows() error: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Path != path {
+		t.Fatalf("DiscoverWorkflows() = %v, want one def for %s", defs, path)
+	}
+
+	if _, err := DiscoverWorkflows(nil, []string{filepath.Join(dir, "missing.yaml")}); err == nil {
+		t.Error("DiscoverWorkflows() with missing file: expected error, got nil")
+	}
+
+	txtPath := writeWorkflow(t, dir, "notaworkflow.txt", "hello")
+	if _, err := DiscoverWorkflows(nil, []string{txtPath}); err == nil {
+		t.Error("DiscoverWorkflows() with .txt file: expected error, got nil")
+	}
+}
+
+func TestDiscoverWorkflowsDuplicateNames(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	writeWorkflow(t, dirA, "code-review.yaml", "step:\n  input: STDIN\n  model: NA\n  action:\n    - a\n  output: STDOUT\n")
+	writeWorkflow(t, dirB, "code_review.yml", "step:\n  input: STDIN\n  model: NA\n  action:\n    - b\n  output: STDOUT\n")
+
+	_, err := DiscoverWorkflows([]string{dirA, dirB}, nil)
+	if err == nil {
+		t.Fatal("DiscoverWorkflows() with duplicate tool names: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "code_review") {
+		t.Errorf("duplicate name error should mention the tool name, got: %v", err)
+	}
+	// Both conflicting paths should be listed for a clear startup error.
+	if !strings.Contains(err.Error(), dirA) || !strings.Contains(err.Error(), dirB) {
+		t.Errorf("duplicate name error should list both paths, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `comanda mcp`: a Model Context Protocol (MCP) server so MCP-native agents (Claude Code, Kimi Code, Codex, Cursor) can trigger comanda workflows as first-class tools and use comanda skills as prompts.

- **Workflows → MCP tools**: each discovered workflow YAML (`~/.comanda/workflows/`, `.comanda/workflows/`, `--dir`, `--workflow`) becomes one tool. `{{ var }}` placeholders become optional string inputs, plus a reserved `input` fed as STDIN-style input. Tool descriptions come from the file's first comment line.
- **Skills → MCP prompts**: each skill becomes an MCP prompt with its declared arguments, rendered via the existing `skills.Prepare()` (no LLM call).
- **Transports**: stdio by default (how MCP clients launch local servers); `--http :port` serves the streamable HTTP transport (localhost-trusted, no auth).
- Built on the official SDK `github.com/modelcontextprotocol/go-sdk` v1.6.1. Execution reuses the existing programmatic path (`processor.NewProcessor` + `Process()` + `LastOutput()`), now with cliVars passed through.
- **Stdio hygiene**: all logging and stray workflow stdout are redirected to stderr so the JSON-RPC channel carries only protocol frames (verified with raw JSON-RPC drives).

## Docs

- `docs/design/mcp-server.md` — design doc
- `docs/mcp-server.md` — usage + client setup (Claude Code, Kimi Code, Codex)
- `examples/mcp/` — example workflows + walkthrough
- README section

## Test plan

- 11 new tests in `utils/mcp/` (discovery, var extraction, sanitization, execution adapter with a `model: NA` workflow, in-memory server: tools/list, tools/call success + IsError paths, prompts/list, prompts/get)
- `go test ./...` green; `go vet` clean
- Manual smoke: raw JSON-RPC over stdio (initialize → tools/list → tools/call) and HTTP transport verified

## Non-goals (fast-follows)

- `server.mcp` config block / `comanda server mcp on|off`
- MCP resources (codebase indexes), elicitation/sampling
- Auth for `--http` mode