### PR TITLE
fix: harden long-running loop durability

### DIFF
--- a/cmd/loop.go
+++ b/cmd/loop.go
@@ -96,16 +96,19 @@ var loopStatusCmd = &cobra.Command{
 
 			// Print table
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "LOOP NAME\tSTATUS\tITERATION\tELAPSED\tLAST UPDATED")
+			fmt.Fprintln(w, "LOOP NAME\tSTATUS\tITERATION\tELAPSED\tLAST GATE\tLAST ERROR\tLAST UPDATED")
 			for _, state := range states {
 				elapsed := state.LastUpdateTime.Sub(state.StartTime)
 				lastUpdate := time.Since(state.LastUpdateTime)
-				fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\t%s\n",
+				gate, lastError := loopGateSummary(state)
+				fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\t%s\t%s\t%s\n",
 					state.LoopName,
 					state.Status,
 					state.Iteration,
 					state.MaxIterations,
 					formatDuration(elapsed),
+					gate,
+					lastError,
 					formatDuration(lastUpdate)+" ago",
 				)
 			}
@@ -190,6 +193,24 @@ var loopStatusCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// loopGateSummary returns a compact health summary for the status table.
+func loopGateSummary(state *processor.LoopState) (string, string) {
+	if len(state.QualityGateResults) == 0 {
+		return "-", "-"
+	}
+
+	last := state.QualityGateResults[len(state.QualityGateResults)-1]
+	if last.Passed {
+		return "PASS " + last.GateName, "-"
+	}
+
+	message := strings.TrimSpace(last.Message)
+	if len(message) > 80 {
+		message = message[:77] + "..."
+	}
+	return "FAIL " + last.GateName, message
 }
 
 var loopCancelCmd = &cobra.Command{

--- a/cmd/loop_test.go
+++ b/cmd/loop_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/processor"
+)
+
+func TestLoopGateSummary(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     *processor.LoopState
+		wantGate  string
+		wantError string
+	}{
+		{"no gates", &processor.LoopState{}, "-", "-"},
+		{"passing gate", &processor.LoopState{QualityGateResults: []processor.QualityGateResult{{GateName: "tests", Passed: true}}}, "PASS tests", "-"},
+		{"failed gate", &processor.LoopState{QualityGateResults: []processor.QualityGateResult{{GateName: "tests", Message: "test suite failed"}}}, "FAIL tests", "test suite failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gate, lastError := loopGateSummary(tt.state)
+			if gate != tt.wantGate || lastError != tt.wantError {
+				t.Fatalf("loopGateSummary() = (%q, %q), want (%q, %q)", gate, lastError, tt.wantGate, tt.wantError)
+			}
+		})
+	}
+}

--- a/examples/agentic-loop/README-STATE-AND-QUALITY.md
+++ b/examples/agentic-loop/README-STATE-AND-QUALITY.md
@@ -58,9 +58,19 @@ agentic-loop:
 
 **On Failure Actions:**
 
-- `retry` - Retry with backoff (default: 3 attempts)
+- `retry` - Retry the same gate command with backoff (default: 3 attempts). This is fail-open after all attempts fail, so use it only for genuinely flaky checks; the failure is recorded in `comanda loop status` and printed as a warning.
 - `abort` - Stop loop and save state as "failed"
 - `skip` - Log warning and continue
