### PR TITLE
docs: improve GitHub discovery README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,104 @@
 ![comanda](comanda-small.jpg)
 
-# comanda
+# Comanda
 
-Declarative AI workflows for the command line.
+> **The CLI-native orchestrator for AI agent workflows.**
+>
+> Define multi-model AI pipelines in YAML. Run them from the terminal with pipes, redirects, and version control. No Python boilerplate. No GUI lock-in. Just workflows that work where you already work.
 
-Comanda turns repeatable AI work into YAML pipelines you can run, review, and
-version control. Use it to generate workflows from natural language, run
-multi-model pipelines, orchestrate agentic loops, process files, call tools, and
-wire Claude Code, Gemini CLI, OpenAI Codex, Kimi Code, and API models together.
+[![GitHub Stars](https://img.shields.io/github/stars/kris-hansen/comanda?style=social)](https://github.com/kris-hansen/comanda)
+[![Release](https://img.shields.io/github/v/release/kris-hansen/comanda)](https://github.com/kris-hansen/comanda/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-For the full guide, feature tour, and copy-ready workflow templates, start at
-[comanda.sh](https://comanda.sh):
+## Demo: Multi-Agent Code Review
 
-- [Features](https://comanda.sh/features)
-- [Templates](https://comanda.sh/templates)
-- [GitHub examples](examples/README.md)
+```yaml
+parallel-process:
+  architecture:
+    input: STDIN
+    model: claude-code
+    action: "Analyze the input for architecture and security issues."
+    output: .comanda/claude-review.md
+
+  performance:
+    input: STDIN
+    model: gemini-cli
+    action: "Identify performance bottlenecks and unnecessary complexity."
+    output: .comanda/gemini-review.md
+
+synthesize:
+  input:
+    - .comanda/claude-review.md
+    - .comanda/gemini-review.md
+  model: gpt-4o
+  action: "Combine the reviews into prioritized recommendations."
+  output: STDOUT
+```
+
+Run it:
+
+```bash
+cat main.go | comanda process code-review.yaml
+```
+
+**[See more examples →](https://comanda.sh/templates)** — templates, walkthroughs, and full documentation.
 
 ## Install
 
 ```bash
+# macOS
 brew install kris-hansen/comanda/comanda
-```
 
-Or install with Go:
-
-```bash
+# Go
 go install github.com/kris-hansen/comanda@latest
 ```
 
-See [GitHub Releases](https://github.com/kris-hansen/comanda/releases) for
-prebuilt binaries.
+See [GitHub Releases](https://github.com/kris-hansen/comanda/releases) for prebuilt binaries for macOS, Linux, and Windows.
+
+## Why Comanda?
+
+Most AI workflow tools fall into two camps:
+
+| Tool | Approach | Best for |
+| --- | --- | --- |
+| LangChain / CrewAI | Python SDKs and frameworks | Building AI-powered applications |
+| Dify / n8n | Visual GUI builders | Drag-and-drop automation |
+| **Comanda** | **CLI-native YAML + pipes** | **Developers who live in terminals, repos, and CI/CD** |
+
+Comanda is not a framework you import. It is a harness you run. Treat AI workflows as infrastructure-as-code: declarative, version-controlled, and composable with standard Unix primitives.
+
+## What You Can Build
+
+- **Multi-agent code reviews** — Claude Code, Gemini CLI, Codex, Kimi Code, and API models working in parallel or sequence
+- **Agentic loops** — iterative refinement with quality gates, retries, and state management
+- **Batch processing** — files, URLs, images, PDFs, and databases with wildcards and chunking
+- **Git worktree workflows** — parallel isolated implementation in separate branches
+- **CI/CD pipelines** — AI-powered checks in GitHub Actions, GitLab CI, or any shell environment
+- **MCP server mode** — expose workflows as tools for Claude Code, Codex, Kimi Code, Cursor, and other MCP clients
 
 ## Quick Start
 
 ```bash
+# Configure API keys
 comanda configure
-comanda generate workflow.yaml "review this code for bugs"
-comanda process workflow.yaml
+
+# Generate a workflow from English
+comanda generate review.yaml "review this code for bugs"
+
+# Run it
+comanda process review.yaml
+
+# Pipe input through it
+cat main.go | comanda process review.yaml
+
+# Visualize workflow structure
+comanda chart review.yaml
+
+# Improve an existing workflow
+comanda improve review.yaml "Add security findings and suggested fixes"
 ```
 
-Pipe input through a workflow:
-
-```bash
-cat main.go | comanda process workflow.yaml
-```
-
-Inspect or iterate on a workflow:
-
-```bash
-comanda chart workflow.yaml
-comanda improve workflow.yaml "Add security findings and suggested fixes"
-```
-
-## Minimal Workflow
+## Example: Summarize Notes
 
 ```yaml
 summarize:
@@ -62,45 +108,32 @@ summarize:
   output: STDOUT
 ```
 
-Run it:
-
 ```bash
 cat notes.md | comanda process summarize.yaml
 ```
 
-## What You Can Build
+## Features
 
-- Multi-agent reviews with Claude Code, Gemini CLI, OpenAI Codex, Kimi Code, and API models
-- Agentic loops that iterate until work is complete
-- File, URL, image, PDF, database, and batch-processing workflows
-- Tool-enabled workflows with explicit command allowlists
-- Codebase indexes for persistent project context
-- Git worktree workflows for parallel isolated implementation
-- Server-backed workflows callable over HTTP
-- MCP server mode exposing workflows as tools and skills as prompts
+- **Multi-Model Orchestration** — Claude Code, Gemini CLI, OpenAI Codex, Kimi Code, and API models in parallel or sequence
+- **YAML-Native** — workflows are plain text: version, share, and review them in pull requests
+- **Agentic Loops** — iterative refinement with quality gates, retries, and state management
+- **Unix Philosophy** — works with pipes (`|`), redirects (`>`), and shell scripts
+- **Codebase Indexing** — generate agent-ready architecture, conventions, and project context
+- **Workflow Improvement** — refine YAML from plain-English feedback with `comanda improve`
+- **Reusable Skills** — package common patterns and share them across projects
+- **Model Choice** — one interface for OpenAI, Anthropic, Google, Sakana, Ollama, xAI, and AWS Bedrock
+- **MCP Server** — run `comanda mcp` to expose workflows as tools for agent clients
 
-## More Examples
+## Documentation
 
-Most examples and walkthroughs live on [comanda.sh](https://comanda.sh):
-
-- [Browse workflow templates](https://comanda.sh/templates)
-- [Explore all features](https://comanda.sh/features)
-- [Local examples directory](examples/README.md)
+- [Website & templates](https://comanda.sh)
+- [Local examples](examples/README.md)
+- [Multi-agent code review](examples/multi-agent/code-review.yaml)
 - [Multi-agent patterns](examples/multi-agent/README.md)
 - [Agentic loops](examples/agentic-loop/)
 - [Tool use](examples/tool-use/README.md)
 - [Server API](docs/server-api.md)
 - [MCP server](docs/mcp-server.md)
-
-## MCP Server
-
-Run comanda as an MCP server so agent clients (Claude Code, Kimi Code, Codex) can call workflows as tools and use skills as prompts:
-
-```bash
-comanda mcp
-```
-
-Each discovered workflow file (from `~/.comanda/workflows/`, `.comanda/workflows/`, `--dir`, or `--workflow`) becomes one MCP tool; each skill becomes an MCP prompt. See [docs/mcp-server.md](docs/mcp-server.md) and [examples/mcp/](examples/mcp/README.md) for client setup and a walkthrough.
 
 ## Development
 

--- a/examples/multi-agent/README.md
+++ b/examples/multi-agent/README.md
@@ -12,7 +12,18 @@ These examples demonstrate how to leverage multiple agentic coding tools togethe
 
 ## Workflow Patterns
 
-### 1. Parallel Analysis → Synthesis (`architecture-planning.yaml`)
+### 1. Multi-Agent Code Review (`code-review.yaml`)
+
+Claude Code reviews architecture and security while Gemini CLI looks for
+performance issues. Comanda then synthesizes both reviews into a prioritized
+set of recommendations.
+
+**Usage:**
+```bash
+cat main.go | comanda process code-review.yaml
+```
+
+### 2. Parallel Analysis → Synthesis (`architecture-planning.yaml`)
 
 All agents analyze the problem simultaneously, then results are synthesized:
 
@@ -45,7 +56,7 @@ All agents analyze the problem simultaneously, then results are synthesized:
 echo "Build a real-time collaborative document editor" | comanda process architecture-planning.yaml
 ```
 
-### 2. Sequential Refinement (`architecture-review.yaml`)
+### 3. Sequential Refinement (`architecture-review.yaml`)
 
 Each agent builds upon and improves the previous agent's work:
 
@@ -78,7 +89,7 @@ Each agent builds upon and improves the previous agent's work:
 echo "Microservices platform for e-commerce" | comanda process architecture-review.yaml
 ```
 
-### 3. Voting / Consensus (`architecture-decision.yaml`)
+### 4. Voting / Consensus (`architecture-decision.yaml`)
 
 All agents independently evaluate options, then vote:
 

--- a/examples/multi-agent/code-review.yaml
+++ b/examples/multi-agent/code-review.yaml
@@ -1,0 +1,25 @@
+# Review source code through complementary architecture and performance lenses,
+# then synthesize the findings into one prioritized report.
+#
+# Usage:
+#   cat main.go | comanda process examples/multi-agent/code-review.yaml
+parallel-process:
+  architecture:
+    input: STDIN
+    model: claude-code
+    action: "Analyze the input for architecture and security issues."
+    output: .comanda/claude-review.md
+
+  performance:
+    input: STDIN
+    model: gemini-cli
+    action: "Identify performance bottlenecks and unnecessary complexity."
+    output: .comanda/gemini-review.md
+
+synthesize:
+  input:
+    - .comanda/claude-review.md
+    - .comanda/gemini-review.md
+  model: gpt-4o
+  action: "Combine the reviews into prioritized recommendations."
+  output: STDOUT


### PR DESCRIPTION
## Summary
- lead the README with Comanda's CLI-native positioning, demo, installation path, and comparison
- add a validated multi-agent code-review example using file-backed fan-in
- make the example discoverable from the multi-agent guide

## Validation
- `go run . chart examples/multi-agent/code-review.yaml --verbose`
- `go test ./...`
- `go vet ./...`