### PR TITLE
fix: make Codex command timeout configurable

### DIFF
--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -862,6 +862,9 @@ func renderAgenticLoopBox(config *processor.AgenticLoopConfig, boxWidth int) {
 	if config.TimeoutSeconds > 0 {
 		configLine += fmt.Sprintf(" │ Timeout: %ds", config.TimeoutSeconds)
 	}
+	if config.CodexTimeoutSeconds > 0 {
+		configLine += fmt.Sprintf(" │ Codex: %ds", config.CodexTimeoutSeconds)
+	}
 	if config.Stateful {
 		configLine += " │ Stateful"
 	}

--- a/utils/models/openaicodex.go
+++ b/utils/models/openaicodex.go
@@ -16,6 +16,12 @@ import (
 	"github.com/kris-hansen/comanda/utils/retry"
 )
 
+// DefaultOpenAICodexCommandTimeoutSeconds is the per-command watchdog used
+// for Codex CLI executions unless a workflow overrides it.
+const DefaultOpenAICodexCommandTimeoutSeconds = 20 * 60
+
+const defaultOpenAICodexCommandTimeout = time.Duration(DefaultOpenAICodexCommandTimeoutSeconds) * time.Second
+
 // OpenAICodexProvider handles OpenAI Codex CLI for agentic programming tasks
 type OpenAICodexProvider struct {
 	verbose    bool
@@ -110,6 +116,12 @@ func (o *OpenAICodexProvider) findCodexBinary() (string, error) {
 
 // SendPrompt sends a prompt to OpenAI Codex and returns the response
 func (o *OpenAICodexProvider) SendPrompt(modelName string, prompt string) (string, error) {
+	return o.SendPromptWithTimeout(modelName, prompt, 0)
+}
+
+// SendPromptWithTimeout sends a prompt with an optional per-command timeout.
+// A timeout of zero uses the 20-minute provider default.
+func (o *OpenAICodexProvider) SendPromptWithTimeout(modelName string, prompt string, timeoutSeconds int) (string, error) {
 	o.debugf("Preparing to send prompt via OpenAI Codex")
 	o.debugf("Prompt length: %d characters", len(prompt))
 
@@ -124,10 +136,13 @@ func (o *OpenAICodexProvider) SendPrompt(modelName string, prompt string) (strin
 
 	o.debugf("Executing: %s %v", o.binaryPath, args)
 
+	timeout := openAICodexCommandTimeout(timeoutSeconds)
+	o.debugf("Codex command timeout: %s", timeout)
+
 	// Use retry mechanism for execution
 	result, err := retry.WithRetry(
 		func() (interface{}, error) {
-			return o.executeCommand(args, "")
+			return o.executeCommandWithTimeout(args, "", timeout)
 		},
 		func(err error) bool {
 			// Retry on timeout or transient errors
@@ -148,6 +163,13 @@ func (o *OpenAICodexProvider) SendPrompt(modelName string, prompt string) (strin
 
 // SendPromptWithFile sends a prompt along with file context to OpenAI Codex
 func (o *OpenAICodexProvider) SendPromptWithFile(modelName string, prompt string, file FileInput) (string, error) {
+	return o.SendPromptWithFileWithTimeout(modelName, prompt, file, 0)
+}
+
+// SendPromptWithFileWithTimeout sends a prompt with file context and an
+// optional per-command timeout. A timeout of zero uses the 20-minute provider
+// default.
+func (o *OpenAICodexProvider) SendPromptWithFileWithTimeout(modelName string, prompt string, file FileInput, timeoutSeconds int) (string, error) {
 	o.debugf("Preparing to send prompt with file to OpenAI Codex")
 	o.debugf("File path: %s", file.Path)
 
@@ -173,9 +195,12 @@ func (o *OpenAICodexProvider) SendPromptWithFile(modelName string, prompt string
 
 	o.debugf("Executing with file context: %s", file.Path)
 
+	timeout := openAICodexCommandTimeout(timeoutSeconds)
+	o.debugf("Codex command timeout: %s", timeout)
+
 	result, err := retry.WithRetry(
 		func() (interface{}, error) {
-			return o.executeCommand(args, filepath.Dir(file.Path))
+			return o.executeCommandWithTimeout(args, filepath.Dir(file.Path), timeout)
 		},
 		func(err error) bool {
 			return strings.Contains(err.Error(), "timeout") ||
@@ -228,6 +253,12 @@ func (o *OpenAICodexProvider) buildArgs(modelName string, prompt string, workDir
 
 // executeCommand runs the codex binary and captures output
 func (o *OpenAICodexProvider) executeCommand(args []string, workDir string) (string, error) {
+	return o.executeCommandWithTimeout(args, workDir, defaultOpenAICodexCommandTimeout)
+}
+
+// executeCommandWithTimeout runs the codex binary and captures output with a
+// per-command watchdog.
+func (o *OpenAICodexProvider) executeCommandWithTimeout(args []string, workDir string, timeout time.Duration) (string, error) {
 	// Create a temp file to capture the final response cleanly
 	tmpFile, err := os.CreateTemp("", "codex-output-*.txt")
 	if err != nil {
@@ -256,8 +287,6 @@ func (o *OpenAICodexProvider) executeCommand(args []string, workDir string) (str
 		done <- cmd.Run()
 	}()
 
-	// 10 minute timeout for complex tasks
-	timeout := 10 * time.Minute
 	select {
 	case err := <-done:
 		if err != nil {
@@ -284,6 +313,13 @@ func (o *OpenAICodexProvider) executeCommand(args []string, workDir string) (str
 		}
 		return "", fmt.Errorf("codex command timed out after %v", timeout)
 	}
+}
+
+func openAICodexCommandTimeout(timeoutSeconds int) time.Duration {
+	if timeoutSeconds <= 0 {
+		return defaultOpenAICodexCommandTimeout
+	}
+	return time.Duration(timeoutSeconds) * time.Second
 }
 
 // SetVerbose enables or disables verbose mode

--- a/utils/models/openaicodex_test.go
+++ b/utils/models/openaicodex_test.go
@@ -2,12 +2,22 @@ package models
 
 import (
 	"testing"
+	"time"
 )
 
 func TestOpenAICodexProviderName(t *testing.T) {
 	provider := NewOpenAICodexProvider()
 	if provider.Name() != "openai-codex" {
 		t.Errorf("Expected provider name 'openai-codex', got '%s'", provider.Name())
+	}
+}
+
+func TestOpenAICodexCommandTimeout(t *testing.T) {
+	if got := openAICodexCommandTimeout(0); got != 20*time.Minute {
+		t.Fatalf("openAICodexCommandTimeout(0) = %s, want 20m", got)
+	}
+	if got := openAICodexCommandTimeout(1800); got != 30*time.Minute {
+		t.Fatalf("openAICodexCommandTimeout(1800) = %s, want 30m", got)
 	}
 }
 

--- a/utils/processor/action_handler.go
+++ b/utils/processor/action_handler.go
@@ -139,7 +139,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 					}, nil
 				}
 			}
-			result, err := configuredProvider.SendPrompt(resolvedModelName, action)
+			result, err := p.sendPromptWithAgenticTimeout(configuredProvider, resolvedModelName, action, isAgenticMode, agenticConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -249,8 +249,8 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 						}, nil
 					}
 				}
-				// Non-agentic mode: use SendPromptWithFile as before
-				result, err := configuredProvider.SendPromptWithFile(resolvedModelName, action, fileInputs[0])
+				// Non-agentic mode: use SendPromptWithFile as before.
+				result, err := p.sendPromptWithFileAgenticTimeout(configuredProvider, resolvedModelName, action, fileInputs[0], isAgenticMode, agenticConfig)
 				if err != nil {
 					return nil, err
 				}
@@ -279,7 +279,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 					combinedPrompt += fmt.Sprintf("File %d (%s):\n%s\n\n", i+1, file.Path, string(content))
 				}
 				combinedPrompt += fmt.Sprintf("\nAction: %s", action)
-				result, err := configuredProvider.SendPrompt(resolvedModelName, combinedPrompt)
+				result, err := p.sendPromptWithAgenticTimeout(configuredProvider, resolvedModelName, combinedPrompt, isAgenticMode, agenticConfig)
 				if err != nil {
 					return nil, err
 				}
@@ -302,8 +302,8 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 				// Build a clean prompt that discourages metadata wrapping
 				// Detect output format from action to provide appropriate instructions
 				// Try to process each file individually
-				result, err := configuredProvider.SendPromptWithFile(resolvedModelName,
-					fmt.Sprintf("%sFor this file: %s", PromptPrefix, action), file)
+				result, err := p.sendPromptWithFileAgenticTimeout(configuredProvider, resolvedModelName,
+					fmt.Sprintf("%sFor this file: %s", PromptPrefix, action), file, isAgenticMode, agenticConfig)
 
 				if err != nil {
 					// Log error but continue with other files if skipErrors is true
@@ -387,7 +387,7 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 				}
 			}
 
-			result, err := configuredProvider.SendPrompt(resolvedModelName, combinedPrompt)
+			result, err := p.sendPromptWithAgenticTimeout(configuredProvider, resolvedModelName, combinedPrompt, isAgenticMode, agenticConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -399,4 +399,43 @@ func (p *Processor) processActions(modelNames []string, actions []string) (*Acti
 	}
 
 	return nil, fmt.Errorf("no actions processed")
+}
+
+// sendPromptWithAgenticTimeout applies an agentic loop's Codex-specific
+// watchdog without changing timeouts for other providers.
+func (p *Processor) sendPromptWithAgenticTimeout(provider models.Provider, modelName, prompt string, isAgenticMode bool, config *AgenticLoopConfig) (string, error) {
+	if isAgenticMode {
+		if codex, ok := provider.(*models.OpenAICodexProvider); ok {
+			timeoutSeconds := 0
+			if config != nil {
+				timeoutSeconds = config.CodexTimeoutSeconds
+			}
+			p.debugf("Using Codex per-command timeout of %d seconds", effectiveCodexTimeoutSeconds(timeoutSeconds))
+			return codex.SendPromptWithTimeout(modelName, prompt, timeoutSeconds)
+		}
+	}
+	return provider.SendPrompt(modelName, prompt)
+}
+
+// sendPromptWithFileAgenticTimeout is the file-input counterpart to
+// sendPromptWithAgenticTimeout.
+func (p *Processor) sendPromptWithFileAgenticTimeout(provider models.Provider, modelName, prompt string, file models.FileInput, isAgenticMode bool, config *AgenticLoopConfig) (string, error) {
+	if isAgenticMode {
+		if codex, ok := provider.(*models.OpenAICodexProvider); ok {
+			timeoutSeconds := 0
+			if config != nil {
+				timeoutSeconds = config.CodexTimeoutSeconds
+			}
+			p.debugf("Using Codex per-command timeout of %d seconds", effectiveCodexTimeoutSeconds(timeoutSeconds))
+			return codex.SendPromptWithFileWithTimeout(modelName, prompt, file, timeoutSeconds)
+		}
+	}
+	return provider.SendPromptWithFile(modelName, prompt, file)
+}
+
+func effectiveCodexTimeoutSeconds(timeoutSeconds int) int {
+	if timeoutSeconds > 0 {
+		return timeoutSeconds
+	}
+	return models.DefaultOpenAICodexCommandTimeoutSeconds
 }

--- a/utils/processor/embedded_guide.go
+++ b/utils/processor/embedded_guide.go
@@ -366,6 +366,7 @@ agentic-loop:
   config:
     max_iterations: 5           # Safety limit (default: 10)
     timeout_seconds: 300        # Total timeout (default: 300)
+    codex_timeout_seconds: 1200 # Per-Codex-command timeout (default: 20 minutes)
     exit_condition: llm_decides # or "pattern_match"
     exit_pattern: "DONE"        # For pattern_match
     context_window: 3           # Past iterations to include (default: 5)
@@ -393,6 +394,7 @@ agentic-loop:
 **Core Settings:**
 - ` + "`max_iterations`" + `: (int, default: 10) Maximum iterations before stopping.
 - ` + "`timeout_seconds`" + `: (int, default: 0) Total time limit in seconds. **0 = no timeout** (loop runs until max_iterations or exit condition).
+- ` + "`codex_timeout_seconds`" + `: (int, default: 1200) Per-command watchdog for ` + "`openai-codex`" + ` loop steps. Set a positive value to override it; **0 uses the 20-minute provider default**. This does not change the loop-wide ` + "`timeout_seconds`" + ` setting.
 - ` + "`exit_condition`" + `: (string) How to detect completion:
   - ` + "`llm_decides`" + `: Exits when output ends with "DONE", "COMPLETE", or "FINISHED" (case-insensitive). Works when these words appear at the very end of the output, at the end of any line, or as the entire output.
   - ` + "`pattern_match`" + `: Exits when output matches ` + "`exit_pattern`" + ` regex
@@ -1739,6 +1741,7 @@ agentic-loop:
   config:
     max_iterations: 5           # Safety limit (default: 10)
     timeout_seconds: 300        # Total timeout (default: 300)
+    codex_timeout_seconds: 1200 # Per-Codex-command timeout (default: 20 minutes)
     exit_condition: llm_decides # or "pattern_match"
     exit_pattern: "DONE"        # For pattern_match
     context_window: 3           # Past iterations to include (default: 5)
@@ -1766,6 +1769,7 @@ agentic-loop:
 **Core Settings:**
 - ` + "`max_iterations`" + `: (int, default: 10) Maximum iterations before stopping.
 - ` + "`timeout_seconds`" + `: (int, default: 0) Total time limit in seconds. **0 = no timeout** (loop runs until max_iterations or exit condition).
+- ` + "`codex_timeout_seconds`" + `: (int, default: 1200) Per-command watchdog for ` + "`openai-codex`" + ` loop steps. Set a positive value to override it; **0 uses the 20-minute provider default**. This does not change the loop-wide ` + "`timeout_seconds`" + ` setting.
 - ` + "`exit_condition`" + `: (string) How to detect completion:
   - ` + "`llm_decides`" + `: Exits when output ends with "DONE", "COMPLETE", or "FINISHED" (case-insensitive). Works when these words appear at the very end of the output, at the end of any line, or as the entire output.
   - ` + "`pattern_match`" + `: Exits when output matches ` + "`exit_pattern`" + ` regex

--- a/utils/processor/loop_unmarshal_test.go
+++ b/utils/processor/loop_unmarshal_test.go
@@ -15,6 +15,7 @@ loops:
     name: backend-processing
     max_iterations: 10
     timeout_seconds: 300
+    codex_timeout_seconds: 1800
     stateful: true
     checkpoint_interval: 3
     exit_condition: llm_decides
@@ -70,6 +71,9 @@ execute_loops:
 	}
 	if backend.TimeoutSeconds != 300 {
 		t.Errorf("backend.TimeoutSeconds = %d, want 300", backend.TimeoutSeconds)
+	}
+	if backend.CodexTimeoutSeconds != 1800 {
+		t.Errorf("backend.CodexTimeoutSeconds = %d, want 1800", backend.CodexTimeoutSeconds)
 	}
 	if !backend.Stateful {
 		t.Error("backend.Stateful should be true")

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -34,15 +34,16 @@ func resolvePathAtParseTime(path string) string {
 
 // AgenticLoopConfig represents the configuration for an agentic loop
 type AgenticLoopConfig struct {
-	MaxIterations     int                      `yaml:"max_iterations"`               // Maximum iterations before stopping (default: 10)
-	TimeoutSeconds    int                      `yaml:"timeout_seconds"`              // Total timeout in seconds (default: 0 = no timeout)
-	ExitCondition     string                   `yaml:"exit_condition"`               // Exit condition: llm_decides, pattern_match
-	ExitPattern       string                   `yaml:"exit_pattern"`                 // Regex pattern for pattern_match exit condition
-	ContextWindow     int                      `yaml:"context_window"`               // Number of past iterations to include in context (default: 5)
-	Steps             []Step                   `yaml:"steps,omitempty"`              // Sub-steps to execute within each iteration
-	AllowedPaths      []string                 `yaml:"allowed_paths,omitempty"`      // Directories for agentic tool access
-	Tools             []string                 `yaml:"tools,omitempty"`              // Optional tool whitelist (Read, Write, Edit, Bash, etc.)
-	PromptImprovement *PromptImprovementConfig `yaml:"prompt_improvement,omitempty"` // Optional prompt refinement between iterations
+	MaxIterations       int                      `yaml:"max_iterations"`               // Maximum iterations before stopping (default: 10)
+	TimeoutSeconds      int                      `yaml:"timeout_seconds"`              // Total timeout in seconds (default: 0 = no timeout)
+	CodexTimeoutSeconds int                      `yaml:"codex_timeout_seconds"`        // Per-Codex-command timeout in seconds (default: 1200; 0 = provider default)
+	ExitCondition       string                   `yaml:"exit_condition"`               // Exit condition: llm_decides, pattern_match
+	ExitPattern         string                   `yaml:"exit_pattern"`                 // Regex pattern for pattern_match exit condition
+	ContextWindow       int                      `yaml:"context_window"`               // Number of past iterations to include in context (default: 5)
+	Steps               []Step                   `yaml:"steps,omitempty"`              // Sub-steps to execute within each iteration
+	AllowedPaths        []string                 `yaml:"allowed_paths,omitempty"`      // Directories for agentic tool access
+	Tools               []string                 `yaml:"tools,omitempty"`              // Optional tool whitelist (Read, Write, Edit, Bash, etc.)
+	PromptImprovement   *PromptImprovementConfig `yaml:"prompt_improvement,omitempty"` // Optional prompt refinement between iterations
 
 	// State persistence & quality gates
 	Name               string              `yaml:"name,omitempty"`                // Loop name (required for stateful loops)


### PR DESCRIPTION
## Summary
- raise the default per-Codex-command watchdog from 10 to 20 minutes
- add codex_timeout_seconds for per-agentic-loop overrides
- document and display the setting in workflow charts

## Validation
- go test ./...
- go vet ./...