+- `repair` - Run `repair_command` once, then verify the gate again. If it still fails, stop the loop. Use this for deterministic checks that need to fix or quarantine bad state.
+
+For example:
+
+```yaml
+- name: validate-report
+  command: "./scripts/validate-report.sh"
+  on_fail: repair
+  repair_command: "./scripts/quarantine-invalid-report.sh"
+```
 
 ### 3. No Timeout by Default
 Loops can now run indefinitely (and that's a very long time!):
@@ -72,6 +82,13 @@ agentic-loop:
     max_iterations: 1000
 ```
 Control is via `max_iterations` and exit conditions instead of time limits. Set this for safety if you are leaving your loops unattended.
+
+### Completion Sentinels
+
+`llm_decides` stops only when the final non-empty line is exactly `DONE`,
+`COMPLETE`, `FINISHED`, or `TASK_COMPLETE`. This avoids accidental exits when
+long-form output mentions completion or remaining work in normal prose. For a
+custom sentinel, use `exit_condition: pattern_match` with `exit_pattern`.
 
 ### 4. Loop Management CLI
 New `comanda loop` command for managing loop state:
@@ -195,7 +212,8 @@ State files are stored in `~/.comanda/loop-states/{loop-name}.json`:
 | `name` | string | ✓ | Gate name |
 | `command` | string | - | Shell command to execute |
 | `type` | string | - | Built-in type: syntax, security, test |
-| `on_fail` | string | ✓ | Action: retry, skip, abort |
+| `on_fail` | string | ✓ | Action: retry, skip, abort, repair |
+| `repair_command` | string | with `repair` | Command run once before the gate is checked again |
 | `timeout` | int | - | Timeout in seconds |
 | `retry` | RetryConfig | - | Retry configuration |
 

--- a/utils/models/claudecode.go
+++ b/utils/models/claudecode.go
@@ -166,11 +166,7 @@ func (c *ClaudeCodeProvider) SendPrompt(modelName string, prompt string) (string
 		func() (interface{}, error) {
 			return c.executeCommand(args, prompt, "")
 		},
-		func(err error) bool {
-			// Retry on timeout or transient errors
-			return strings.Contains(err.Error(), "timeout") ||
-				strings.Contains(err.Error(), "connection")
-		},
+		retry.IsTransient,
 		retry.DefaultRetryConfig,
 	)
 
@@ -214,10 +210,7 @@ func (c *ClaudeCodeProvider) SendPromptWithFile(modelName string, prompt string,
 		func() (interface{}, error) {
 			return c.executeCommand(args, combinedPrompt, filepath.Dir(file.Path))
 		},
-		func(err error) bool {
-			return strings.Contains(err.Error(), "timeout") ||
-				strings.Contains(err.Error(), "connection")
-		},
+		retry.IsTransient,
 		retry.DefaultRetryConfig,
 	)
 
@@ -273,10 +266,7 @@ func (c *ClaudeCodeProvider) SendPromptAgentic(modelName string, prompt string, 
 		func() (interface{}, error) {
 			return c.executeCommand(args, prompt, workDir)
 		},
-		func(err error) bool {
-			return strings.Contains(err.Error(), "timeout") ||
-				strings.Contains(err.Error(), "connection")
-		},
+		retry.IsTransient,
 		retry.DefaultRetryConfig,
 	)
 

--- a/utils/models/openaicodex.go
+++ b/utils/models/openaicodex.go
@@ -144,11 +144,7 @@ func (o *OpenAICodexProvider) SendPromptWithTimeout(modelName string, prompt str
 		func() (interface{}, error) {
 			return o.executeCommandWithTimeout(args, "", timeout)
 		},
-		func(err error) bool {
-			// Retry on timeout or transient errors
-			return strings.Contains(err.Error(), "timeout") ||
-				strings.Contains(err.Error(), "connection")
-		},
+		retry.IsTransient,
 		retry.DefaultRetryConfig,
 	)
 
@@ -202,10 +198,7 @@ func (o *OpenAICodexProvider) SendPromptWithFileWithTimeout(modelName string, pr
 		func() (interface{}, error) {
 			return o.executeCommandWithTimeout(args, filepath.Dir(file.Path), timeout)
 		},
-		func(err error) bool {
-			return strings.Contains(err.Error(), "timeout") ||
-				strings.Contains(err.Error(), "connection")
-		},
+		retry.IsTransient,
 		retry.DefaultRetryConfig,
 	)
 

--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,26 +25,7 @@ const (
 // Pre-compiled regex patterns for exit condition detection (better performance)
 var (
 	completionPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)^\s*DONE\.?\s*$`),      // DONE as entire output
