### PR TITLE
feat: knowledge graphs from codebase indexes stored in semantic memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,29 @@ complete workflow. Automatic fact extraction, deduplication, and project-state
 compaction are planned as the next layer; this first release deliberately
 keeps persistence explicit and inspectable.
 
+## Knowledge Graphs
+
+A codebase index can be turned into a traversable knowledge graph stored in
+the semantic memory database. Extraction is deterministic and local: the index
+scan contributes components, packages, files, symbols, and imports as typed
+edges tagged `EXTRACTED` (explicit in the source) or `INFERRED` (name
+resolution, or an optional AI pass).
+
+```bash
+comanda index capture -n myproject --graph      # index + graph in one run
+comanda graph build myproject                   # or build from a registered index
+comanda graph explain Store                     # a node and its connections
+comanda graph path main Store                   # shortest connection between nodes
+comanda graph query "what uses the store?"      # scoped subgraph for a question
+comanda graph stats                             # counts and hub nodes
+comanda graph export -o graph.json              # graphify-style JSON
+```
+
+Graph nodes are mirrored into the memory FTS index as `graph_node` records, so
+workflow steps recall them with the existing memory mapping
+(`types: [graph_node]`). See [examples/knowledge-graph/](examples/knowledge-graph/README.md)
+and the [design doc](docs/design/knowledge-graph.md).
+
 Browse [all examples](examples/README.md) or visit [comanda.sh](https://comanda.sh) for documentation and templates.
 
 ## Development

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -1,0 +1,339 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
+	"github.com/kris-hansen/comanda/utils/knowledgegraph"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	graphNamespace    string
+	graphDBPath       string
+	graphEnhance      bool
+	graphEnhanceModel string
+	graphJSON         bool
+	graphExportOutput string
+)
+
+var graphCmd = &cobra.Command{
+	Use:   "graph",
+	Short: "Build and query knowledge graphs from codebase indexes",
+	Long: `Build a knowledge graph from a registered codebase index and store it in
+the semantic memory store, then query it instead of grepping files.
+
+The graph is extracted deterministically from the index scan (components,
+packages, files, symbols, imports). Edges carry confidence tags: EXTRACTED
+means explicit in the source, INFERRED means resolved by name matching or an
+optional AI enhancement pass (--enhance).
+
+Graph data lives in the project's semantic memory database
+(.comanda/memory/<index-name>.db), so 'comanda memory search' and workflow
+memory recall (types: [graph_node]) see graph concepts too.
+
+Examples:
+  comanda graph build myproject              # Build graph from a registered index
+  comanda graph build myproject --enhance    # Add AI-inferred concept nodes/edges
+  comanda graph explain Store                # Show a node and its connections
+  comanda graph path main Store              # Shortest connection between nodes
+  comanda graph query "what uses the store?" # Scoped subgraph for a question
+  comanda graph stats                        # Counts and hub nodes
+  comanda graph export -o graph.json         # graphify-style JSON export`,
+}
+
+var graphBuildCmd = &cobra.Command{
+	Use:   "build <index-name>",
+	Short: "Build (or rebuild) the knowledge graph for a registered index",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runGraphBuild,
+}
+
+var graphUpdateCmd = &cobra.Command{
+	Use:   "update <index-name>",
+	Short: "Rebuild the knowledge graph from a fresh scan of the index",
+	Long: `Rebuild the knowledge graph for a registered index.
+
+The graph is rebuilt from a fresh deterministic scan and replaces the stored
+graph for the namespace (stale nodes from deleted files are removed).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runGraphBuild,
+}
+
+var graphExplainCmd = &cobra.Command{
+	Use:   "explain <node>",
+	Short: "Show a node and its connections",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		q, closeStore, err := openGraphQuerier()
+		if err != nil {
+			return err
+		}
+		defer closeStore()
+		ctx := context.Background()
+		if graphJSON {
+			node, err := q.Resolve(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			sub, err := q.ScopedExport(ctx, []semanticmemory.GraphNode{*node}, 1)
+			if err != nil {
+				return err
+			}
+			return json.NewEncoder(os.Stdout).Encode(sub)
+		}
+		out, err := q.Explain(ctx, args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+		return nil
+	},
+}
+
+var graphPathCmd = &cobra.Command{
+	Use:   "path <A> <B>",
+	Short: "Show the shortest connection between two nodes",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(_ *cobra.Command, args []string) error {
+		q, closeStore, err := openGraphQuerier()
+		if err != nil {
+			return err
+		}
+		defer closeStore()
+		ctx := context.Background()
+		if graphJSON {
+			hops, err := q.PathHops(ctx, args[0], args[1])
+			if err != nil {
+				return err
+			}
+			return json.NewEncoder(os.Stdout).Encode(map[string]any{
+				"from": args[0], "to": args[1], "hops": hops,
+			})
+		}
+		out, err := q.Path(ctx, args[0], args[1])
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+		return nil
+	},
+}
+
+var graphQueryCmd = &cobra.Command{
+	Use:   "query <question>",
+	Short: "Answer a question with a scoped subgraph",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		q, closeStore, err := openGraphQuerier()
+		if err != nil {
+			return err
+		}
+		defer closeStore()
+		ctx := context.Background()
+		if graphJSON {
+			seeds, err := q.FindNodes(ctx, args[0], 5)
+			if err != nil {
+				return err
+			}
+			sub, err := q.ScopedExport(ctx, seeds, 1)
+			if err != nil {
+				return err
+			}
+			return json.NewEncoder(os.Stdout).Encode(sub)
+		}
+		out, err := q.Query(ctx, args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+		return nil
+	},
+}
+
+var graphStatsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show graph counts and hub nodes",
+	Args:  cobra.NoArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		q, closeStore, err := openGraphQuerier()
+		if err != nil {
+			return err
+		}
+		defer closeStore()
+		out, err := q.Stats(context.Background())
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+		return nil
+	},
+}
+
+var graphExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export the graph as graphify-style JSON",
+	Args:  cobra.NoArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		q, closeStore, err := openGraphQuerier()
+		if err != nil {
+			return err
+		}
+		defer closeStore()
+		exported, err := q.Export(context.Background())
+		if err != nil {
+			return err
+		}
+		data, err := json.MarshalIndent(exported, "", "  ")
+		if err != nil {
+			return err
+		}
+		if graphExportOutput != "" {
+			if err := os.WriteFile(graphExportOutput, data, 0644); err != nil {
+				return fmt.Errorf("failed to write export: %w", err)
+			}
+			log.Printf("Graph exported to %s (%d nodes, %d edges)\n", graphExportOutput, len(exported.Nodes), len(exported.Edges))
+			return nil
+		}
+		fmt.Println(string(data))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(graphCmd)
+	graphCmd.AddCommand(graphBuildCmd, graphUpdateCmd, graphExplainCmd, graphPathCmd, graphQueryCmd, graphStatsCmd, graphExportCmd)
+
+	graphCmd.PersistentFlags().StringVarP(&graphNamespace, "namespace", "n", "", "Graph namespace (default: index registered for current directory)")
+	graphCmd.PersistentFlags().StringVar(&graphDBPath, "db", "", "Path to the graph/memory SQLite database (default: project-local)")
+
+	graphBuildCmd.Flags().BoolVar(&graphEnhance, "enhance", false, "Add AI-inferred concept nodes and edges using default_generation_model")
+	graphBuildCmd.Flags().StringVar(&graphEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+	graphUpdateCmd.Flags().BoolVar(&graphEnhance, "enhance", false, "Add AI-inferred concept nodes and edges using default_generation_model")
+	graphUpdateCmd.Flags().StringVar(&graphEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+
+	graphExplainCmd.Flags().BoolVar(&graphJSON, "json", false, "Output JSON subgraph")
+	graphPathCmd.Flags().BoolVar(&graphJSON, "json", false, "Output JSON hop list")
+	graphQueryCmd.Flags().BoolVar(&graphJSON, "json", false, "Output JSON subgraph")
+
+	graphExportCmd.Flags().StringVarP(&graphExportOutput, "output", "o", "", "Write export to a file instead of stdout")
+}
+
+// buildKnowledgeGraph scans the repo behind a registered index and rebuilds
+// its knowledge graph. Shared by index capture/update (--graph) and the
+// graph build/update commands.
+func buildKnowledgeGraph(indexName, repoPath string, enhance bool, enhanceModel string) error {
+	entryEncrypted := false
+	if envConfig != nil && envConfig.Indexes != nil {
+		if entry, ok := envConfig.Indexes[indexName]; ok {
+			entryEncrypted = entry.Encrypted
+		}
+	}
+	if entryEncrypted {
+		log.Printf("Warning: skipping graph build for encrypted index '%s'\n", indexName)
+		return nil
+	}
+
+	cfg := codebaseindex.DefaultConfig()
+	cfg.Root = repoPath
+	cfg.Verbose = verbose
+	cfg.MaxFiles = indexMaxFiles
+	cfg.MaxFilesPerDir = indexMaxFilesPerDir
+
+	manager, err := codebaseindex.NewManager(cfg, verbose)
+	if err != nil {
+		return fmt.Errorf("failed to create index manager: %w", err)
+	}
+
+	log.Printf("Scanning %s for graph build...\n", repoPath)
+	scan, _, err := manager.Scan()
+	if err != nil {
+		return fmt.Errorf("graph scan failed: %w", err)
+	}
+
+	graph := knowledgegraph.Build(scan, indexName)
+
+	if enhance {
+		modelName, enhanceFunc, err := buildIndexEnhancer(enhanceModel)
+		if err != nil {
+			return err
+		}
+		log.Printf("Enhancing graph with model: %s\n", modelName)
+		if err := knowledgegraph.Enhance(graph, enhanceFunc); err != nil {
+			log.Printf("Warning: graph enhancement skipped: %v\n", err)
+		}
+	}
+
+	dbPath := graphDBPath
+	if dbPath == "" {
+		dbPath = semanticmemory.DefaultPath(repoPath, indexName)
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return fmt.Errorf("create graph database directory: %w", err)
+	}
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	if err := knowledgegraph.Rebuild(context.Background(), store, graph); err != nil {
+		return fmt.Errorf("failed to store graph: %w", err)
+	}
+
+	log.Printf("Knowledge graph built: %d nodes, %d edges (namespace %s, db %s)\n",
+		len(graph.Nodes), len(graph.Edges), indexName, dbPath)
+	return nil
+}
+
+func runGraphBuild(_ *cobra.Command, args []string) error {
+	entry, name, err := findIndex(args[0])
+	if err != nil {
+		return err
+	}
+	return buildKnowledgeGraph(name, entry.Path, graphEnhance, graphEnhanceModel)
+}
+
+// openGraphQuerier resolves the namespace (flag, or the index registered for
+// the current directory) and opens a querier on the right database.
+func openGraphQuerier() (*knowledgegraph.Querier, func() error, error) {
+	namespace := graphNamespace
+	dbPath := graphDBPath
+
+	if dbPath == "" {
+		root := ""
+		if namespace == "" {
+			// Default: the index registered for the current directory.
+			entry, name, err := findIndex("")
+			if err != nil {
+				return nil, nil, fmt.Errorf("no namespace given and %v", err)
+			}
+			namespace = name
+			root = entry.Path
+		} else if envConfig != nil && envConfig.Indexes != nil {
+			if entry, ok := envConfig.Indexes[namespace]; ok {
+				root = entry.Path
+			}
+		}
+		if root == "" {
+			var err error
+			root, err = os.Getwd()
+			if err != nil {
+				return nil, nil, fmt.Errorf("resolve current directory: %w", err)
+			}
+		}
+		dbPath = semanticmemory.DefaultPath(root, namespace)
+	}
+
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return knowledgegraph.NewQuerier(store, namespace), store.Close, nil
+}

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -75,7 +75,7 @@ var graphExplainCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer closeStore()
+		defer func() { _ = closeStore() }()
 		ctx := context.Background()
 		if graphJSON {
 			node, err := q.Resolve(ctx, args[0])
@@ -106,7 +106,7 @@ var graphPathCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer closeStore()
+		defer func() { _ = closeStore() }()
 		ctx := context.Background()
 		if graphJSON {
 			hops, err := q.PathHops(ctx, args[0], args[1])
@@ -135,7 +135,7 @@ var graphQueryCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer closeStore()
+		defer func() { _ = closeStore() }()
 		ctx := context.Background()
 		if graphJSON {
 			seeds, err := q.FindNodes(ctx, args[0], 5)
@@ -166,7 +166,7 @@ var graphStatsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer closeStore()
+		defer func() { _ = closeStore() }()
 		out, err := q.Stats(context.Background())
 		if err != nil {
 			return err
@@ -185,7 +185,7 @@ var graphExportCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer closeStore()
+		defer func() { _ = closeStore() }()
 		exported, err := q.Export(context.Background())
 		if err != nil {
 			return err

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -25,6 +25,7 @@ var (
 	indexForce          bool
 	indexEnhance        bool
 	indexEnhanceModel   string
+	indexGraph          bool
 	indexMaxFiles       int
 	indexMaxFilesPerDir int
 
@@ -176,6 +177,7 @@ func init() {
 	captureCmd.Flags().BoolVar(&indexForce, "force", false, "Overwrite existing index")
 	captureCmd.Flags().BoolVar(&indexEnhance, "enhance", false, "Run a second-pass AI macro analysis using default_generation_model")
 	captureCmd.Flags().StringVar(&indexEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+	captureCmd.Flags().BoolVar(&indexGraph, "graph", false, "Also build a knowledge graph into semantic memory (namespace = index name)")
 	captureCmd.Flags().IntVar(&indexMaxFiles, "max-files", codebaseindex.DefaultMaxFiles, "Max source files included in the index (0 = unlimited)")
 	captureCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
 
@@ -183,6 +185,7 @@ func init() {
 	updateCmd.Flags().BoolVar(&updateFull, "full", false, "Force full regeneration")
 	updateCmd.Flags().BoolVar(&indexEnhance, "enhance", false, "Run a second-pass AI macro analysis during update")
 	updateCmd.Flags().StringVar(&indexEnhanceModel, "enhance-model", "", "Model for --enhance (default: configured default_generation_model)")
+	updateCmd.Flags().BoolVar(&indexGraph, "graph", false, "Also rebuild the knowledge graph in semantic memory")
 	updateCmd.Flags().IntVar(&indexMaxFiles, "max-files", codebaseindex.DefaultMaxFiles, "Max source files included in the index (0 = unlimited)")
 	updateCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
 
@@ -328,6 +331,13 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		log.Printf("Index was generated at: %s\n", result.OutputPath)
 	} else {
 		log.Printf("Index registered as '%s'\n", name)
+	}
+
+	// Optionally build the knowledge graph into semantic memory
+	if indexGraph {
+		if err := buildKnowledgeGraph(name, absPath, indexEnhance, indexEnhanceModel); err != nil {
+			log.Printf("Warning: knowledge graph build failed: %v\n", err)
+		}
 	}
 
 	// Print summary
@@ -510,6 +520,13 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	// Update registry
 	if err := registerIndex(name, entry.Path, result, manager.GetConfig()); err != nil {
 		log.Printf("Warning: failed to update registry: %v\n", err)
+	}
+
+	// Optionally rebuild the knowledge graph
+	if indexGraph {
+		if err := buildKnowledgeGraph(name, entry.Path, indexEnhance, indexEnhanceModel); err != nil {
+			log.Printf("Warning: knowledge graph rebuild failed: %v\n", err)
+		}
 	}
 
 	log.Printf("\nIndex updated:")

--- a/docs/design/knowledge-graph.md
+++ b/docs/design/knowledge-graph.md
@@ -1,0 +1,89 @@
+# Knowledge Graphs
+
+Comanda can turn a codebase index into a knowledge graph and store it in the
+semantic memory database, inspired by [Graphify](https://github.com/Graphify-Labs/graphify).
+
+The pipeline:
+
+```
+comanda index capture  →  outline (components, packages, files, symbols)
+comanda graph build    →  typed nodes + edges in .comanda/memory/<index>.db
+comanda graph query    →  traverse instead of grep
+```
+
+## Graph model
+
+- **Nodes** — `component`, `package`, `file`, `type`, `function`, `concept`
+  (concepts come only from the optional AI pass).
+- **Edges** — `contains`, `belongs_to`, `imports`, `defines` (structural),
+  `uses`, `references` (semantic).
+- **Confidence** — every edge is tagged `extracted` (explicit in the source:
+  imports, declarations, component roots) or `inferred` (symbol-name
+  resolution or the AI pass). You always know what was read vs. guessed.
+
+## Building
+
+```bash
+# One shot: index + graph
+comanda index capture -n myproject --graph
+
+# Or later, from the registered index
+comanda graph build myproject
+comanda graph build myproject --enhance          # add AI-inferred concepts/edges
+comanda graph update myproject                   # rebuild from a fresh scan
+```
+
+`--graph` also works on `comanda index update`. Encrypted indexes are skipped
+(graph data is plain SQLite). The graph is rebuilt deterministically on each
+run — nodes and edges have stable IDs, so rebuilds upsert in place and stale
+nodes from deleted files are removed.
+
+The graph lives in the project's semantic memory database,
+`.comanda/memory/<index-name>.db`, in `graph_nodes` / `graph_edges` tables.
+Every node is additionally mirrored as a `graph_node` memory record, so
+`comanda memory search` and workflow recall see graph concepts.
+
+## Querying
+
+```bash
+comanda graph explain Store                  # node + connections, confidence-tagged
+comanda graph path main Store                # BFS shortest connection
+comanda graph query "what uses the store?"   # scoped subgraph for a question
+comanda graph stats                          # counts by kind + hub nodes
+comanda graph export -o graph.json           # graphify-style JSON
+```
+
+`-n <namespace>` selects a graph (default: the index registered for the
+current directory); `--db <path>` points at a specific database.
+`explain`, `path`, and `query` accept `--json`.
+
+## Workflow recall
+
+No new step type is needed — graph nodes are memory records:
+
+```yaml
+review:
+  input: STDIN
+  model: openai-codex
+  memory:
+    namespace: myproject
+    recall:
+      query: input
+      types: [graph_node, decision]
+      limit: 8
+  action: "Review this change; cite relevant graph node IDs."
+  output: STDOUT
+```
+
+## Design notes and limits
+
+- Symbol extraction reuses the codebaseindex language adapters (regex-based,
+  Go/Python/TypeScript/Flutter/Java) — no tree-sitter dependency. Edge
+  precision is lower than AST-based tools; the `inferred` tag makes that
+  explicit, and only type names defined exactly once in the scan participate
+  in inferred `uses` resolution.
+- Storage adds `graph_nodes` / `graph_edges` tables (plus a node FTS index) to
+  the existing semantic memory SQLite database — no new dependencies.
+- Hub ranking (`graph stats`) is computed at query time. Community detection,
+  HTML visualization, MCP serving, and a dedicated `knowledge_graph.use`
+  workflow step type are deliberately out of scope for v1.

--- a/examples/knowledge-graph/README.md
+++ b/examples/knowledge-graph/README.md
@@ -1,0 +1,39 @@
+# Knowledge Graph Examples
+
+Turn a codebase index into a traversable knowledge graph stored in semantic
+memory, then query the graph instead of grepping files. See the
+[design doc](../../docs/design/knowledge-graph.md) for the full model.
+
+## Build a graph
+
+```bash
+# Index + graph in one run
+comanda index capture -n myproject --graph
+
+# Or build/update from a registered index
+comanda graph build myproject
+comanda graph build myproject --enhance   # optional AI-inferred concepts/edges
+comanda graph update myproject
+```
+
+## Query it
+
+```bash
+comanda graph explain Store                # a node and its connections
+comanda graph path main Store              # shortest connection between nodes
+comanda graph query "what uses the store?" # scoped subgraph for a question
+comanda graph stats                        # counts and hub nodes
+comanda graph export -o graph.json         # graphify-style JSON export
+```
+
+Edges are confidence-tagged: `EXTRACTED` (explicit in the source) vs.
+`INFERRED` (name resolution or the AI pass).
+
+## Recall it in a workflow
+
+[graph-recall.yaml](graph-recall.yaml) shows a step that pulls relevant graph
+nodes into context through the standard semantic memory mapping:
+
+```bash
+git diff | comanda process examples/knowledge-graph/graph-recall.yaml
+```

--- a/examples/knowledge-graph/graph-recall.yaml
+++ b/examples/knowledge-graph/graph-recall.yaml
@@ -1,0 +1,24 @@
+# Knowledge-graph recall. Build the graph first:
+#
+#   comanda index capture -n myproject --graph
+#   # or: comanda graph build myproject
+#
+# Graph nodes live in the semantic memory database as graph_node records, so a
+# normal memory mapping recalls them. Ask questions with `comanda graph query`
+# / `explain` / `path` for full traversal.
+
+explain_change:
+  input: STDIN
+  model: openai-codex
+  memory:
+    namespace: myproject
+    recall:
+      query: input
+      limit: 8
+      max_chars: 6000
+      types: [graph_node]
+  action: |
+    Explain how this change fits into the codebase. Treat recalled graph nodes
+    as a map of the surrounding structure (files, packages, types) and cite
+    node IDs when you rely on them.
+  output: STDOUT

--- a/utils/codebaseindex/manager.go
+++ b/utils/codebaseindex/manager.go
@@ -43,21 +43,21 @@ func NewManager(config *Config, verbose bool) (*Manager, error) {
 	return m, nil
 }
 
-// Generate creates the codebase index
-func (m *Manager) Generate() (*Result, error) {
-	startTime := time.Now()
-
-	m.logf("Starting codebase index generation for: %s", m.config.Root)
-
+// Scan runs the deterministic front half of index generation — adapter
+// detection, repository scan, symbol extraction, and component analysis —
+// without synthesizing markdown. It returns the populated ScanResult and the
+// detected language names. Knowledge-graph building and other consumers use
+// this to get structured data without producing an index file.
+func (m *Manager) Scan() (*ScanResult, []string, error) {
 	// Check if root path exists
 	if _, err := os.Stat(m.config.Root); os.IsNotExist(err) {
-		return nil, fmt.Errorf("repository path does not exist: %s", m.config.Root)
+		return nil, nil, fmt.Errorf("repository path does not exist: %s", m.config.Root)
 	}
 
 	// Step 1: Detect or use specified adapters
 	m.adapters = m.detectAdapters()
 	if len(m.adapters) == 0 {
-		return nil, fmt.Errorf("no language adapters detected for repository at %s (supported: Go, Python, TypeScript, Flutter, Java)", m.config.Root)
+		return nil, nil, fmt.Errorf("no language adapters detected for repository at %s (supported: Go, Python, TypeScript, Flutter, Java)", m.config.Root)
 	}
 
 	languages := make([]string, len(m.adapters))
@@ -70,19 +70,33 @@ func (m *Manager) Generate() (*Result, error) {
 	m.logf("Scanning repository...")
 	scanResult, err := m.scanRepository()
 	if err != nil {
-		return nil, fmt.Errorf("scan failed: %w", err)
+		return nil, nil, fmt.Errorf("scan failed: %w", err)
 	}
 	m.logf("Found %d files, selected %d candidates", scanResult.TotalFiles, len(scanResult.Candidates))
 
 	// Step 3: Extract symbols from candidates
 	m.logf("Extracting symbols...")
 	if err := m.extractSymbols(scanResult.Candidates); err != nil {
-		return nil, fmt.Errorf("symbol extraction failed: %w", err)
+		return nil, nil, fmt.Errorf("symbol extraction failed: %w", err)
 	}
 
 	// Step 3b: Infer macro components after symbol extraction so monorepos retain
 	// frontend/backend/package boundaries in the generated index.
 	m.analyzeComponents(scanResult)
+
+	return scanResult, languages, nil
+}
+
+// Generate creates the codebase index
+func (m *Manager) Generate() (*Result, error) {
+	startTime := time.Now()
+
+	m.logf("Starting codebase index generation for: %s", m.config.Root)
+
+	scanResult, languages, err := m.Scan()
+	if err != nil {
+		return nil, err
+	}
 
 	// Step 4: Synthesize markdown
 	m.logf("Synthesizing index...")

--- a/utils/knowledgegraph/builder.go
+++ b/utils/knowledgegraph/builder.go
@@ -1,0 +1,416 @@
+package knowledgegraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+// minInferredNameLen bounds inferred `uses` resolution to names long enough to
+// avoid noise (I, T, err, ...).
+const minInferredNameLen = 3
+
+// Build constructs a knowledge graph from a codebaseindex scan. Everything it
+// emits is deterministic: structural edges are extracted from the scan, and
+// `uses` edges between files and uniquely-named types are inferred from symbol
+// name references.
+func Build(scan *codebaseindex.ScanResult, namespace string) *Graph {
+	g := NewGraph(namespace)
+
+	// Pass 1: file and package nodes, belongs_to edges.
+	for _, f := range scan.Candidates {
+		summary := fileSummary(f)
+		g.AddNode("file:"+f.Path, NodeFile, path.Base(f.Path), f.Path, symbolPackage(f), summary)
+		if pkg := symbolPackage(f); pkg != "" {
+			g.AddNode("pkg:"+pkg, NodePackage, pkg, "", pkg, "")
+			g.AddEdge(NodeID(namespace, "file:"+f.Path), NodeID(namespace, "pkg:"+pkg),
+				EdgeBelongsTo, ConfidenceExtracted, "package declaration")
+		}
+	}
+
+	// Pass 2: symbol nodes and defines edges.
+	for _, f := range scan.Candidates {
+		if f.Symbols == nil {
+			continue
+		}
+		fileID := NodeID(namespace, "file:"+f.Path)
+		for _, t := range f.Symbols.Types {
+			local := fmt.Sprintf("type:%s@%s", t.Name, f.Path)
+			summary := strings.TrimSpace(t.Kind + " " + t.Comments)
+			g.AddNode(local, NodeType, t.Name, f.Path, f.Symbols.Package, summary)
+			g.AddEdge(fileID, NodeID(namespace, local), EdgeDefines, ConfidenceExtracted, "type declaration")
+		}
+		for _, fn := range f.Symbols.Functions {
+			name := fn.Name
+			if fn.IsMethod && fn.Receiver != "" {
+				name = fn.Receiver + "." + fn.Name
+			}
+			local := fmt.Sprintf("func:%s@%s", name, f.Path)
+			g.AddNode(local, NodeFunction, name, f.Path, f.Symbols.Package, strings.TrimSpace(fn.Comments))
+			g.AddEdge(fileID, NodeID(namespace, local), EdgeDefines, ConfidenceExtracted, "function declaration")
+		}
+	}
+
+	// Pass 3: component contains edges.
+	for _, c := range scan.Components {
+		g.AddNode("component:"+c.Name, NodeComponent, c.Name, c.Root, "",
+			fmt.Sprintf("%s component (%d files)", c.Kind, c.FileCount))
+		componentID := NodeID(namespace, "component:"+c.Name)
+		for _, f := range scan.Candidates {
+			if f.Path == c.Root || strings.HasPrefix(f.Path, strings.TrimSuffix(c.Root, "/")+"/") {
+				g.AddEdge(componentID, NodeID(namespace, "file:"+f.Path), EdgeContains, ConfidenceExtracted, "component root")
+			}
+		}
+	}
+
+	// Pass 4: import edges. An import that resolves to a known local package
+	// links to that package node; anything else becomes an external package
+	// node so the graph keeps a record of third-party dependencies.
+	for _, f := range scan.Candidates {
+		if f.Symbols == nil {
+			continue
+		}
+		fileID := NodeID(namespace, "file:"+f.Path)
+		for _, imp := range f.Symbols.Imports {
+			target := resolveImport(g, namespace, imp)
+			g.AddEdge(fileID, target, EdgeImports, ConfidenceExtracted, "import "+imp)
+		}
+	}
+
+	// Pass 5: inferred uses edges from symbol name references.
+	inferUses(g, scan, namespace)
+
+	return g
+}
+
+// resolveImport maps an import string to a package node ID, creating the
+// package node when it is not defined locally.
+func resolveImport(g *Graph, namespace, imp string) string {
+	imp = strings.Trim(imp, "\"`")
+	if imp == "" {
+		return NodeID(namespace, "pkg:unknown")
+	}
+	// Local packages are keyed by their package clause name; the last path
+	// segment of an import usually matches it.
+	last := imp
+	if idx := strings.LastIndex(imp, "/"); idx >= 0 {
+		last = imp[idx+1:]
+	}
+	// Strip version suffixes like /v2 and dashed variants are kept as-is.
+	if id := NodeID(namespace, "pkg:"+last); g.Nodes[id] != nil {
+		return id
+	}
+	if id := NodeID(namespace, "pkg:"+imp); g.Nodes[id] != nil {
+		return id
+	}
+	g.AddNode("pkg:"+imp, NodePackage, imp, "", "", "external dependency")
+	return NodeID(namespace, "pkg:"+imp)
+}
+
+// inferUses links files to uniquely-named types they reference in function
+// signatures, receivers, and struct fields. These edges are tagged inferred:
+// the reference is a name match, not a resolved symbol.
+func inferUses(g *Graph, scan *codebaseindex.ScanResult, namespace string) {
+	// Registry of type names defined exactly once (ambiguous names are skipped).
+	type def struct {
+		nodeID  string
+		defFile string
+	}
+	counts := make(map[string]int)
+	defs := make(map[string]def)
+	for _, f := range scan.Candidates {
+		if f.Symbols == nil {
+			continue
+		}
+		for _, t := range f.Symbols.Types {
+			if len(t.Name) < minInferredNameLen {
+				continue
+			}
+			counts[t.Name]++
+			defs[t.Name] = def{nodeID: NodeID(namespace, fmt.Sprintf("type:%s@%s", t.Name, f.Path)), defFile: f.Path}
+		}
+	}
+
+	for _, f := range scan.Candidates {
+		if f.Symbols == nil {
+			continue
+		}
+		haystack := referenceText(f.Symbols)
+		if haystack == "" {
+			continue
+		}
+		fileID := NodeID(namespace, "file:"+f.Path)
+		for name, d := range defs {
+			if counts[name] != 1 || d.defFile == f.Path {
+				continue
+			}
+			if wordMatch(haystack, name) {
+				g.AddEdge(fileID, d.nodeID, EdgeUses, ConfidenceInferred, "references "+name)
+			}
+		}
+	}
+}
+
+// referenceText flattens the parts of a file's symbols that can mention other
+// types: signatures, receivers, fields, and method lists.
+func referenceText(s *codebaseindex.SymbolInfo) string {
+	var b strings.Builder
+	for _, fn := range s.Functions {
+		b.WriteString(fn.Signature)
+		b.WriteString(" ")
+		b.WriteString(fn.Receiver)
+		b.WriteString(" ")
+	}
+	for _, t := range s.Types {
+		for _, field := range t.Fields {
+			b.WriteString(field)
+			b.WriteString(" ")
+		}
+		for _, method := range t.Methods {
+			b.WriteString(method)
+			b.WriteString(" ")
+		}
+	}
+	return b.String()
+}
+
+var wordBoundary = regexp.MustCompile(`[\p{L}\p{N}_]`)
+
+// wordMatch reports whether name appears in text as a whole word.
+func wordMatch(text, name string) bool {
+	idx := 0
+	for {
+		i := strings.Index(text[idx:], name)
+		if i < 0 {
+			return false
+		}
+		start := idx + i
+		end := start + len(name)
+		leftOK := start == 0 || !wordBoundary.MatchString(text[start-1:start])
+		rightOK := end == len(text) || !wordBoundary.MatchString(text[end:end+1])
+		if leftOK && rightOK {
+			return true
+		}
+		idx = start + 1
+	}
+}
+
+func symbolPackage(f *codebaseindex.FileEntry) string {
+	if f.Symbols == nil {
+		return ""
+	}
+	return f.Symbols.Package
+}
+
+func fileSummary(f *codebaseindex.FileEntry) string {
+	if f.Symbols == nil {
+		return f.Language + " file"
+	}
+	parts := []string{}
+	if f.Symbols.Package != "" {
+		parts = append(parts, "package "+f.Symbols.Package)
+	}
+	if n := len(f.Symbols.Types); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d types", n))
+	}
+	if n := len(f.Symbols.Functions); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d functions", n))
+	}
+	if len(parts) == 0 {
+		return f.Language + " file"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// EnhanceFunc matches the index enhancement hook signature: it takes a prompt
+// and returns the model's response.
+type EnhanceFunc func(prompt string) (string, error)
+
+// llmGraph is the JSON shape the enhancement pass is asked to produce.
+type llmGraph struct {
+	Nodes []struct {
+		Name    string `json:"name"`
+		Summary string `json:"summary"`
+	} `json:"nodes"`
+	Edges []struct {
+		Source   string `json:"source"`
+		Target   string `json:"target"`
+		Kind     string `json:"kind"`
+		Evidence string `json:"evidence"`
+	} `json:"edges"`
+}
+
+// Enhance asks a model for concept nodes and semantic edges over the existing
+// graph outline. Everything it adds is tagged inferred. A malformed response
+// is an error for the caller to warn about, never a partial mutation.
+func Enhance(g *Graph, fn EnhanceFunc) error {
+	prompt := buildEnhancePrompt(g)
+	response, err := fn(prompt)
+	if err != nil {
+		return fmt.Errorf("enhancement model call failed: %w", err)
+	}
+
+	var parsed llmGraph
+	if err := json.Unmarshal([]byte(stripCodeFence(response)), &parsed); err != nil {
+		return fmt.Errorf("enhancement response was not valid JSON: %w", err)
+	}
+
+	for _, n := range parsed.Nodes {
+		name := strings.TrimSpace(n.Name)
+		if name == "" {
+			continue
+		}
+		g.AddNode("concept:"+slug(name), NodeConcept, name, "", "", strings.TrimSpace(n.Summary))
+	}
+
+	// Edges resolve endpoints by node name. Exact case matches win, then more
+	// specific kinds (a type named "Store" beats a package named "store").
+	byNameExact := make(map[string]string, len(g.Nodes))
+	byNameLower := make(map[string]string, len(g.Nodes))
+	sorted := make([]*semanticmemory.GraphNode, 0, len(g.Nodes))
+	for _, node := range g.Nodes {
+		sorted = append(sorted, node)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		pi, pj := resolvePriority(sorted[i].Kind), resolvePriority(sorted[j].Kind)
+		if pi != pj {
+			return pi < pj
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+	for _, node := range sorted {
+		if _, taken := byNameExact[node.Name]; !taken {
+			byNameExact[node.Name] = node.ID
+		}
+		key := strings.ToLower(node.Name)
+		if _, taken := byNameLower[key]; !taken {
+			byNameLower[key] = node.ID
+		}
+	}
+	resolveName := func(name string) (string, bool) {
+		if id, ok := byNameExact[name]; ok {
+			return id, true
+		}
+		id, ok := byNameLower[strings.ToLower(name)]
+		return id, ok
+	}
+	for _, e := range parsed.Edges {
+		kind := strings.ToLower(strings.TrimSpace(e.Kind))
+		if kind != EdgeUses && kind != EdgeReference {
+			continue
+		}
+		src, okSrc := resolveName(strings.TrimSpace(e.Source))
+		tgt, okTgt := resolveName(strings.TrimSpace(e.Target))
+		if !okSrc || !okTgt {
+			continue
+		}
+		g.AddEdge(src, tgt, kind, ConfidenceInferred, strings.TrimSpace(e.Evidence))
+	}
+	return nil
+}
+
+// resolvePriority ranks node kinds for name resolution: lower wins.
+func resolvePriority(kind string) int {
+	switch kind {
+	case NodeConcept:
+		return 0
+	case NodeType:
+		return 1
+	case NodeFunction:
+		return 2
+	case NodeComponent:
+		return 3
+	case NodeFile:
+		return 4
+	default: // package and anything else
+		return 5
+	}
+}
+
+// maxEnhanceNodes bounds how much of the outline is sent to the model.
+const maxEnhanceNodes = 150
+
+func buildEnhancePrompt(g *Graph) string {
+	var b strings.Builder
+	b.WriteString("You are enriching a knowledge graph extracted from a codebase. ")
+	b.WriteString("Below are the known nodes (format: name [kind]).\n\n")
+	count := 0
+	for _, node := range g.Nodes {
+		if count >= maxEnhanceNodes {
+			fmt.Fprintf(&b, "... and %d more nodes\n", len(g.Nodes)-count)
+			break
+		}
+		fmt.Fprintf(&b, "- %s [%s]\n", node.Name, node.Kind)
+		count++
+	}
+	b.WriteString(`
+Respond with JSON only (no prose, no code fences) in this exact shape:
+{
+  "nodes": [{"name": "Concept Name", "summary": "one sentence"}],
+  "edges": [{"source": "Node Name", "target": "Node Name", "kind": "references", "evidence": "why"}]
+}
+Rules:
+- "nodes" are high-level concepts, subsystems, or cross-cutting concerns (at most 10).
+- "edges" connect EXISTING node names or new concept nodes; kind is "references" or "uses".
+- Only add edges you are confident about.`)
+	return b.String()
+}
+
+func stripCodeFence(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "```") {
+		if idx := strings.Index(s, "\n"); idx >= 0 {
+			s = s[idx+1:]
+		}
+		s = strings.TrimSuffix(strings.TrimSpace(s), "```")
+	}
+	return strings.TrimSpace(s)
+}
+
+func slug(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+		} else if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// Save persists a graph into the semantic memory store, upserting all nodes
+// and edges and refreshing degree counts. It does not delete stale nodes; use
+// Rebuild for a clean slate.
+func Save(ctx context.Context, store *semanticmemory.Store, g *Graph) error {
+	for _, node := range g.Nodes {
+		if _, err := store.UpsertGraphNode(ctx, *node); err != nil {
+			return err
+		}
+	}
+	for _, edge := range g.Edges {
+		if _, err := store.UpsertGraphEdge(ctx, *edge); err != nil {
+			return err
+		}
+	}
+	return store.RefreshGraphDegrees(ctx, g.Namespace)
+}
+
+// Rebuild replaces the stored graph for a namespace with the given one.
+func Rebuild(ctx context.Context, store *semanticmemory.Store, g *Graph) error {
+	if err := store.DeleteGraphNamespace(ctx, g.Namespace); err != nil {
+		return err
+	}
+	return Save(ctx, store, g)
+}

--- a/utils/knowledgegraph/knowledgegraph_test.go
+++ b/utils/knowledgegraph/knowledgegraph_test.go
@@ -1,0 +1,225 @@
+package knowledgegraph
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+func fixtureScan() *codebaseindex.ScanResult {
+	return &codebaseindex.ScanResult{
+		Candidates: []*codebaseindex.FileEntry{
+			{
+				Path:     "cmd/server.go",
+				Language: "go",
+				Symbols: &codebaseindex.SymbolInfo{
+					Package: "cmd",
+					Imports: []string{"github.com/acme/proj/utils/store", "fmt"},
+					Functions: []codebaseindex.FunctionInfo{
+						{Name: "main", Signature: "func main()"},
+						{Name: "Run", Signature: "func Run(s *store.Store) error", IsExported: true},
+					},
+				},
+			},
+			{
+				Path:     "utils/store/store.go",
+				Language: "go",
+				Symbols: &codebaseindex.SymbolInfo{
+					Package: "store",
+					Types: []codebaseindex.TypeInfo{
+						{Name: "Store", Kind: "struct", IsExported: true, Fields: []string{"db *sql.DB"}},
+					},
+					Functions: []codebaseindex.FunctionInfo{
+						{Name: "Open", Signature: "func Open(path string) (*Store, error)", IsExported: true},
+					},
+				},
+			},
+		},
+		Components: []*codebaseindex.CodebaseComponent{
+			{Name: "cli", Root: "cmd", Kind: "cli", FileCount: 1},
+		},
+	}
+}
+
+func TestBuildDeterministicEdges(t *testing.T) {
+	g := Build(fixtureScan(), "proj")
+
+	// File, package, type, function, component, and external package nodes.
+	for _, local := range []string{
+		"file:cmd/server.go", "file:utils/store/store.go",
+		"pkg:cmd", "pkg:store", "pkg:fmt",
+		"type:Store@utils/store/store.go",
+		"func:Open@utils/store/store.go",
+		"component:cli",
+	} {
+		if g.Nodes[NodeID("proj", local)] == nil {
+			t.Errorf("missing node %s", local)
+		}
+	}
+
+	// belongs_to, defines, contains, imports edges are extracted.
+	expect := []struct {
+		src, tgt, kind string
+	}{
+		{"file:cmd/server.go", "pkg:cmd", EdgeBelongsTo},
+		{"file:utils/store/store.go", "type:Store@utils/store/store.go", EdgeDefines},
+		{"component:cli", "file:cmd/server.go", EdgeContains},
+		{"file:cmd/server.go", "pkg:store", EdgeImports}, // resolves to local package
+		{"file:cmd/server.go", "pkg:fmt", EdgeImports},   // external package node
+	}
+	for _, e := range expect {
+		id := EdgeID("proj", NodeID("proj", e.src), NodeID("proj", e.tgt), e.kind)
+		edge := g.Edges[id]
+		if edge == nil {
+			t.Errorf("missing edge %s -%s-> %s", e.src, e.kind, e.tgt)
+			continue
+		}
+		if edge.Confidence != ConfidenceExtracted {
+			t.Errorf("edge %s -%s-> %s confidence = %s, want extracted", e.src, e.kind, e.tgt, edge.Confidence)
+		}
+	}
+
+	// cmd/server.go references store.Store in a signature -> inferred uses.
+	usesID := EdgeID("proj", NodeID("proj", "file:cmd/server.go"), NodeID("proj", "type:Store@utils/store/store.go"), EdgeUses)
+	uses := g.Edges[usesID]
+	if uses == nil {
+		t.Fatal("missing inferred uses edge from server.go to Store")
+	}
+	if uses.Confidence != ConfidenceInferred {
+		t.Fatalf("uses edge confidence = %s, want inferred", uses.Confidence)
+	}
+}
+
+func TestEnhanceAddsConceptNodes(t *testing.T) {
+	g := Build(fixtureScan(), "proj")
+	fakeLLM := func(prompt string) (string, error) {
+		return "```json\n" + `{
+          "nodes": [{"name": "Persistence", "summary": "Storage layer concern"}],
+          "edges": [
+            {"source": "Persistence", "target": "Store", "kind": "references", "evidence": "Store persists data"},
+            {"source": "main", "target": "Store", "kind": "deletes", "evidence": "bad kind"},
+            {"source": "Nobody", "target": "Store", "kind": "uses", "evidence": "unresolvable"}
+          ]
+        }` + "\n```", nil
+	}
+	if err := Enhance(g, fakeLLM); err != nil {
+		t.Fatal(err)
+	}
+
+	concept := g.Nodes[NodeID("proj", "concept:persistence")]
+	if concept == nil {
+		t.Fatal("concept node not added")
+	}
+	edgeID := EdgeID("proj", concept.ID, NodeID("proj", "type:Store@utils/store/store.go"), EdgeReference)
+	if g.Edges[edgeID] == nil {
+		t.Fatal("concept references edge not added")
+	}
+	// Bad kind and unresolvable endpoints are skipped.
+	for _, e := range g.Edges {
+		if e.Kind == "deletes" {
+			t.Fatal("edge with unsupported kind was added")
+		}
+		if strings.Contains(e.SourceID, "Nobody") {
+			t.Fatal("edge with unresolvable endpoint was added")
+		}
+	}
+}
+
+func TestEnhanceRejectsBadJSON(t *testing.T) {
+	g := Build(fixtureScan(), "proj")
+	if err := Enhance(g, func(string) (string, error) { return "not json", nil }); err == nil {
+		t.Fatal("expected error for malformed enhancement response")
+	}
+}
+
+func openTestStore(t *testing.T) *semanticmemory.Store {
+	t.Helper()
+	store, err := semanticmemory.Open(filepath.Join(t.TempDir(), "memory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestSaveRebuildAndQuery(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	g := Build(fixtureScan(), "proj")
+	if err := Rebuild(ctx, store, g); err != nil {
+		t.Fatal(err)
+	}
+
+	q := NewQuerier(store, "proj")
+
+	explain, err := q.Explain(ctx, "Store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(explain, "Node: Store") || !strings.Contains(explain, "[EXTRACTED]") {
+		t.Fatalf("unexpected explain output:\n%s", explain)
+	}
+
+	pathOut, err := q.Path(ctx, "cli", "Store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(pathOut, "Shortest path") {
+		t.Fatalf("unexpected path output:\n%s", pathOut)
+	}
+
+	stats, err := q.Stats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stats, "Hub nodes") {
+		t.Fatalf("unexpected stats output:\n%s", stats)
+	}
+
+	exported, err := q.Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Nodes) == 0 || len(exported.Edges) == 0 {
+		t.Fatal("export is empty")
+	}
+	if _, err := json.Marshal(exported); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rebuild replaces rather than duplicates.
+	before := len(exported.Nodes)
+	if err := Rebuild(ctx, store, Build(fixtureScan(), "proj")); err != nil {
+		t.Fatal(err)
+	}
+	after, err := q.Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.Nodes) != before {
+		t.Fatalf("rebuild duplicated nodes: before %d, after %d", before, len(after.Nodes))
+	}
+}
+
+func TestWordMatch(t *testing.T) {
+	cases := []struct {
+		text, name string
+		want       bool
+	}{
+		{"func Run(s *store.Store) error", "Store", true},
+		{"Storage layer", "Store", false},
+		{"func Open(path string)", "Store", false},
+		{"re *StoreManager", "Store", false}, // prefix of a longer identifier is not a word match
+	}
+	for _, c := range cases {
+		if got := wordMatch(c.text, c.name); got != c.want {
+			t.Errorf("wordMatch(%q, %q) = %v, want %v", c.text, c.name, got, c.want)
+		}
+	}
+}

--- a/utils/knowledgegraph/query.go
+++ b/utils/knowledgegraph/query.go
@@ -1,0 +1,407 @@
+package knowledgegraph
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+// Querier runs read-only graph questions against the semantic memory store.
+type Querier struct {
+	store     *semanticmemory.Store
+	namespace string
+}
+
+// NewQuerier binds a querier to a store and namespace.
+func NewQuerier(store *semanticmemory.Store, namespace string) *Querier {
+	return &Querier{store: store, namespace: namespace}
+}
+
+// resolve finds the single best node for a user-supplied name. Exact
+// case-sensitive matches win, then case-insensitive, then more specific kinds
+// (a type named "Store" beats a package named "store"), then FTS ranking.
+func (q *Querier) resolve(ctx context.Context, name string) (*semanticmemory.GraphNode, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("empty node name")
+	}
+	nodes, err := q.store.GraphFindNodes(ctx, q.namespace, name, 10)
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no graph node matches %q", name)
+	}
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return resolvePriority(nodes[i].Kind) < resolvePriority(nodes[j].Kind)
+	})
+	for i := range nodes {
+		if nodes[i].Name == name {
+			return &nodes[i], nil
+		}
+	}
+	for i := range nodes {
+		if strings.EqualFold(nodes[i].Name, name) {
+			return &nodes[i], nil
+		}
+	}
+	return &nodes[0], nil
+}
+
+// Explain renders a node and its connections, grouped by edge kind, with
+// confidence tags. Mirrors `graphify explain`.
+func (q *Querier) Explain(ctx context.Context, name string) (string, error) {
+	node, err := q.resolve(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	edges, neighbors, err := q.store.GraphNeighbors(ctx, q.namespace, node.ID)
+	if err != nil {
+		return "", err
+	}
+	byID := make(map[string]semanticmemory.GraphNode, len(neighbors))
+	for _, n := range neighbors {
+		byID[n.ID] = n
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Node: %s\n", NodeLabel(node))
+	if node.Package != "" {
+		fmt.Fprintf(&b, "  Package: %s\n", node.Package)
+	}
+	if node.Summary != "" {
+		fmt.Fprintf(&b, "  Summary: %s\n", node.Summary)
+	}
+	fmt.Fprintf(&b, "  Degree:  %d\n", node.Degree)
+	if len(edges) == 0 {
+		b.WriteString("\nNo connections.\n")
+		return b.String(), nil
+	}
+
+	fmt.Fprintf(&b, "\nConnections (%d):\n", len(edges))
+	for _, edge := range edges {
+		other, ok := byID[edge.TargetID]
+		arrow := "-->"
+		if edge.SourceID == node.ID {
+			arrow = "-->"
+		} else {
+			other, ok = byID[edge.SourceID]
+			arrow = "<--"
+		}
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&b, "  %s %s [%s] [%s]\n", arrow, NodeLabel(&other), edge.Kind, strings.ToUpper(edge.Confidence))
+	}
+	return b.String(), nil
+}
+
+// Path finds the shortest connection between two nodes (edges traversed in
+// either direction) and renders the hop chain.
+func (q *Querier) Path(ctx context.Context, fromName, toName string) (string, error) {
+	from, to, hops, err := q.pathHops(ctx, fromName, toName)
+	if err != nil {
+		return "", err
+	}
+	if hops == nil {
+		return fmt.Sprintf("%s and %s resolve to the same node.\n", fromName, toName), nil
+	}
+	if len(hops) == 0 {
+		return fmt.Sprintf("No path between %s and %s.\n", NodeLabel(from), NodeLabel(to)), nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Shortest path (%d hops):\n", len(hops))
+	for _, hop := range hops {
+		fmt.Fprintf(&b, "  %s\n", hop)
+	}
+	return b.String(), nil
+}
+
+// pathHops resolves both names and returns the hop chain between them.
+// hops == nil means both names resolved to the same node; len(hops) == 0
+// means no path exists.
+func (q *Querier) pathHops(ctx context.Context, fromName, toName string) (*semanticmemory.GraphNode, *semanticmemory.GraphNode, []string, error) {
+	from, err := q.resolve(ctx, fromName)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	to, err := q.resolve(ctx, toName)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if from.ID == to.ID {
+		return from, to, nil, nil
+	}
+
+	edges, err := q.store.GraphEdges(ctx, q.namespace)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	nodes, err := q.store.GraphNodes(ctx, q.namespace)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	byID := make(map[string]semanticmemory.GraphNode, len(nodes))
+	for _, n := range nodes {
+		byID[n.ID] = n
+	}
+
+	// BFS over the undirected adjacency.
+	type step struct {
+		neighbor string
+		edge     semanticmemory.GraphEdge
+	}
+	adj := make(map[string][]step)
+	for _, e := range edges {
+		adj[e.SourceID] = append(adj[e.SourceID], step{neighbor: e.TargetID, edge: e})
+		adj[e.TargetID] = append(adj[e.TargetID], step{neighbor: e.SourceID, edge: e})
+	}
+	type parent struct {
+		node string
+		edge semanticmemory.GraphEdge
+	}
+	parents := map[string]parent{from.ID: {}}
+	queue := []string{from.ID}
+	found := false
+	for len(queue) > 0 && !found {
+		var next []string
+		for _, cur := range queue {
+			for _, s := range adj[cur] {
+				if _, seen := parents[s.neighbor]; seen {
+					continue
+				}
+				parents[s.neighbor] = parent{node: cur, edge: s.edge}
+				if s.neighbor == to.ID {
+					found = true
+					break
+				}
+				next = append(next, s.neighbor)
+			}
+			if found {
+				break
+			}
+		}
+		queue = next
+	}
+	if !found {
+		return from, to, []string{}, nil
+	}
+
+	// Walk back from target to source.
+	var chain []string
+	cur := to.ID
+	for cur != from.ID {
+		p := parents[cur]
+		fmtEdge := fmt.Sprintf("%s (%s)", p.edge.Kind, p.edge.Confidence)
+		chain = append([]string{fmt.Sprintf("%s --%s--> %s", nodeShortName(byID[p.node]), fmtEdge, nodeShortName(byID[cur]))}, chain...)
+		cur = p.node
+	}
+	return from, to, chain, nil
+}
+
+// maxQuerySeeds and maxQueryChars bound the scoped subgraph returned by Query.
+const (
+	maxQuerySeeds = 5
+	maxQueryChars = 6000
+)
+
+// Query answers a plain-language question with a scoped subgraph: the best
+// matching nodes plus their immediate connections, as compact markdown.
+func (q *Querier) Query(ctx context.Context, question string) (string, error) {
+	seeds, err := q.store.GraphFindNodes(ctx, q.namespace, question, maxQuerySeeds)
+	if err != nil {
+		return "", err
+	}
+	if len(seeds) == 0 {
+		return fmt.Sprintf("No graph nodes match %q.\n", question), nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Subgraph for %q (%d seed nodes):\n", question, len(seeds))
+	used := 0
+	for i := range seeds {
+		section, err := q.Explain(ctx, seeds[i].Name)
+		if err != nil {
+			continue
+		}
+		if used+len(section) > maxQueryChars {
+			break
+		}
+		b.WriteString("\n---\n")
+		b.WriteString(section)
+		used += len(section)
+	}
+	return b.String(), nil
+}
+
+// Stats summarizes the graph: counts by kind and the highest-degree hub nodes
+// (graphify's "god nodes").
+func (q *Querier) Stats(ctx context.Context) (string, error) {
+	nodes, err := q.store.GraphNodes(ctx, q.namespace)
+	if err != nil {
+		return "", err
+	}
+	edges, err := q.store.GraphEdges(ctx, q.namespace)
+	if err != nil {
+		return "", err
+	}
+
+	nodeKinds := make(map[string]int)
+	for _, n := range nodes {
+		nodeKinds[n.Kind]++
+	}
+	edgeKinds := make(map[string]int)
+	inferred := 0
+	for _, e := range edges {
+		edgeKinds[e.Kind]++
+		if e.Confidence == ConfidenceInferred {
+			inferred++
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Graph: %s\n", q.namespace)
+	fmt.Fprintf(&b, "Nodes: %d (%s)\n", len(nodes), kindBreakdown(nodeKinds))
+	fmt.Fprintf(&b, "Edges: %d (%s; %d inferred)\n", len(edges), kindBreakdown(edgeKinds), inferred)
+
+	const hubCount = 10
+	sorted := make([]semanticmemory.GraphNode, len(nodes))
+	copy(sorted, nodes)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Degree > sorted[j].Degree })
+	b.WriteString("\nHub nodes (most connected):\n")
+	for i, n := range sorted {
+		if i >= hubCount || n.Degree == 0 {
+			break
+		}
+		fmt.Fprintf(&b, "  %2d. %s — degree %d\n", i+1, NodeLabel(&n), n.Degree)
+	}
+	return b.String(), nil
+}
+
+// Export dumps the namespace graph in the graphify-style graph.json shape.
+func (q *Querier) Export(ctx context.Context) (*ExportGraph, error) {
+	nodes, err := q.store.GraphNodes(ctx, q.namespace)
+	if err != nil {
+		return nil, err
+	}
+	edges, err := q.store.GraphEdges(ctx, q.namespace)
+	if err != nil {
+		return nil, err
+	}
+	out := &ExportGraph{
+		Namespace: q.namespace,
+		Nodes:     make([]ExportNode, 0, len(nodes)),
+		Edges:     make([]ExportEdge, 0, len(edges)),
+	}
+	for _, n := range nodes {
+		out.Nodes = append(out.Nodes, ExportNode{
+			ID: LocalID(n.ID), Kind: n.Kind, Name: n.Name, Path: n.Path,
+			Package: n.Package, Summary: n.Summary, Degree: n.Degree,
+		})
+	}
+	for _, e := range edges {
+		out.Edges = append(out.Edges, ExportEdge{
+			Source: LocalID(e.SourceID), Target: LocalID(e.TargetID),
+			Kind: e.Kind, Confidence: e.Confidence, Evidence: e.Evidence,
+		})
+	}
+	return out, nil
+}
+
+// Resolve exposes node resolution for callers that need the matched node
+// itself (e.g. JSON output paths).
+func (q *Querier) Resolve(ctx context.Context, name string) (*semanticmemory.GraphNode, error) {
+	return q.resolve(ctx, name)
+}
+
+// FindNodes returns the best matching nodes for a plain-text query.
+func (q *Querier) FindNodes(ctx context.Context, query string, limit int) ([]semanticmemory.GraphNode, error) {
+	return q.store.GraphFindNodes(ctx, q.namespace, query, limit)
+}
+
+// PathHops returns the hop chain between two nodes for structured output.
+// An empty slice means no path; a nil slice means both names are the same node.
+func (q *Querier) PathHops(ctx context.Context, fromName, toName string) ([]string, error) {
+	_, _, hops, err := q.pathHops(ctx, fromName, toName)
+	return hops, err
+}
+
+// ScopedExport dumps the subgraph reachable within `hops` of the given seed
+// nodes, in the same shape as Export. Used for --json query/explain output.
+func (q *Querier) ScopedExport(ctx context.Context, seeds []semanticmemory.GraphNode, hops int) (*ExportGraph, error) {
+	if hops < 1 {
+		hops = 1
+	}
+	allEdges, err := q.store.GraphEdges(ctx, q.namespace)
+	if err != nil {
+		return nil, err
+	}
+	inScope := make(map[string]semanticmemory.GraphNode, len(seeds))
+	frontier := make(map[string]bool, len(seeds))
+	for _, n := range seeds {
+		inScope[n.ID] = n
+		frontier[n.ID] = true
+	}
+	var scopedEdges []semanticmemory.GraphEdge
+	for hop := 0; hop < hops; hop++ {
+		next := make(map[string]bool)
+		for _, e := range allEdges {
+			srcIn, tgtIn := frontier[e.SourceID], frontier[e.TargetID]
+			if !srcIn && !tgtIn {
+				continue
+			}
+			scopedEdges = append(scopedEdges, e)
+			for _, id := range []string{e.SourceID, e.TargetID} {
+				if _, seen := inScope[id]; !seen {
+					node, err := q.store.GetGraphNode(ctx, id)
+					if err != nil {
+						continue
+					}
+					inScope[id] = node
+				}
+				if !frontier[id] {
+					next[id] = true
+				}
+			}
+		}
+		frontier = next
+	}
+
+	out := &ExportGraph{Namespace: q.namespace, Nodes: []ExportNode{}, Edges: []ExportEdge{}}
+	for _, n := range inScope {
+		out.Nodes = append(out.Nodes, ExportNode{
+			ID: LocalID(n.ID), Kind: n.Kind, Name: n.Name, Path: n.Path,
+			Package: n.Package, Summary: n.Summary, Degree: n.Degree,
+		})
+	}
+	for _, e := range scopedEdges {
+		out.Edges = append(out.Edges, ExportEdge{
+			Source: LocalID(e.SourceID), Target: LocalID(e.TargetID),
+			Kind: e.Kind, Confidence: e.Confidence, Evidence: e.Evidence,
+		})
+	}
+	return out, nil
+}
+
+func kindBreakdown(counts map[string]int) string {
+	kinds := make([]string, 0, len(counts))
+	for k := range counts {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	parts := make([]string, 0, len(kinds))
+	for _, k := range kinds {
+		parts = append(parts, fmt.Sprintf("%s: %d", k, counts[k]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func nodeShortName(n semanticmemory.GraphNode) string {
+	if n.Name != "" {
+		return n.Name
+	}
+	return LocalID(n.ID)
+}

--- a/utils/knowledgegraph/types.go
+++ b/utils/knowledgegraph/types.go
@@ -1,0 +1,153 @@
+// Package knowledgegraph turns a codebaseindex scan into a typed,
+// confidence-tagged knowledge graph persisted in the semantic memory store.
+// Extraction is deterministic and local first (components, packages, files,
+// symbols, imports); an optional LLM pass can add inferred concept nodes and
+// edges. Inspired by github.com/Graphify-Labs/graphify.
+package knowledgegraph
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+// Node and edge kinds are re-exported from semanticmemory so callers use one
+// vocabulary end to end.
+const (
+	NodeComponent = semanticmemory.GraphNodeComponent
+	NodePackage   = semanticmemory.GraphNodePackage
+	NodeFile      = semanticmemory.GraphNodeFile
+	NodeType      = semanticmemory.GraphNodeType
+	NodeFunction  = semanticmemory.GraphNodeFunction
+	NodeConcept   = semanticmemory.GraphNodeConcept
+
+	EdgeContains  = semanticmemory.GraphEdgeContains
+	EdgeBelongsTo = semanticmemory.GraphEdgeBelongsTo
+	EdgeImports   = semanticmemory.GraphEdgeImports
+	EdgeDefines   = semanticmemory.GraphEdgeDefines
+	EdgeUses      = semanticmemory.GraphEdgeUses
+	EdgeReference = semanticmemory.GraphEdgeReference
+
+	ConfidenceExtracted = semanticmemory.GraphConfidenceExtracted
+	ConfidenceInferred  = semanticmemory.GraphConfidenceInferred
+)
+
+// Graph is an in-memory knowledge graph under construction.
+type Graph struct {
+	Namespace string
+	Nodes     map[string]*semanticmemory.GraphNode
+	Edges     map[string]*semanticmemory.GraphEdge
+}
+
+// NewGraph creates an empty graph for a namespace.
+func NewGraph(namespace string) *Graph {
+	return &Graph{
+		Namespace: namespace,
+		Nodes:     make(map[string]*semanticmemory.GraphNode),
+		Edges:     make(map[string]*semanticmemory.GraphEdge),
+	}
+}
+
+// NodeID builds a stable, namespace-qualified node ID so rebuilds upsert in
+// place and separate graphs never collide on the primary key.
+func NodeID(namespace, local string) string {
+	return namespace + "|" + local
+}
+
+// EdgeID builds a stable edge ID from its endpoints and kind.
+func EdgeID(namespace, sourceID, targetID, kind string) string {
+	sum := sha1.Sum([]byte(sourceID + ">" + targetID + "|" + kind))
+	return namespace + "|e" + hex.EncodeToString(sum[:8])
+}
+
+// AddNode inserts or replaces a node. The node's ID and namespace are set
+// from the local ID and graph namespace.
+func (g *Graph) AddNode(localID, kind, name, path, pkg, summary string) *semanticmemory.GraphNode {
+	id := NodeID(g.Namespace, localID)
+	node, ok := g.Nodes[id]
+	if !ok {
+		node = &semanticmemory.GraphNode{ID: id, Namespace: g.Namespace}
+		g.Nodes[id] = node
+	}
+	node.Kind = kind
+	node.Name = name
+	node.Path = path
+	node.Package = pkg
+	if summary != "" {
+		node.Summary = summary
+	}
+	return node
+}
+
+// AddEdge inserts an edge between two node IDs (already namespace-qualified).
+// Duplicate (source, target, kind) edges collapse; the first confidence wins
+// unless the existing one was inferred and the new one is extracted.
+func (g *Graph) AddEdge(sourceID, targetID, kind, confidence, evidence string) {
+	if sourceID == targetID {
+		return
+	}
+	id := EdgeID(g.Namespace, sourceID, targetID, kind)
+	if existing, ok := g.Edges[id]; ok {
+		if existing.Confidence == ConfidenceInferred && confidence == ConfidenceExtracted {
+			existing.Confidence = confidence
+			existing.Evidence = evidence
+		}
+		return
+	}
+	g.Edges[id] = &semanticmemory.GraphEdge{
+		ID:         id,
+		Namespace:  g.Namespace,
+		SourceID:   sourceID,
+		TargetID:   targetID,
+		Kind:       kind,
+		Confidence: confidence,
+		Evidence:   evidence,
+	}
+}
+
+// LocalID strips the namespace prefix from a stored node or edge ID.
+func LocalID(id string) string {
+	for i := len(id) - 1; i >= 0; i-- {
+		if id[i] == '|' {
+			return id[i+1:]
+		}
+	}
+	return id
+}
+
+// ExportNode is the JSON export shape for a node (graphify-style graph.json).
+type ExportNode struct {
+	ID      string `json:"id"`
+	Kind    string `json:"kind"`
+	Name    string `json:"name"`
+	Path    string `json:"path,omitempty"`
+	Package string `json:"package,omitempty"`
+	Summary string `json:"summary,omitempty"`
+	Degree  int    `json:"degree"`
+}
+
+// ExportEdge is the JSON export shape for an edge.
+type ExportEdge struct {
+	Source     string `json:"source"`
+	Target     string `json:"target"`
+	Kind       string `json:"kind"`
+	Confidence string `json:"confidence"`
+	Evidence   string `json:"evidence,omitempty"`
+}
+
+// ExportGraph is the top-level graph.json shape.
+type ExportGraph struct {
+	Namespace string       `json:"namespace"`
+	Nodes     []ExportNode `json:"nodes"`
+	Edges     []ExportEdge `json:"edges"`
+}
+
+// String renders a node for display.
+func NodeLabel(n *semanticmemory.GraphNode) string {
+	if n.Path != "" {
+		return fmt.Sprintf("%s (%s, %s)", n.Name, n.Kind, n.Path)
+	}
+	return fmt.Sprintf("%s (%s)", n.Name, n.Kind)
+}

--- a/utils/knowledgegraph/types.go
+++ b/utils/knowledgegraph/types.go
@@ -6,9 +6,8 @@
 package knowledgegraph
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 
 	"github.com/kris-hansen/comanda/utils/semanticmemory"
 )
@@ -56,10 +55,12 @@ func NodeID(namespace, local string) string {
 	return namespace + "|" + local
 }
 
-// EdgeID builds a stable edge ID from its endpoints and kind.
+// EdgeID builds a stable edge ID from its endpoints and kind. FNV-1a is used
+// for compactness; the ID is a dedup key, not a security primitive.
 func EdgeID(namespace, sourceID, targetID, kind string) string {
-	sum := sha1.Sum([]byte(sourceID + ">" + targetID + "|" + kind))
-	return namespace + "|e" + hex.EncodeToString(sum[:8])
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(sourceID + ">" + targetID + "|" + kind))
+	return fmt.Sprintf("%s|e%016x", namespace, h.Sum64())
 }
 
 // AddNode inserts or replaces a node. The node's ID and namespace are set

--- a/utils/semanticmemory/graph.go
+++ b/utils/semanticmemory/graph.go
@@ -1,0 +1,424 @@
+package semanticmemory
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Graph node kinds.
+const (
+	GraphNodeComponent = "component"
+	GraphNodePackage   = "package"
+	GraphNodeFile      = "file"
+	GraphNodeType      = "type"
+	GraphNodeFunction  = "function"
+	GraphNodeConcept   = "concept"
+)
+
+// Graph edge kinds.
+const (
+	GraphEdgeContains  = "contains"
+	GraphEdgeBelongsTo = "belongs_to"
+	GraphEdgeImports   = "imports"
+	GraphEdgeDefines   = "defines"
+	GraphEdgeUses      = "uses"
+	GraphEdgeReference = "references"
+)
+
+// Graph edge confidence tags: extracted edges are explicit in the source,
+// inferred edges come from name resolution or an LLM pass.
+const (
+	GraphConfidenceExtracted = "extracted"
+	GraphConfidenceInferred  = "inferred"
+)
+
+// graphMirrorRecordPrefix is the ID prefix for memory records that mirror
+// graph nodes into the FTS search path.
+const graphMirrorRecordPrefix = "gnode_"
+
+// graphMirrorSourceRef marks mirrored records so they can be cleaned up with
+// the graph namespace that produced them.
+func graphMirrorSourceRef(namespace string) string { return "graph/" + namespace }
+
+// GraphNode is one vertex in a knowledge graph stored alongside durable memory.
+type GraphNode struct {
+	ID        string
+	Namespace string
+	Kind      string
+	Name      string
+	Path      string
+	Package   string
+	Summary   string
+	Degree    int
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// GraphEdge is one typed, confidence-tagged connection between two nodes.
+type GraphEdge struct {
+	ID         string
+	Namespace  string
+	SourceID   string
+	TargetID   string
+	Kind       string
+	Confidence string
+	Evidence   string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+var graphMigrateStatements = []string{
+	`CREATE TABLE IF NOT EXISTS graph_nodes (
+        id TEXT PRIMARY KEY,
+        namespace TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL DEFAULT '',
+        package TEXT NOT NULL DEFAULT '',
+        summary TEXT NOT NULL DEFAULT '',
+        degree INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )`,
+	`CREATE INDEX IF NOT EXISTS idx_graph_nodes_namespace_name ON graph_nodes(namespace, name)`,
+	`CREATE VIRTUAL TABLE IF NOT EXISTS graph_nodes_fts USING fts5(
+        id UNINDEXED,
+        namespace UNINDEXED,
+        name,
+        summary,
+        tokenize='unicode61'
+    )`,
+	`CREATE TABLE IF NOT EXISTS graph_edges (
+        id TEXT PRIMARY KEY,
+        namespace TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        confidence TEXT NOT NULL DEFAULT 'extracted',
+        evidence TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )`,
+	`CREATE INDEX IF NOT EXISTS idx_graph_edges_namespace_source ON graph_edges(namespace, source_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_graph_edges_namespace_target ON graph_edges(namespace, target_id)`,
+}
+
+// UpsertGraphNode writes a graph node, refreshes its FTS entry, and mirrors it
+// as a memory record (type graph_node) so memory search and workflow recall
+// can find graph concepts. Callers should pass a stable ID so rebuilds update
+// in place instead of duplicating.
+func (s *Store) UpsertGraphNode(ctx context.Context, node GraphNode) (GraphNode, error) {
+	node.Namespace = normalizeNamespace(node.Namespace)
+	node.Kind = strings.TrimSpace(strings.ToLower(node.Kind))
+	node.Name = strings.TrimSpace(node.Name)
+	if node.ID == "" {
+		return GraphNode{}, fmt.Errorf("graph node ID is required")
+	}
+	if node.Name == "" {
+		return GraphNode{}, fmt.Errorf("graph node name is required")
+	}
+	now := time.Now().UTC()
+	if node.CreatedAt.IsZero() {
+		node.CreatedAt = now
+	}
+	node.UpdatedAt = now
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return GraphNode{}, fmt.Errorf("start graph node transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `INSERT INTO graph_nodes (
+        id, namespace, kind, name, path, package, summary, degree, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+        namespace=excluded.namespace, kind=excluded.kind, name=excluded.name,
+        path=excluded.path, package=excluded.package, summary=excluded.summary,
+        updated_at=excluded.updated_at`,
+		node.ID, node.Namespace, node.Kind, node.Name, node.Path, node.Package, node.Summary,
+		node.Degree, node.CreatedAt.Format(time.RFC3339Nano), node.UpdatedAt.Format(time.RFC3339Nano))
+	if err != nil {
+		return GraphNode{}, fmt.Errorf("write graph node: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM graph_nodes_fts WHERE id = ?`, node.ID); err != nil {
+		return GraphNode{}, fmt.Errorf("refresh graph node index: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO graph_nodes_fts(id, namespace, name, summary) VALUES (?, ?, ?, ?)`,
+		node.ID, node.Namespace, node.Name, node.Summary); err != nil {
+		return GraphNode{}, fmt.Errorf("index graph node: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return GraphNode{}, fmt.Errorf("commit graph node transaction: %w", err)
+	}
+
+	// Mirror into durable memory so FTS search/recall sees graph concepts.
+	content := node.Name
+	if node.Summary != "" {
+		content = node.Name + " — " + node.Summary
+	}
+	if _, err := s.Upsert(ctx, Record{
+		ID:        graphMirrorRecordPrefix + node.ID,
+		Namespace: node.Namespace,
+		Type:      "graph_node",
+		Content:   content,
+		SourceRef: graphMirrorSourceRef(node.Namespace),
+	}); err != nil {
+		return GraphNode{}, fmt.Errorf("mirror graph node into memory: %w", err)
+	}
+	return node, nil
+}
+
+// UpsertGraphEdge writes a graph edge. Callers should pass a stable ID derived
+// from (source, target, kind) so rebuilds update in place.
+func (s *Store) UpsertGraphEdge(ctx context.Context, edge GraphEdge) (GraphEdge, error) {
+	edge.Namespace = normalizeNamespace(edge.Namespace)
+	edge.Kind = strings.TrimSpace(strings.ToLower(edge.Kind))
+	if edge.ID == "" {
+		return GraphEdge{}, fmt.Errorf("graph edge ID is required")
+	}
+	if edge.SourceID == "" || edge.TargetID == "" {
+		return GraphEdge{}, fmt.Errorf("graph edge source and target are required")
+	}
+	if edge.Confidence == "" {
+		edge.Confidence = GraphConfidenceExtracted
+	}
+	now := time.Now().UTC()
+	if edge.CreatedAt.IsZero() {
+		edge.CreatedAt = now
+	}
+	edge.UpdatedAt = now
+
+	_, err := s.db.ExecContext(ctx, `INSERT INTO graph_edges (
+        id, namespace, source_id, target_id, kind, confidence, evidence, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+        namespace=excluded.namespace, source_id=excluded.source_id, target_id=excluded.target_id,
+        kind=excluded.kind, confidence=excluded.confidence, evidence=excluded.evidence,
+        updated_at=excluded.updated_at`,
+		edge.ID, edge.Namespace, edge.SourceID, edge.TargetID, edge.Kind, edge.Confidence, edge.Evidence,
+		edge.CreatedAt.Format(time.RFC3339Nano), edge.UpdatedAt.Format(time.RFC3339Nano))
+	if err != nil {
+		return GraphEdge{}, fmt.Errorf("write graph edge: %w", err)
+	}
+	return edge, nil
+}
+
+// RefreshGraphDegrees recomputes the degree column for every node in a
+// namespace from the current edge set. Call once after a batch of edge writes.
+func (s *Store) RefreshGraphDegrees(ctx context.Context, namespace string) error {
+	namespace = normalizeNamespace(namespace)
+	_, err := s.db.ExecContext(ctx, `UPDATE graph_nodes SET degree = (
+        SELECT COUNT(*) FROM graph_edges
+        WHERE graph_edges.namespace = graph_nodes.namespace
+          AND (graph_edges.source_id = graph_nodes.id OR graph_edges.target_id = graph_nodes.id)
+    ) WHERE namespace = ?`, namespace)
+	if err != nil {
+		return fmt.Errorf("refresh graph degrees: %w", err)
+	}
+	return nil
+}
+
+// GetGraphNode returns a graph node by ID.
+func (s *Store) GetGraphNode(ctx context.Context, id string) (GraphNode, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, namespace, kind, name, path, package, summary, degree, created_at, updated_at
+        FROM graph_nodes WHERE id = ?`, id)
+	return scanGraphNode(row)
+}
+
+// GraphNodes returns all nodes in a namespace.
+func (s *Store) GraphNodes(ctx context.Context, namespace string) ([]GraphNode, error) {
+	namespace = normalizeNamespace(namespace)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, namespace, kind, name, path, package, summary, degree, created_at, updated_at
+        FROM graph_nodes WHERE namespace = ? ORDER BY degree DESC, name`, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("list graph nodes: %w", err)
+	}
+	defer rows.Close()
+	return collectGraphNodes(rows)
+}
+
+// GraphEdges returns all edges in a namespace.
+func (s *Store) GraphEdges(ctx context.Context, namespace string) ([]GraphEdge, error) {
+	namespace = normalizeNamespace(namespace)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, namespace, source_id, target_id, kind, confidence, evidence, created_at, updated_at
+        FROM graph_edges WHERE namespace = ?`, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("list graph edges: %w", err)
+	}
+	defer rows.Close()
+	return collectGraphEdges(rows)
+}
+
+// GraphNeighbors returns the edges touching a node (in either direction) and
+// the nodes at the other end of those edges.
+func (s *Store) GraphNeighbors(ctx context.Context, namespace, nodeID string) ([]GraphEdge, []GraphNode, error) {
+	namespace = normalizeNamespace(namespace)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, namespace, source_id, target_id, kind, confidence, evidence, created_at, updated_at
+        FROM graph_edges WHERE namespace = ? AND (source_id = ? OR target_id = ?)`, namespace, nodeID, nodeID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list graph neighbors: %w", err)
+	}
+	edges, err := collectGraphEdges(rows)
+	rows.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(edges) == 0 {
+		return edges, nil, nil
+	}
+
+	seen := make(map[string]bool, len(edges))
+	var ids []any
+	var placeholders []string
+	for _, edge := range edges {
+		other := edge.TargetID
+		if other == nodeID {
+			other = edge.SourceID
+		}
+		if !seen[other] {
+			seen[other] = true
+			ids = append(ids, other)
+			placeholders = append(placeholders, "?")
+		}
+	}
+	nodeRows, err := s.db.QueryContext(ctx, `SELECT id, namespace, kind, name, path, package, summary, degree, created_at, updated_at
+        FROM graph_nodes WHERE id IN (`+strings.Join(placeholders, ",")+`)`, ids...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load graph neighbor nodes: %w", err)
+	}
+	defer nodeRows.Close()
+	nodes, err := collectGraphNodes(nodeRows)
+	if err != nil {
+		return nil, nil, err
+	}
+	return edges, nodes, nil
+}
+
+// GraphFindNodes looks nodes up by name/summary with FTS5, degrading to a
+// LIKE search when the query cannot be expressed as FTS syntax.
+func (s *Store) GraphFindNodes(ctx context.Context, namespace, query string, limit int) ([]GraphNode, error) {
+	namespace = normalizeNamespace(namespace)
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	ftsQuery := buildFTSQuery(query)
+	if ftsQuery == "" {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT n.id, n.namespace, n.kind, n.name, n.path, n.package, n.summary, n.degree, n.created_at, n.updated_at
+        FROM graph_nodes_fts f JOIN graph_nodes n ON n.id = f.id
+        WHERE graph_nodes_fts MATCH ? AND n.namespace = ?
+        ORDER BY bm25(graph_nodes_fts), n.degree DESC LIMIT ?`, ftsQuery, namespace, limit)
+	if err == nil {
+		defer rows.Close()
+		return collectGraphNodes(rows)
+	}
+	rows, fallbackErr := s.db.QueryContext(ctx, `SELECT id, namespace, kind, name, path, package, summary, degree, created_at, updated_at
+        FROM graph_nodes WHERE namespace = ? AND (name LIKE ? OR summary LIKE ?)
+        ORDER BY degree DESC, name LIMIT ?`, namespace, "%"+strings.TrimSpace(query)+"%", "%"+strings.TrimSpace(query)+"%", limit)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("find graph nodes: %w", err)
+	}
+	defer rows.Close()
+	return collectGraphNodes(rows)
+}
+
+// DeleteGraphNamespace removes all nodes, edges, and mirrored memory records
+// for a namespace.
+func (s *Store) DeleteGraphNamespace(ctx context.Context, namespace string) error {
+	namespace = normalizeNamespace(namespace)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("start graph delete transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	statements := []struct {
+		query string
+		args  []any
+	}{
+		{`DELETE FROM graph_edges WHERE namespace = ?`, []any{namespace}},
+		{`DELETE FROM graph_nodes_fts WHERE namespace = ?`, []any{namespace}},
+		{`DELETE FROM graph_nodes WHERE namespace = ?`, []any{namespace}},
+		{`DELETE FROM memory_fts WHERE id IN (SELECT id FROM memories WHERE namespace = ? AND source_ref = ?)`,
+			[]any{namespace, graphMirrorSourceRef(namespace)}},
+		{`DELETE FROM memories WHERE namespace = ? AND source_ref = ?`, []any{namespace, graphMirrorSourceRef(namespace)}},
+	}
+	for _, stmt := range statements {
+		if _, err := tx.ExecContext(ctx, stmt.query, stmt.args...); err != nil {
+			return fmt.Errorf("delete graph namespace: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit graph delete transaction: %w", err)
+	}
+	return nil
+}
+
+func scanGraphNode(row rowScanner) (GraphNode, error) {
+	var node GraphNode
+	var createdAt, updatedAt string
+	if err := row.Scan(&node.ID, &node.Namespace, &node.Kind, &node.Name, &node.Path, &node.Package,
+		&node.Summary, &node.Degree, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return GraphNode{}, fmt.Errorf("graph node not found")
+		}
+		return GraphNode{}, err
+	}
+	node.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+	node.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+	return node, nil
+}
+
+func collectGraphNodes(rows *sql.Rows) ([]GraphNode, error) {
+	var nodes []GraphNode
+	for rows.Next() {
+		node, err := scanGraphNode(rows)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, node)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}
+
+func scanGraphEdge(row rowScanner) (GraphEdge, error) {
+	var edge GraphEdge
+	var createdAt, updatedAt string
+	if err := row.Scan(&edge.ID, &edge.Namespace, &edge.SourceID, &edge.TargetID, &edge.Kind,
+		&edge.Confidence, &edge.Evidence, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return GraphEdge{}, fmt.Errorf("graph edge not found")
+		}
+		return GraphEdge{}, err
+	}
+	edge.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+	edge.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+	return edge, nil
+}
+
+func collectGraphEdges(rows *sql.Rows) ([]GraphEdge, error) {
+	var edges []GraphEdge
+	for rows.Next() {
+		edge, err := scanGraphEdge(rows)
+		if err != nil {
+			return nil, err
+		}
+		edges = append(edges, edge)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return edges, nil
+}

--- a/utils/semanticmemory/graph.go
+++ b/utils/semanticmemory/graph.go
@@ -3,6 +3,7 @@ package semanticmemory
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -273,8 +274,7 @@ func (s *Store) GraphNeighbors(ctx context.Context, namespace, nodeID string) ([
 	}
 
 	seen := make(map[string]bool, len(edges))
-	var ids []any
-	var placeholders []string
+	var ids []string
 	for _, edge := range edges {
 		other := edge.TargetID
 		if other == nodeID {
@@ -283,11 +283,14 @@ func (s *Store) GraphNeighbors(ctx context.Context, namespace, nodeID string) ([
 		if !seen[other] {
 			seen[other] = true
 			ids = append(ids, other)
-			placeholders = append(placeholders, "?")
 		}
 	}
+	idsJSON, err := json.Marshal(ids)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode neighbor IDs: %w", err)
+	}
 	nodeRows, err := s.db.QueryContext(ctx, `SELECT id, namespace, kind, name, path, package, summary, degree, created_at, updated_at
-        FROM graph_nodes WHERE id IN (`+strings.Join(placeholders, ",")+`)`, ids...)
+        FROM graph_nodes WHERE id IN (SELECT value FROM json_each(?))`, string(idsJSON))
 	if err != nil {
 		return nil, nil, fmt.Errorf("load graph neighbor nodes: %w", err)
 	}

--- a/utils/semanticmemory/graph_test.go
+++ b/utils/semanticmemory/graph_test.go
@@ -1,0 +1,137 @@
+package semanticmemory
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestGraphNodeUpsertMirrorsIntoMemorySearch(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "memory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	node, err := store.UpsertGraphNode(ctx, GraphNode{
+		ID: "n1", Namespace: "repo", Kind: GraphNodeType,
+		Name: "Manager", Path: "utils/codebaseindex/manager.go", Summary: "Orchestrates codebase indexing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if node.Namespace != "repo" {
+		t.Fatalf("unexpected namespace: %s", node.Namespace)
+	}
+
+	// Mirror record should be findable through regular memory search.
+	records, err := store.Search(ctx, "Manager indexing", SearchOptions{Namespace: "repo", Types: []string{"graph_node"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d mirrored records, want 1", len(records))
+	}
+	if records[0].ID != graphMirrorRecordPrefix+"n1" {
+		t.Fatalf("unexpected mirror ID: %s", records[0].ID)
+	}
+
+	// Graph FTS lookup should find the node itself.
+	found, err := store.GraphFindNodes(ctx, "repo", "Manager", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(found) != 1 || found[0].ID != "n1" {
+		t.Fatalf("unexpected find result: %#v", found)
+	}
+
+	// Stable ID upsert updates in place.
+	if _, err := store.UpsertGraphNode(ctx, GraphNode{ID: "n1", Namespace: "repo", Kind: GraphNodeType, Name: "Manager", Summary: "Updated"}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := store.GetGraphNode(ctx, "n1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Summary != "Updated" {
+		t.Fatalf("summary not updated: %s", updated.Summary)
+	}
+}
+
+func TestGraphEdgesNeighborsDegreesAndDelete(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "memory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	for _, node := range []GraphNode{
+		{ID: "file-a", Namespace: "repo", Kind: GraphNodeFile, Name: "a.go"},
+		{ID: "file-b", Namespace: "repo", Kind: GraphNodeFile, Name: "b.go"},
+		{ID: "fn-x", Namespace: "repo", Kind: GraphNodeFunction, Name: "X"},
+	} {
+		if _, err := store.UpsertGraphNode(ctx, node); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.UpsertGraphEdge(ctx, GraphEdge{ID: "e1", Namespace: "repo", SourceID: "file-a", TargetID: "fn-x", Kind: GraphEdgeDefines}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertGraphEdge(ctx, GraphEdge{ID: "e2", Namespace: "repo", SourceID: "file-b", TargetID: "fn-x", Kind: GraphEdgeUses, Confidence: GraphConfidenceInferred}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RefreshGraphDegrees(ctx, "repo"); err != nil {
+		t.Fatal(err)
+	}
+
+	hub, err := store.GetGraphNode(ctx, "fn-x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hub.Degree != 2 {
+		t.Fatalf("degree = %d, want 2", hub.Degree)
+	}
+
+	edges, nodes, err := store.GraphNeighbors(ctx, "repo", "fn-x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 2 || len(nodes) != 2 {
+		t.Fatalf("neighbors: %d edges, %d nodes; want 2/2", len(edges), len(nodes))
+	}
+
+	allEdges, err := store.GraphEdges(ctx, "repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allEdges) != 2 {
+		t.Fatalf("got %d edges, want 2", len(allEdges))
+	}
+
+	if err := store.DeleteGraphNamespace(ctx, "repo"); err != nil {
+		t.Fatal(err)
+	}
+	remainingNodes, err := store.GraphNodes(ctx, "repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remainingNodes) != 0 {
+		t.Fatalf("got %d nodes after delete, want 0", len(remainingNodes))
+	}
+	remainingEdges, err := store.GraphEdges(ctx, "repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remainingEdges) != 0 {
+		t.Fatalf("got %d edges after delete, want 0", len(remainingEdges))
+	}
+	mirrored, err := store.Search(ctx, "X", SearchOptions{Namespace: "repo", Types: []string{"graph_node"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mirrored) != 0 {
+		t.Fatalf("got %d mirrored records after delete, want 0", len(mirrored))
+	}
+}

--- a/utils/semanticmemory/store.go
+++ b/utils/semanticmemory/store.go
@@ -109,6 +109,7 @@ func (s *Store) migrate(ctx context.Context) error {
             tokenize='unicode61'
         )`,
 	}
+	statements = append(statements, graphMigrateStatements...)
 	for _, statement := range statements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("initialize memory store: %w", err)


### PR DESCRIPTION
## Summary

Adds knowledge-graph support to comanda, inspired by [Graphify](https://github.com/Graphify-Labs/graphify). The existing codebase index drives the outline (components → packages → files → symbols), a deterministic builder turns that outline into a typed knowledge graph, and the graph is persisted in the semantic memory store.

```bash
comanda index capture -n myproject --graph   # index + graph in one run
comanda graph build myproject                # or build from a registered index
comanda graph explain Store                  # a node and its connections
comanda graph path main Store                # shortest connection (BFS)
comanda graph query "what uses the store?"   # scoped subgraph for a question
comanda graph stats                          # counts + hub nodes
comanda graph export -o graph.json           # graphify-style JSON
```

## Design

- **Extraction is deterministic and local first.** Structural edges (`contains`, `belongs_to`, `imports`, `defines`) come straight from the index scan; `uses` edges between files and uniquely-named types are inferred from symbol-name references. Every edge is confidence-tagged `EXTRACTED` vs `INFERRED`, so you can tell what was read from what was resolved.
- **Storage reuses semantic memory.** `graph_nodes` / `graph_edges` tables (plus a node FTS index) are added to the existing `.comanda/memory/<namespace>.db` SQLite database — no new dependencies. Every node is also mirrored as a `graph_node` memory record, so `comanda memory search` and workflow `memory.recall` (`types: [graph_node]`) find graph concepts with zero workflow changes.
- **Optional AI pass.** `graph build --enhance` (reuses the index `--enhance` model plumbing) adds concept nodes and semantic edges, all tagged `INFERRED`. A malformed model response never fails the build.
- **Stable IDs.** Rebuilds upsert in place; `graph update` replaces the namespace graph so nodes from deleted files are removed.

## Changes

- `utils/semanticmemory/graph.go` — graph schema + store methods (upsert/neighbors/find/delete, degree refresh, memory mirroring)
- `utils/knowledgegraph/` — graph model, builder, LLM enhancement, query engine
- `utils/codebaseindex/manager.go` — exported `Manager.Scan()`; `Generate()` behavior unchanged (refactor only)
- `cmd/graph.go` — new `graph` command group; `cmd/index.go` — `--graph` flag on capture/update
- Tests for store, builder, enhancement, and queries; `docs/design/knowledge-graph.md`; `examples/knowledge-graph/`; README section

## Verification

- `go build ./...`, `go vet`, `gofmt` clean; full `go test ./...` passes
- Smoke-tested on this repo: 1749 nodes / 2515 edges; `explain`, `path` (6-hop chain), `query`, export, and `memory search --types graph_node` all verified
- Note: `golangci-lint` could not run locally (its build targets go1.24 vs. the project's go1.25 — pre-existing environment issue)

## Deliberate v1 limits

Regex-based symbol extraction (existing adapters, no tree-sitter dependency); no community detection / HTML visualization / MCP server yet; `graph update` is a deterministic rebuild rather than diff-patched nodes. Encrypted indexes are skipped (graph DB is plain SQLite).
