### PR TITLE
fix: preserve Codex args across retries

### DIFF
--- a/utils/models/openaicodex.go
+++ b/utils/models/openaicodex.go
@@ -268,10 +268,11 @@ func (o *OpenAICodexProvider) executeCommandWithTimeout(args []string, workDir s
 	tmpFile.Close()
 	defer os.Remove(tmpPath)
 
-	// Add --output-last-message flag to capture clean output
-	args = append(args[:len(args)-1], "--output-last-message", tmpPath, args[len(args)-1])
+	// Add --output-last-message without modifying args. Callers reuse args when
+	// retrying transient Codex failures.
+	cmdArgs := withOutputLastMessage(args, tmpPath)
 
-	cmd := exec.Command(o.binaryPath, args...)
+	cmd := exec.Command(o.binaryPath, cmdArgs...)
 
 	if workDir != "" {
 		cmd.Dir = workDir
@@ -313,6 +314,19 @@ func (o *OpenAICodexProvider) executeCommandWithTimeout(args []string, workDir s
 		}
 		return "", fmt.Errorf("codex command timed out after %v", timeout)
 	}
+}
+
+// withOutputLastMessage adds Codex's output flag immediately before the prompt.
+// It always allocates a new slice so a retry can safely reuse the original args.
+func withOutputLastMessage(args []string, outputPath string) []string {
+	if len(args) == 0 {
+		return []string{"--output-last-message", outputPath}
+	}
+
+	cmdArgs := append([]string(nil), args[:len(args)-1]...)
+	cmdArgs = append(cmdArgs, "--output-last-message", outputPath)
+	cmdArgs = append(cmdArgs, args[len(args)-1])
+	return cmdArgs
 }
 
 func openAICodexCommandTimeout(timeoutSeconds int) time.Duration {

--- a/utils/models/openaicodex_test.go
+++ b/utils/models/openaicodex_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -119,6 +120,29 @@ func TestOpenAICodexBuildArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestWithOutputLastMessageDoesNotMutateRetryArgs(t *testing.T) {
+	args := make([]string, 3, 8)
+	copy(args, []string{"exec", "--skip-git-repo-check", "Reply with exactly: OK"})
+	wantOriginal := append([]string(nil), args...)
+	wantCommand := []string{
+		"exec",
+		"--skip-git-repo-check",
+		"--output-last-message",
+		"/tmp/codex-output.txt",
+		"Reply with exactly: OK",
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		got := withOutputLastMessage(args, "/tmp/codex-output.txt")
+		if !reflect.DeepEqual(got, wantCommand) {
+			t.Fatalf("attempt %d command args = %q, want %q", attempt, got, wantCommand)
+		}
+		if !reflect.DeepEqual(args, wantOriginal) {
+			t.Fatalf("attempt %d mutated retry args: got %q, want %q", attempt, args, wantOriginal)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary\n- build a fresh Codex argument slice before inserting `--output-last-message`\n- prevent retry attempts from overwriting the prompt in the caller's backing array\n- add regression coverage for two consecutive attempts using the same retry args\n\n## Validation\n- `go test -run TestWithOutputLastMessageDoesNotMutateRetryArgs -v ./utils/models`\n- `make test`\n- `go vet ./...`\n- `gofmt -w utils/models/openaicodex.go utils/models/openaicodex_test.go`\n\nThe local `golangci-lint` v2.12.2 cannot load this repository's v1-format config; GitHub Actions installs it using Go 1.25 and the same PR checks have passed on current main.