-		regexp.MustCompile(`(?i)^\s*COMPLETE\.?\s*$`),  // COMPLETE as entire output
-		regexp.MustCompile(`(?i)^\s*FINISHED\.?\s*$`),  // FINISHED as entire output
-		regexp.MustCompile(`(?i)\bDONE\.?\s*$`),        // DONE at end of output
-		regexp.MustCompile(`(?i)\bCOMPLETE\.?\s*$`),    // COMPLETE at end of output
-		regexp.MustCompile(`(?i)\bFINISHED\.?\s*$`),    // FINISHED at end of output
-		regexp.MustCompile(`(?i)^.*\bDONE\.?\s*$`),     // DONE at end of any line (multiline)
-		regexp.MustCompile(`(?i)^.*\bCOMPLETE\.?\s*$`), // COMPLETE at end of any line
-		regexp.MustCompile(`(?i)^.*\bFINISHED\.?\s*$`), // FINISHED at end of any line
-		regexp.MustCompile(`(?i)TASK[_\s-]?COMPLETE`),  // TASK_COMPLETE anywhere
-	}
-	contextExhaustionPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)completion[_\-\s]?plan`),
-		regexp.MustCompile(`(?i)context[_\s]*(limit|exhaust|full|window)`),
-		regexp.MustCompile(`(?i)remaining[_\s]*work`),
-		regexp.MustCompile(`(?i)continue[_\s]*in[_\s]*(a\s+)?new[_\s]*session`),
-		regexp.MustCompile(`(?i)documented.*remaining`),
-		regexp.MustCompile(`(?i)out\s+of\s+(context|tokens?)`),
-		regexp.MustCompile(`(?i)cannot\s+continue`),
-		regexp.MustCompile(`(?i)unable\s+to\s+complete`),
+		regexp.MustCompile(`(?i)^(?:DONE|COMPLETE|FINISHED|TASK[_\s-]?COMPLETE)\.?$`),
 	}
 )
 
@@ -280,6 +262,19 @@ func (p *Processor) processAgenticLoopWithFile(loopName string, config *AgenticL
 					p.debugf("Quality gate '%s' passed (attempts: %d, duration: %v)", result.GateName, result.Attempts, result.Duration)
 				} else {
 					p.debugf("Quality gate '%s' failed after %d attempts: %s", result.GateName, result.Attempts, result.Message)
+					log.Printf("WARNING: quality gate '%s' failed after %d attempt(s): %s", result.GateName, result.Attempts, result.Message)
+				}
+			}
+
+			// Persist gate outcomes even when a fail-open retry/skip allows the
+			// loop to continue. Otherwise `loop status` cannot reveal a chronic
+			// gate failure after a successful checkpoint.
+			if config.Stateful {
+				state := loopStateFromContext(loopCtx, config.Name, config, workflowFile, p.variables)
+				state.Status = "running"
+				state.QualityGateResults = gateResults
+				if saveErr := stateManager.SaveState(state); saveErr != nil {
+					p.debugf("Warning: Failed to save quality gate results: %v", saveErr)
 				}
 			}
 		}
@@ -628,23 +623,16 @@ func (p *Processor) checkExitCondition(config *AgenticLoopConfig, output string)
 
 	switch config.ExitCondition {
 	case "llm_decides", "":
-		// Look for common completion indicators using pre-compiled patterns
-		// Patterns match DONE/COMPLETE/FINISHED:
-		// - As the entire output (with optional whitespace)
-		// - At the end of output (e.g., "All tasks completed. DONE")
-		// - On their own line
+		// Require an explicit sentinel on the final line. Long-form research and
+		// audit work commonly uses words such as "done", "remaining work", and
+		// "unable to complete" in ordinary prose; treating those as completion
+		// silently stops useful loops after one iteration.
 		trimmedOutput := strings.TrimSpace(output)
+		lines := strings.Split(trimmedOutput, "\n")
+		lastLine := strings.TrimSpace(lines[len(lines)-1])
 		for _, pattern := range completionPatterns {
-			if pattern.MatchString(trimmedOutput) {
+			if pattern.MatchString(lastLine) {
 				return true, "LLM indicated completion"
-			}
-		}
-
-		// Check for context exhaustion / completion plan signals
-		// These indicate the agent realized it can't continue and documented remaining work
-		for _, pattern := range contextExhaustionPatterns {
-			if pattern.MatchString(output) {
-				return true, "Agent signaled context exhaustion or documented remaining work"
 			}
 		}
 

--- a/utils/processor/agentic_loop_test.go
+++ b/utils/processor/agentic_loop_test.go
@@ -61,26 +61,16 @@ func TestCheckExitCondition_LLMDecides(t *testing.T) {
 			output:     "  DONE  ",
 			shouldExit: true,
 		},
-		// New test cases for end-of-output detection
+		// Completion words in ordinary prose must not stop a long-running loop.
 		{
-			name:       "DONE at end of sentence exits",
+			name:       "DONE at end of prose continues",
 			output:     "There is nothing further to document. DONE",
-			shouldExit: true,
+			shouldExit: false,
 		},
 		{
-			name:       "DONE at end with period exits",
-			output:     "All tasks completed. DONE.",
-			shouldExit: true,
-		},
-		{
-			name:       "COMPLETE at end of output exits",
-			output:     "All work has been finished. COMPLETE",
-			shouldExit: true,
-		},
-		{
-			name:       "FINISHED at end of output exits",
-			output:     "The implementation is ready. FINISHED",
-			shouldExit: true,
+			name:       "context exhaustion prose continues",
+			output:     "Unable to complete the remaining work in this iteration.",
+			shouldExit: false,
 		},
 		{
 			name:       "DONE in middle of sentence does NOT exit",
@@ -88,8 +78,8 @@ func TestCheckExitCondition_LLMDecides(t *testing.T) {
 			shouldExit: false,
 		},
 		{
-			name:       "multiline with DONE at end of last line exits",
-			output:     "Step 1 complete.\nStep 2 complete.\nAll work DONE",
+			name:       "multiline final sentinel exits",
+			output:     "Step 1 complete.\nStep 2 complete.\nDONE",
 			shouldExit: true,
 		},
 		{

--- a/utils/processor/quality_gates.go
+++ b/utils/processor/quality_gates.go
@@ -340,7 +340,29 @@ func RunQualityGates(configs []QualityGateConfig, workDir string) ([]QualityGate
 				// Continue to next gate
 				continue
 			case "retry":
-				// Already retried, continue
+				// Retry only re-runs the command against unchanged state. It is
+				// intentionally fail-open once exhausted; the recorded result makes
+				// that outcome visible to operators and loop status.
+				continue
+			case "repair":
+				repairOutput, repairErr := runGateRepair(ctx, config, workDir)
+				if repairErr != nil {
+					return results, fmt.Errorf("quality gate '%s' repair failed: %w", config.Name, repairErr)
+				}
+
+				verified, verifyErr := runGateWithRetry(ctx, gate, workDir, config)
+				if verifyErr != nil {
+					return results, fmt.Errorf("quality gate '%s' failed after repair: %w", config.Name, verifyErr)
+				}
+				verified.Attempts += result.Attempts
+				if verified.Details == nil {
+					verified.Details = make(map[string]interface{})
+				}
+				verified.Details["repair_output"] = repairOutput
+				results[len(results)-1] = *verified
+				if !verified.Passed {
+					return results, fmt.Errorf("quality gate '%s' failed after repair", config.Name)
+				}
 				continue
 			default:
 				// Default to abort
@@ -350,6 +372,30 @@ func RunQualityGates(configs []QualityGateConfig, workDir string) ([]QualityGate
 	}
 
 	return results, nil
+}
+
+// runGateRepair runs a gate's repair command once before the gate is verified
+// again. Repair is for deterministic failures where retrying unchanged state
+// cannot help.
+func runGateRepair(ctx context.Context, config QualityGateConfig, workDir string) (string, error) {
+	if strings.TrimSpace(config.RepairCommand) == "" {
+		return "", fmt.Errorf("on_fail: repair requires repair_command")
+	}
+
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = 60
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, "bash", "-c", config.RepairCommand)
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
 }
 
 // createGate creates a QualityGate from config

--- a/utils/processor/quality_gates_test.go
+++ b/utils/processor/quality_gates_test.go
@@ -1,0 +1,53 @@
+package processor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunQualityGates_RetryFailureIsReturnedForVisibility(t *testing.T) {
+	results, err := RunQualityGates([]QualityGateConfig{{
+		Name:    "always-fails",
+		Command: "exit 1",
+		OnFail:  "retry",
+		Retry:   &RetryConfig{MaxAttempts: 2},
+	}}, t.TempDir())
+	if err != nil {
+		t.Fatalf("RunQualityGates() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Passed || results[0].Attempts != 2 {
+		t.Fatalf("unexpected retry result: %#v", results)
+	}
+}
+
+func TestRunQualityGates_RepairFixesDeterministicFailure(t *testing.T) {
+	workDir := t.TempDir()
+	marker := filepath.Join(workDir, "ready")
+	results, err := RunQualityGates([]QualityGateConfig{{
+		Name:          "marker",
+		Command:       "test -f ready",
+		OnFail:        "repair",
+		RepairCommand: "touch ready",
+	}}, workDir)
+	if err != nil {
+		t.Fatalf("RunQualityGates() error = %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("repair did not create marker: %v", err)
+	}
+	if len(results) != 1 || !results[0].Passed || results[0].Attempts != 2 {
+		t.Fatalf("unexpected repair result: %#v", results)
+	}
+}
+
+func TestRunQualityGates_RepairRequiresCommand(t *testing.T) {
+	_, err := RunQualityGates([]QualityGateConfig{{
+		Name:    "missing-repair",
+		Command: "exit 1",
+		OnFail:  "repair",
+	}}, t.TempDir())
+	if err == nil {
+		t.Fatal("RunQualityGates() error = nil, want missing repair_command error")
+	}
+}

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -316,12 +316,13 @@ type AdapterOverride struct {
 
 // QualityGateConfig represents the configuration for a quality gate
 type QualityGateConfig struct {
-	Name    string       `yaml:"name"`              // Gate name
-	Command string       `yaml:"command,omitempty"` // Shell command to execute
-	Type    string       `yaml:"type,omitempty"`    // Built-in type: syntax, security, test
-	OnFail  string       `yaml:"on_fail"`           // Action on failure: retry, skip, abort
-	Timeout int          `yaml:"timeout,omitempty"` // Timeout in seconds
-	Retry   *RetryConfig `yaml:"retry,omitempty"`   // Retry configuration
+	Name          string       `yaml:"name"`                     // Gate name
+	Command       string       `yaml:"command,omitempty"`        // Shell command to execute
+	Type          string       `yaml:"type,omitempty"`           // Built-in type: syntax, security, test
+	OnFail        string       `yaml:"on_fail"`                  // Action on failure: retry, skip, abort, repair
+	RepairCommand string       `yaml:"repair_command,omitempty"` // Command to run once before verifying a failed repair gate
+	Timeout       int          `yaml:"timeout,omitempty"`        // Timeout in seconds
+	Retry         *RetryConfig `yaml:"retry,omitempty"`          // Retry configuration
 }
 
 // RetryConfig configures retry behavior for quality gates

--- a/utils/retry/retry.go
+++ b/utils/retry/retry.go
@@ -1,9 +1,12 @@
 package retry
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math"
+	"net"
 	"strings"
 	"time"
 
@@ -60,7 +63,7 @@ func WithRetry(operation func() (interface{}, error), shouldRetry func(error) bo
 			err, retryWait, attempt+1, config.MaxRetries)
 
 		// Also print a brief message in non-debug mode
-		log.Printf("Rate limit detected, retrying in %v (attempt %d/%d)...\n",
+		log.Printf("Transient failure detected, retrying in %v (attempt %d/%d)...\n",
 			retryWait, attempt+1, config.MaxRetries)
 
 		// Wait before next retry
@@ -74,17 +77,45 @@ func WithRetry(operation func() (interface{}, error), shouldRetry func(error) bo
 	return nil, fmt.Errorf("unexpected error in retry logic")
 }
 
-// Is429Error checks if the error is a rate limit (429) error
-func Is429Error(err error) bool {
+// IsTransient reports whether an error is safe to retry without changing the
+// request. It deliberately excludes ordinary client/configuration failures so
+// those remain fast-fail. Providers use this shared classifier to avoid drift
+// between HTTP APIs and local agent CLIs.
+func IsTransient(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	errMsg := err.Error()
-	return strings.Contains(errMsg, "429") ||
-		strings.Contains(errMsg, "rate limit") ||
-		strings.Contains(errMsg, "quota exceeded") ||
-		strings.Contains(errMsg, "too many requests")
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var networkErr net.Error
+	if errors.As(err, &networkErr) && networkErr.Timeout() {
+		return true
+	}
+
+	errMsg := strings.ToLower(err.Error())
+	transientPhrases := []string{
+		"429", "rate limit", "quota exceeded", "too many requests",
+		"500", "502", "503", "504", "overloaded", "server error",
+		"response stalled", "eof", "broken pipe", "connection reset",
+		"connection refused", "connection aborted", "network is unreachable",
+		"context deadline exceeded", "deadline exceeded", "timeout", "timed out",
+	}
+	for _, phrase := range transientPhrases {
+		if strings.Contains(errMsg, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// Is429Error is retained for existing API providers. Despite its historical
+// name, it now delegates to the shared transient classifier so every provider
+// receives the same retry coverage.
+func Is429Error(err error) bool {
+	return IsTransient(err)
 }
 
 // extractRetryTime attempts to extract a retry time from an error message

--- a/utils/retry/retry_test.go
+++ b/utils/retry/retry_test.go
@@ -1,0 +1,33 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"rate limit", errors.New("HTTP 429 rate limit"), true},
+		{"overloaded", errors.New("API Error: overloaded"), true},
+		{"stalled stream", errors.New("API Error: Response stalled mid-stream"), true},
+		{"broken pipe", errors.New("write: broken pipe"), true},
+		{"deadline", fmt.Errorf("request failed: %w", context.DeadlineExceeded), true},
+		{"server error", errors.New("status code: 503"), true},
+		{"bad request", errors.New("status code: 400 invalid model"), false},
+		{"authentication", errors.New("authentication failed"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransient(tt.err); got != tt.want {
+				t.Fatalf("IsTransient(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- unify transient retry classification across providers and agent CLIs
- persist and surface fail-open quality-gate failures; add a repair-and-verify policy
- require explicit final-line completion sentinels to prevent prose-triggered exits
- add gate/error summaries to loop status

## Validation
- go test ./...
- go vet ./...
- golangci-lint v1.64.8 run