### PR TITLE
feat: server API parity and observability improvements

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,6 +49,7 @@ OpenAI-Compatible Endpoints (when enabled):
 			return
 		}
 
+		server.SetVersion(getVersion())
 		if err := server.Run(envConfig); err != nil {
 			log.Printf("Server failed to start: %v\n", err)
 			return

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -256,21 +256,20 @@ components:
       properties:
         input:
           type: string
-          description: Input for YAML processing (required for POST requests)
+          description: Optional input for YAML processing (may also be supplied via the input query parameter)
         streaming:
           type: boolean
           description: |
             Enable real-time output streaming using Server-Sent Events (SSE).
             When true, the response will be in text/event-stream format with the following event types:
             - data: Regular output data
-            - progress: Progress updates
+            - progress: Progress updates (plain string for start/completion messages, JSON object with step info and metrics for step updates)
+            - log: Stream-log lines (loop iterations, context usage, tool activity) in the same format as the CLI's --stream-log file
             - spinner: Spinner/loading status updates
             - complete: Processing completion message
             - error: Error messages
             - heartbeat: Connection keep-alive signals
             - output: JSON-encoded output from YAML processing when output is set to STDOUT (format: {"content": "output text"})
-      required:
-        - input
 
     StepInfo:
       type: object
@@ -300,8 +299,44 @@ components:
         step:
           $ref: '#/components/schemas/StepInfo'
           description: Step information (if available)
+        metrics:
+          $ref: '#/components/schemas/PerformanceMetrics'
+          description: Per-step performance metrics (if available)
       required:
         - message
+
+    PerformanceMetrics:
+      type: object
+      description: Per-step processing times in milliseconds
+      properties:
+        input_ms:
+          type: integer
+          format: int64
+        model_ms:
+          type: integer
+          format: int64
+        action_ms:
+          type: integer
+          format: int64
+        output_ms:
+          type: integer
+          format: int64
+        total_ms:
+          type: integer
+          format: int64
+
+    LogData:
+      type: object
+      description: |
+        Stream-log line emitted during workflow execution. Lines use the same
+        format as the CLI's --stream-log file ("[HH:MM:SS] message") and include
+        loop iterations ("ITERATION x/y - name"), context usage ("CONTEXT: ..."),
+        tool activity, and exit conditions ("★ EXIT: ...").
+      properties:
+        line:
+          type: string
+      required:
+        - line
 
     OutputData:
       type: object
@@ -319,12 +354,13 @@ components:
       properties:
         event:
           type: string
-          enum: [data, progress, complete, error, heartbeat, output]
+          enum: [data, progress, log, spinner, complete, error, heartbeat, output]
           description: Type of SSE event
         data:
           oneOf:
             - type: string
             - $ref: '#/components/schemas/ProgressData'
+            - $ref: '#/components/schemas/LogData'
             - $ref: '#/components/schemas/OutputData'
             - type: object
               properties:
@@ -1088,6 +1124,17 @@ paths:
   /health:
     get:
       summary: Server Health Check
+      description: |
+        Returns server health, the comanda version, and the feature capabilities
+        this server supports so clients can progressively enable functionality.
+
+        Capability flags:
+        - full-dsl: /process and /yaml/process parse the complete workflow DSL (ordered steps, parallel groups, agentic loops, defer, workflow nodes)
+        - yaml-validate: POST /yaml/validate is available
+        - log-events: streaming responses emit "log" SSE events with stream-log lines
+        - progress-metrics: step "progress" SSE events include performance metrics
+        - stream-no-timeout: streaming runs are not time-limited unless streamTimeoutSeconds is configured
+        - openai-compat: OpenAI-compatible endpoints are enabled
       responses:
         '200':
           description: Server health status
@@ -1096,17 +1143,22 @@ paths:
               schema:
                 type: object
                 properties:
-                  success:
-                    type: boolean
-                  message:
+                  status:
                     type: string
-                  statusCode:
-                    type: integer
-                  response:
+                    example: ok
+                  timestamp:
                     type: string
+                    format: date-time
+                  version:
+                    type: string
+                    example: v0.1.0
+                  capabilities:
+                    type: array
+                    items:
+                      type: string
                 required:
-                  - success
-                  - message
+                  - status
+                  - timestamp
         '401':
           description: Unauthorized
           content:
@@ -1197,6 +1249,79 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/SSEEvent'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /yaml/validate:
+    post:
+      summary: Validate Workflow YAML
+      description: |
+        Validate workflow YAML without executing it, using the same structural
+        validation as the /generate endpoint's retry loop. Optionally verifies
+        that referenced models are configured on this server.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+                  description: YAML content to validate
+                checkModels:
+                  type: boolean
+                  description: Also validate model names against this server's configured models
+              required:
+                - content
+      responses:
+        '200':
+          description: Validation result (returned for both valid and invalid workflows)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  valid:
+                    type: boolean
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        line:
+                          type: integer
+                          description: Line number (omitted if unknown)
+                        field:
+                          type: string
+                          description: Field or step name involved
+                        message:
+                          type: string
+                        fix:
+                          type: string
+                          description: Suggested fix
+                      required:
+                        - message
+                  invalidModels:
+                    type: array
+                    items:
+                      type: string
+                    description: Model names not configured on this server (when checkModels is true)
+                required:
+                  - success
+                  - valid
+        '400':
+          description: Missing or invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
           content:
@@ -1298,15 +1423,25 @@ paths:
     post:
       summary: Process YAML File by Path
       description: |
-        Process a YAML file by path with required input and optional real-time output streaming.
+        Process a YAML file by path with optional input and optional real-time output streaming.
         YAML processing is only available via POST requests.
-        
+
+        The complete workflow DSL is supported — ordered sequential steps, parallel
+        groups, agentic loops (agentic-loop, loops, execute_loops), defer blocks, and
+        workflow nodes — using the same parser as the CLI.
+
+        Streaming runs are not time-limited by default; long-running workflows stream
+        until they finish or the client disconnects (heartbeats keep the connection
+        alive). A server-side limit can be enforced with the streamTimeoutSeconds
+        server configuration setting.
+
         When streaming is enabled (streaming=true):
         - Response will be in Server-Sent Events (SSE) format
         - Client must set Accept: text/event-stream header
         - Server will send various event types:
           * data: Regular output data
-          * progress: Processing progress updates
+          * progress: Processing progress updates (plain string for start/completion messages, JSON object with step info and metrics for step updates)
+          * log: Stream-log lines (loop iterations, context usage, tool activity) in the same format as the CLI's --stream-log file
           * spinner: Loading/status indicators
           * complete: Final completion message
           * error: Error information

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -293,17 +293,33 @@ GET /health
 Authorization: Bearer <token>
 ```
 
-Returns the current health status of the server.
+Returns the current health status of the server, the comanda version, and the
+feature capabilities this server supports. Clients can use `capabilities` to
+progressively enable functionality.
 
 Response:
 ```json
 {
-  "success": true,
-  "message": "Server is healthy",
-  "statusCode": 200,
-  "response": "OK"
+  "status": "ok",
+  "timestamp": "2026-01-01T00:00:00Z",
+  "version": "v0.1.0",
+  "capabilities": [
+    "full-dsl",
+    "yaml-validate",
+    "log-events",
+    "progress-metrics",
+    "stream-no-timeout"
+  ]
 }
 ```
+
+Capability flags:
+- `full-dsl`: `/process` and `/yaml/process` parse the complete workflow DSL (ordered steps, parallel groups, agentic loops, `defer`, `workflow` nodes) using the same parser as the CLI
+- `yaml-validate`: the `POST /yaml/validate` endpoint is available
+- `log-events`: streaming responses emit `log` SSE events with stream-log lines (loop iterations, context usage, tool activity)
+- `progress-metrics`: step `progress` SSE events include per-step performance metrics
+- `stream-no-timeout`: streaming runs are not time-limited unless `streamTimeoutSeconds` is configured
+- `openai-compat`: OpenAI-compatible endpoints are enabled
 
 ### YAML Operations
 
@@ -369,6 +385,40 @@ data: Model response: ...
 data: Processing step 2...
 
 data: Processing complete
+```
+
+#### Validate YAML
+```http
+POST /yaml/validate
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "content": "your yaml content here",
+  "checkModels": true
+}
+```
+
+Validates workflow YAML without executing it, using the same structural
+validation as the `/generate` endpoint's retry loop. Set `checkModels` to also
+verify that every referenced model is configured on this server (including
+locally detected CLI providers).
+
+Response:
+```json
+{
+  "success": true,
+  "valid": false,
+  "errors": [
+    {
+      "line": 3,
+      "field": "step_one",
+      "message": "Step is missing required 'model' field",
+      "fix": "Add a model, e.g. model: gpt-4o-mini"
+    }
+  ],
+  "invalidModels": ["unknown-model"]
+}
 ```
 
 ### Generate Endpoint
@@ -456,6 +506,35 @@ data: Processing complete
   "success": false,
   "error": "YAML processing is only available via POST requests. Please use POST with your YAML content."
 }
+```
+
+Both `/process` and `/yaml/process` parse the complete workflow DSL — ordered
+sequential steps, parallel groups, agentic loops (`agentic-loop`, `loops`,
+`execute_loops`), `defer` blocks, and `workflow` nodes — using the same parser
+as the CLI, so any workflow that runs locally runs identically over HTTP.
+
+#### Streaming Events
+
+Streaming responses use Server-Sent Events with the following event types:
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `progress` | plain string or JSON object | Step progress. Start/completion messages are plain strings; step updates are JSON: `{"message": "...", "step": {"name", "model", "action"}, "metrics": {"input_ms", "model_ms", "action_ms", "output_ms", "total_ms"}}` (`step`/`metrics` present when available) |
+| `log` | `{"line": "[HH:MM:SS] ..."}` | Stream-log lines emitted during execution: loop iterations (`ITERATION x/y - name`), context usage (`CONTEXT: ...`), tool activity, exit conditions (`★ EXIT: ...`). Same line format as the CLI's `--stream-log` file, so the same parsers work for local and remote runs |
+| `spinner` | plain string | Transient status messages |
+| `output` | `{"content": "..."}` | Output produced by a step |
+| `complete` | plain string | Workflow completed |
+| `error` | `{"success": false, "error": "..."}` | Processing error |
+| `: heartbeat` | comment | Sent every 15 seconds to keep the connection alive |
+
+Streaming runs are not time-limited by default: long-running workflows such as
+agentic loops stream until they finish or the client disconnects (heartbeats
+keep the connection alive). To enforce a server-side limit, set
+`streamTimeoutSeconds` in the server configuration:
+
+```yaml
+server:
+  streamTimeoutSeconds: 3600  # optional; 0 or omitted = no timeout
 ```
 
 Note: All YAML processing must be done via POST requests. The endpoint no longer supports GET requests for processing.

--- a/utils/config/server.go
+++ b/utils/config/server.go
@@ -9,6 +9,10 @@ type ServerConfig struct {
 	BearerToken  string             `yaml:"bearerToken"`
 	CORS         CORS               `yaml:"cors"`
 	OpenAICompat OpenAICompatConfig `yaml:"openai_compat,omitempty"`
+	// StreamTimeoutSeconds bounds streaming (SSE) workflow executions.
+	// 0 (the default) means no server-side timeout: long-running workflows
+	// such as agentic loops stream until they finish or the client disconnects.
+	StreamTimeoutSeconds int `yaml:"streamTimeoutSeconds,omitempty"`
 }
 
 // CORS holds Cross-Origin Resource Sharing settings

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -464,6 +464,19 @@ func (p *Processor) SetStreamLog(path string) error {
 	return nil
 }
 
+// SetStreamLogCallback routes stream log lines (loop iterations, context usage,
+// tool activity, exit conditions) to a callback instead of requiring a file.
+// Lines use the same format as the file-based stream log. If a file-based
+// stream log is already configured, the callback receives a copy of each line.
+func (p *Processor) SetStreamLogCallback(cb func(line string)) {
+	if p.streamLog != nil {
+		p.streamLog.SetCallback(cb)
+		return
+	}
+	p.streamLog = NewCallbackStreamLogger(cb)
+	p.debugf("Stream log callback enabled")
+}
+
 // GetStreamLogPath returns the path to the stream log file
 func (p *Processor) GetStreamLogPath() string {
 	return p.streamLogPath

--- a/utils/processor/progress.go
+++ b/utils/processor/progress.go
@@ -10,6 +10,7 @@ const (
 	ProgressError
 	ProgressOutput       // New type for output events
 	ProgressParallelStep // New type for parallel step updates
+	ProgressLog          // Stream log line (loop iterations, context usage, tool activity)
 )
 
 // StepInfo contains detailed information about a processing step

--- a/utils/processor/stream_log.go
+++ b/utils/processor/stream_log.go
@@ -11,9 +11,10 @@ import (
 
 // StreamLogger handles real-time logging to a file for monitoring long-running operations
 type StreamLogger struct {
-	file    *os.File
-	mu      sync.Mutex
-	enabled bool
+	file     *os.File
+	mu       sync.Mutex
+	enabled  bool
+	callback func(line string) // optional sink invoked with each formatted log line
 }
 
 // NewStreamLogger creates a new stream logger that writes to the specified file
@@ -33,8 +34,31 @@ func NewStreamLogger(path string) (*StreamLogger, error) {
 	}, nil
 }
 
+// NewCallbackStreamLogger creates a stream logger that delivers each formatted
+// line to a callback instead of (or in addition to) a file. Lines use the same
+// format as the file-based log, so existing tail/parse tooling works unchanged.
+func NewCallbackStreamLogger(cb func(line string)) *StreamLogger {
+	return &StreamLogger{
+		enabled:  cb != nil,
+		callback: cb,
+	}
+}
+
+// SetCallback attaches a line callback to an existing logger
+func (s *StreamLogger) SetCallback(cb func(line string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.callback = cb
+	if cb != nil {
+		s.enabled = true
+	}
+}
+
 // Close closes the stream log file
 func (s *StreamLogger) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.callback = nil
 	if s.file != nil {
 		return s.file.Close()
 	}
@@ -48,17 +72,27 @@ func (s *StreamLogger) IsEnabled() bool {
 
 // Log writes a message to the stream log with timestamp
 func (s *StreamLogger) Log(format string, args ...interface{}) {
-	if !s.enabled || s.file == nil {
+	if !s.enabled {
 		return
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if s.file == nil && s.callback == nil {
+		return
+	}
+
 	timestamp := time.Now().Format("15:04:05")
 	message := fmt.Sprintf(format, args...)
-	fmt.Fprintf(s.file, "[%s] %s\n", timestamp, message)
-	_ = s.file.Sync() // Flush immediately for tail -f
+	line := fmt.Sprintf("[%s] %s", timestamp, message)
+	if s.file != nil {
+		fmt.Fprintf(s.file, "%s\n", line)
+		_ = s.file.Sync() // Flush immediately for tail -f
+	}
+	if s.callback != nil {
+		s.callback(line)
+	}
 }
 
 // LogSection writes a section header to the stream log

--- a/utils/processor/stream_log_test.go
+++ b/utils/processor/stream_log_test.go
@@ -73,6 +73,75 @@ func TestStreamLoggerDisabled(t *testing.T) {
 	logger.Close()
 }
 
+func TestStreamLoggerCallback(t *testing.T) {
+	var lines []string
+	logger := NewCallbackStreamLogger(func(line string) {
+		lines = append(lines, line)
+	})
+
+	if !logger.IsEnabled() {
+		t.Fatal("Callback logger should be enabled")
+	}
+
+	logger.Log("Test message %d", 1)
+	logger.LogIteration(3, 10, "build")
+	logger.LogExit("completed")
+	logger.Close()
+
+	joined := strings.Join(lines, "\n")
+	checks := []string{
+		"Test message 1",
+		"ITERATION 3/10 - build",
+		"EXIT: completed",
+	}
+	for _, check := range checks {
+		if !strings.Contains(joined, check) {
+			t.Errorf("Callback lines should contain '%s', got:\n%s", check, joined)
+		}
+	}
+
+	// Lines should carry the same [HH:MM:SS] prefix as the file format
+	if len(lines) == 0 || !strings.HasPrefix(lines[0], "[") {
+		t.Errorf("Callback lines should be timestamp-prefixed, got %q", lines)
+	}
+
+	// After Close, the callback must no longer fire
+	count := len(lines)
+	logger.Log("after close")
+	if len(lines) != count {
+		t.Error("Callback should not fire after Close")
+	}
+}
+
+func TestStreamLoggerFileAndCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "both.log")
+
+	logger, err := NewStreamLogger(logPath)
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+
+	var lines []string
+	logger.SetCallback(func(line string) {
+		lines = append(lines, line)
+	})
+
+	logger.Log("shared line")
+	logger.Close()
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+	if !strings.Contains(string(content), "shared line") {
+		t.Error("File should contain the logged line")
+	}
+	if len(lines) != 1 || !strings.Contains(lines[0], "shared line") {
+		t.Errorf("Callback should receive the same line, got %q", lines)
+	}
+}
+
 func TestStreamLoggerOutputTruncation(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "truncate.log")

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -239,11 +239,11 @@ type NormalizeOptions struct {
 
 // PerformanceMetrics tracks timing information for processing steps
 type PerformanceMetrics struct {
-	InputProcessingTime  int64 // Time in milliseconds to process inputs
-	ModelProcessingTime  int64 // Time in milliseconds for model processing
-	ActionProcessingTime int64 // Time in milliseconds for action processing
-	OutputProcessingTime int64 // Time in milliseconds for output processing
-	TotalProcessingTime  int64 // Total time in milliseconds for the step
+	InputProcessingTime  int64 `json:"input_ms"`  // Time in milliseconds to process inputs
+	ModelProcessingTime  int64 `json:"model_ms"`  // Time in milliseconds for model processing
+	ActionProcessingTime int64 `json:"action_ms"` // Time in milliseconds for action processing
+	OutputProcessingTime int64 `json:"output_ms"` // Time in milliseconds for output processing
+	TotalProcessingTime  int64 `json:"total_ms"`  // Total time in milliseconds for the step
 }
 
 // CodebaseIndexConfig represents the configuration for codebase-index step

--- a/utils/server/file_handlers.go
+++ b/utils/server/file_handlers.go
@@ -761,9 +761,11 @@ func (s *Server) handleYAMLProcess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// First unmarshal into a map to preserve step names
-	var rawConfig map[string]processor.StepConfig
-	if err := yaml.Unmarshal([]byte(req.Content), &rawConfig); err != nil {
+	// Unmarshal using the DSLConfig custom unmarshaler (same as CLI) so that
+	// ordered steps and top-level blocks (parallel, agentic-loop, loops,
+	// execute_loops, defer, workflow) are all handled correctly
+	var dslConfig processor.DSLConfig
+	if err := yaml.Unmarshal([]byte(req.Content), &dslConfig); err != nil {
 		if req.Streaming {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Cache-Control", "no-cache")
@@ -789,15 +791,6 @@ func (s *Server) handleYAMLProcess(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		return
-	}
-
-	// Convert map to ordered Steps slice
-	var dslConfig processor.DSLConfig
-	for name, config := range rawConfig {
-		dslConfig.Steps = append(dslConfig.Steps, processor.Step{
-			Name:   name,
-			Config: config,
-		})
 	}
 
 	// Get runtime directory from query parameter
@@ -847,6 +840,22 @@ func (s *Server) handleYAMLProcess(w http.ResponseWriter, r *http.Request) {
 		// Set up processor with progress writer
 		proc.SetProgressWriter(progressWriter)
 
+		// Forward stream log lines (loop iterations, context usage, tool
+		// activity) through the progress channel as structured log events
+		proc.SetStreamLogCallback(func(line string) {
+			progressWriter.WriteProgress(processor.ProgressUpdate{
+				Type:    processor.ProgressLog,
+				Message: line,
+			})
+		})
+
+		// Long-running workflows can stream for a long time; clear the
+		// server's write deadline for this response
+		rc := http.NewResponseController(w)
+		if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+			config.DebugLog("Could not clear write deadline for streaming: %v", err)
+		}
+
 		// Run the processor in a goroutine
 		processDone := make(chan error)
 		go func() {
@@ -875,7 +884,14 @@ func (s *Server) handleYAMLProcess(w http.ResponseWriter, r *http.Request) {
 				case processor.ProgressSpinner:
 					sseWriter.SendSpinner(update.Message)
 				case processor.ProgressStep:
-					sseWriter.SendProgress(update.Message)
+					// For initial and completion messages, send as plain text
+					if update.Message == "Starting workflow processing" || update.Message == "Workflow processing completed successfully" || update.Step == nil && update.PerformanceMetrics == nil {
+						sseWriter.SendProgress(update.Message)
+					} else {
+						sseWriter.SendProgress(buildProgressPayload(update))
+					}
+				case processor.ProgressLog:
+					sseWriter.SendLog(update.Message)
 				case processor.ProgressComplete:
 					sseWriter.SendComplete(update.Message)
 				case processor.ProgressError:

--- a/utils/server/generate_handler.go
+++ b/utils/server/generate_handler.go
@@ -73,31 +73,8 @@ func (s *Server) handleGenerate(w http.ResponseWriter, r *http.Request) {
 	config.VerboseLog("Generating workflow using model: %s", modelForGeneration)
 	config.DebugLog("Generate request: prompt_length=%d, model=%s", len(req.Prompt), modelForGeneration)
 
-	// Get available models from the environment config
-	availableModels := s.envConfig.GetAllConfiguredModels()
-
-	// Add Claude Code models if the claude binary is available
-	if models.IsClaudeCodeAvailable() {
-		claudeCodeModels := []string{"claude-code", "claude-code-opus", "claude-code-sonnet", "claude-code-haiku"}
-		availableModels = append(availableModels, claudeCodeModels...)
-	}
-
-	// Add Gemini CLI models if the gemini binary is available
-	if models.IsGeminiCLIAvailable() {
-		geminiCLIModels := []string{"gemini-cli", "gemini-cli-pro", "gemini-cli-flash", "gemini-cli-flash-lite"}
-		availableModels = append(availableModels, geminiCLIModels...)
-	}
-
-	// Add OpenAI Codex models if the codex binary is available
-	if models.IsOpenAICodexAvailable() {
-		availableModels = append(availableModels, models.GetOpenAICodexModels()...)
-	}
-
-	// Add Kimi Code models if the kimi binary is available
-	if models.IsKimiCodeAvailable() {
-		kimiCodeModels := []string{"kimi-code"}
-		availableModels = append(availableModels, kimiCodeModels...)
-	}
+	// Get available models from the environment config plus detected CLI providers
+	availableModels := collectAvailableModels(s.envConfig)
 
 	dslGuide := processor.GetEmbeddedLLMGuideWithModels(availableModels)
 

--- a/utils/server/handlers.go
+++ b/utils/server/handlers.go
@@ -222,9 +222,11 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 	// Log YAML content details before parsing
 	config.DebugLog("Processing YAML content: length=%d bytes", len(yamlContent))
 
-	// First unmarshal into a map to preserve step names (same as CLI)
-	var rawConfig map[string]processor.StepConfig
-	if err := yaml.Unmarshal(yamlContent, &rawConfig); err != nil {
+	// Unmarshal using the DSLConfig custom unmarshaler (same as CLI) so that
+	// ordered steps and top-level blocks (parallel, agentic-loop, loops,
+	// execute_loops, defer, workflow) are all handled correctly
+	var dslConfig processor.DSLConfig
+	if err := yaml.Unmarshal(yamlContent, &dslConfig); err != nil {
 		config.VerboseLog("Error parsing YAML: %v", err)
 		config.DebugLog("YAML parse error: content_preview='%s' error=%v", truncateString(string(yamlContent), 200), err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -249,16 +251,8 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 		return
 	}
 
-	// Convert map to ordered Steps slice (same as CLI)
-	var dslConfig processor.DSLConfig
-	config.DebugLog("Converting YAML to DSL config: step_count=%d", len(rawConfig))
-	for name, stepConfig := range rawConfig {
-		config.DebugLog("Processing step: name=%s model=%v action=%v", name, stepConfig.Model, stepConfig.Action)
-		dslConfig.Steps = append(dslConfig.Steps, processor.Step{
-			Name:   name,
-			Config: stepConfig,
-		})
-	}
+	config.DebugLog("Parsed DSL config: steps=%d parallel_groups=%d loops=%d",
+		len(dslConfig.Steps), len(dslConfig.ParallelSteps), len(dslConfig.Loops))
 
 	// Get runtime directory from query parameter or calculate from path
 	runtimeDir := r.URL.Query().Get("runtimeDir")
@@ -359,8 +353,23 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 		proc.SetProgressWriter(progressWriter)
 		config.DebugLog("Progress writer configured on processor")
 
-		// Create context with timeout
-		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+		// Forward stream log lines (loop iterations, context usage, tool
+		// activity) through the progress channel as structured log events
+		proc.SetStreamLogCallback(func(line string) {
+			progressWriter.WriteProgress(processor.ProgressUpdate{
+				Type:    processor.ProgressLog,
+				Message: line,
+			})
+		})
+
+		// Long-running workflows (e.g. agentic loops) can stream for a long
+		// time; clear the server's write deadline for this response and only
+		// apply a timeout if one is explicitly configured
+		rc := http.NewResponseController(w)
+		if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+			config.DebugLog("Could not clear write deadline for streaming: %v", err)
+		}
+		ctx, cancel := streamingContext(r.Context(), serverConfig)
 		defer cancel()
 
 		// Add panic recovery for processor initialization
@@ -407,9 +416,9 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 		for {
 			select {
 			case <-ctx.Done():
-				config.DebugLog("Context timeout reached after 5 minutes")
+				config.DebugLog("Streaming context done: %v", ctx.Err())
 				if sw != nil {
-					sw.SendError(fmt.Errorf("processing timed out after 5 minutes"))
+					sw.SendError(fmt.Errorf("processing timed out after %d seconds", serverConfig.StreamTimeoutSeconds))
 				}
 				return
 			case <-r.Context().Done():
@@ -441,19 +450,10 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 					if update.Message == "Starting workflow processing" || update.Message == "Workflow processing completed successfully" {
 						sw.SendProgress(update.Message)
 					} else {
-						// For other messages, create structured progress data
-						progressData := map[string]interface{}{
-							"message": update.Message,
-						}
-						if update.Step != nil {
-							progressData["step"] = map[string]string{
-								"name":   update.Step.Name,
-								"model":  update.Step.Model,
-								"action": update.Step.Action,
-							}
-						}
-						sw.SendProgress(progressData)
+						sw.SendProgress(buildProgressPayload(update))
 					}
+				case processor.ProgressLog:
+					sw.SendLog(update.Message)
 				case processor.ProgressOutput:
 					config.DebugLog("Received output event: %s", update.Stdout)
 					sw.SendOutput(update.Stdout)
@@ -527,4 +527,34 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 		Message: fmt.Sprintf("Successfully processed %s", filename),
 		Output:  finalOutput,
 	})
+}
+
+// streamingContext returns a context for a streaming workflow execution.
+// A timeout is applied only when streamTimeoutSeconds is configured (> 0);
+// by default long-running workflows stream until completion or client
+// disconnect (SSE heartbeats keep the connection alive).
+func streamingContext(parent context.Context, serverConfig *config.ServerConfig) (context.Context, context.CancelFunc) {
+	if serverConfig != nil && serverConfig.StreamTimeoutSeconds > 0 {
+		return context.WithTimeout(parent, time.Duration(serverConfig.StreamTimeoutSeconds)*time.Second)
+	}
+	return context.WithCancel(parent)
+}
+
+// buildProgressPayload converts a step progress update into the structured
+// JSON payload sent on SSE progress events
+func buildProgressPayload(update processor.ProgressUpdate) map[string]interface{} {
+	progressData := map[string]interface{}{
+		"message": update.Message,
+	}
+	if update.Step != nil {
+		progressData["step"] = map[string]string{
+			"name":   update.Step.Name,
+			"model":  update.Step.Model,
+			"action": update.Step.Action,
+		}
+	}
+	if update.PerformanceMetrics != nil {
+		progressData["metrics"] = update.PerformanceMetrics
+	}
+	return progressData
 }

--- a/utils/server/handlers_test.go
+++ b/utils/server/handlers_test.go
@@ -190,62 +190,42 @@ summarize:
 `)
 
 	// CLI-style parsing (from cmd/process.go)
-	var cliRawConfig map[string]processor.StepConfig
-	err := yaml.Unmarshal(yamlContent, &cliRawConfig)
+	var cliConfig processor.DSLConfig
+	err := yaml.Unmarshal(yamlContent, &cliConfig)
 	assert.NoError(t, err, "CLI parsing should not error")
 
-	var cliConfig processor.DSLConfig
-	for name, config := range cliRawConfig {
-		cliConfig.Steps = append(cliConfig.Steps, processor.Step{
-			Name:   name,
-			Config: config,
-		})
-	}
-
-	// Server-style parsing (from utils/server/handlers.go)
-	var serverRawConfig map[string]processor.StepConfig
-	err = yaml.Unmarshal(yamlContent, &serverRawConfig)
+	// Server-style parsing (from utils/server/handlers.go) now uses the same
+	// DSLConfig custom unmarshaler as the CLI
+	var serverConfig processor.DSLConfig
+	err = yaml.Unmarshal(yamlContent, &serverConfig)
 	assert.NoError(t, err, "Server parsing should not error")
 
-	var serverConfig processor.DSLConfig
-	for name, config := range serverRawConfig {
-		serverConfig.Steps = append(serverConfig.Steps, processor.Step{
-			Name:   name,
-			Config: config,
-		})
-	}
-
-	// Verify both methods produce identical results
+	// Verify both methods produce identical, ordered results
 	assert.Equal(t, len(cliConfig.Steps), len(serverConfig.Steps),
 		"CLI and server should parse the same number of steps")
+	assert.Equal(t, 2, len(serverConfig.Steps), "Both steps should be parsed")
 
-	// Create maps for easier comparison since order isn't guaranteed
-	cliSteps := make(map[string]processor.Step)
-	serverSteps := make(map[string]processor.Step)
+	// Step order must be preserved exactly as written in the YAML
+	assert.Equal(t, "analyze_text", serverConfig.Steps[0].Name, "First step should be analyze_text")
+	assert.Equal(t, "summarize", serverConfig.Steps[1].Name, "Second step should be summarize")
 
-	for _, step := range cliConfig.Steps {
-		cliSteps[step.Name] = step
-	}
-	for _, step := range serverConfig.Steps {
-		serverSteps[step.Name] = step
-	}
-
-	// Compare steps by name
-	for name, cliStep := range cliSteps {
-		serverStep, exists := serverSteps[name]
-		assert.True(t, exists, "Step %s should exist in both configs", name)
+	// Compare steps positionally
+	for i, cliStep := range cliConfig.Steps {
+		serverStep := serverConfig.Steps[i]
+		assert.Equal(t, cliStep.Name, serverStep.Name,
+			"Step order should match at index %d", i)
 
 		// Compare StepConfig fields
 		assert.Equal(t, cliStep.Config.Input, serverStep.Config.Input,
-			"Input should match for step %s", name)
+			"Input should match for step %s", cliStep.Name)
 		assert.Equal(t, cliStep.Config.Model, serverStep.Config.Model,
-			"Model should match for step %s", name)
+			"Model should match for step %s", cliStep.Name)
 		assert.Equal(t, cliStep.Config.Action, serverStep.Config.Action,
-			"Action should match for step %s", name)
+			"Action should match for step %s", cliStep.Name)
 		assert.Equal(t, cliStep.Config.Output, serverStep.Config.Output,
-			"Output should match for step %s", name)
+			"Output should match for step %s", cliStep.Name)
 		assert.Equal(t, cliStep.Config.NextAction, serverStep.Config.NextAction,
-			"NextAction should match for step %s", name)
+			"NextAction should match for step %s", cliStep.Name)
 	}
 
 	// Create test server config
@@ -299,6 +279,57 @@ analyze_text:
 	assert.Equal(t, "gpt-4o", dslConfig.Steps[0].Config.Model, "Step model should be 'gpt-4o'")
 	assert.Equal(t, "Test action", dslConfig.Steps[0].Config.Action, "Step action should be 'Test action'")
 	assert.Equal(t, "STDOUT", dslConfig.Steps[0].Config.Output, "Step output should be 'STDOUT'")
+}
+
+// Test that the parsing used by the server handles top-level DSL blocks
+// (parallel, loops, execute_loops, defer) instead of only flat linear steps
+func TestServerParsesComplexWorkflows(t *testing.T) {
+	yamlContent := []byte(`
+prepare:
+  input: NA
+  model: gpt-4o
+  action: "Prepare the data"
+  output: STDOUT
+
+group_one:
+  analyze:
+    input: NA
+    model: gpt-4o
+    action: "Analyze"
+    output: STDOUT
+  summarize:
+    input: NA
+    model: gpt-4o
+    action: "Summarize"
+    output: STDOUT
+
+loops:
+  build:
+    max_iterations: 5
+    exit_condition: "tests pass"
+
+execute_loops:
+  - build
+
+defer:
+  cleanup:
+    input: NA
+    model: gpt-4o
+    action: "Clean up"
+    output: STDOUT
+`)
+
+	var dslConfig processor.DSLConfig
+	err := yaml.Unmarshal(yamlContent, &dslConfig)
+	assert.NoError(t, err, "Complex workflow should parse without error")
+
+	assert.Equal(t, 1, len(dslConfig.Steps), "Should have one sequential step")
+	assert.Equal(t, "prepare", dslConfig.Steps[0].Name)
+	assert.Contains(t, dslConfig.ParallelSteps, "group_one", "Parallel group should be parsed")
+	assert.Equal(t, 2, len(dslConfig.ParallelSteps["group_one"]), "Parallel group should contain both steps")
+	assert.Contains(t, dslConfig.Loops, "build", "Named loop should be parsed")
+	assert.Equal(t, []string{"build"}, dslConfig.ExecuteLoops, "execute_loops should be parsed")
+	assert.Contains(t, dslConfig.Defer, "cleanup", "Deferred step should be parsed")
 }
 
 func TestHandleProcessStreaming(t *testing.T) {

--- a/utils/server/openai_handlers.go
+++ b/utils/server/openai_handlers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/fileutil"
 	"github.com/kris-hansen/comanda/utils/processor"
 	"gopkg.in/yaml.v3"
@@ -207,18 +207,13 @@ func (s *Server) handleNonStreamingChatCompletion(w http.ResponseWriter, r *http
 		return
 	}
 
-	var rawConfig map[string]processor.StepConfig
-	if err := yaml.Unmarshal(yamlContent, &rawConfig); err != nil {
+	// Unmarshal using the DSLConfig custom unmarshaler (same as CLI) so that
+	// ordered steps and top-level blocks (parallel, loops, defer, workflow)
+	// are all handled correctly
+	var dslConfig processor.DSLConfig
+	if err := yaml.Unmarshal(yamlContent, &dslConfig); err != nil {
 		sendOpenAIError(w, http.StatusInternalServerError, "server_error", "Failed to parse workflow: "+err.Error())
 		return
-	}
-
-	var dslConfig processor.DSLConfig
-	for name, stepConfig := range rawConfig {
-		dslConfig.Steps = append(dslConfig.Steps, processor.Step{
-			Name:   name,
-			Config: stepConfig,
-		})
 	}
 
 	// Create processor
@@ -323,18 +318,13 @@ func (s *Server) handleStreamingChatCompletion(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	var rawConfig map[string]processor.StepConfig
-	if err := yaml.Unmarshal(yamlContent, &rawConfig); err != nil {
+	// Unmarshal using the DSLConfig custom unmarshaler (same as CLI) so that
+	// ordered steps and top-level blocks (parallel, loops, defer, workflow)
+	// are all handled correctly
+	var dslConfig processor.DSLConfig
+	if err := yaml.Unmarshal(yamlContent, &dslConfig); err != nil {
 		sendStreamError(w, flusher, "Failed to parse workflow: "+err.Error())
 		return
-	}
-
-	var dslConfig processor.DSLConfig
-	for name, stepConfig := range rawConfig {
-		dslConfig.Steps = append(dslConfig.Steps, processor.Step{
-			Name:   name,
-			Config: stepConfig,
-		})
 	}
 
 	// Create processor
@@ -357,8 +347,14 @@ func (s *Server) handleStreamingChatCompletion(w http.ResponseWriter, r *http.Re
 	progressWriter := processor.NewChannelProgressWriter(progressChan)
 	proc.SetProgressWriter(progressWriter)
 
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+	// Long-running workflows can stream for a long time; clear the server's
+	// write deadline for this response and only apply a timeout if one is
+	// explicitly configured
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		config.DebugLog("Could not clear write deadline for streaming: %v", err)
+	}
+	ctx, cancel := streamingContext(r.Context(), s.config)
 	defer cancel()
 
 	// Run processor in goroutine

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -245,14 +245,42 @@ func New(envConfig *config.EnvConfig) (*http.Server, error) {
 	return server, nil
 }
 
+// serverVersion is the comanda version reported by /health. It is injected
+// at startup (see SetVersion) because the version string lives in the cmd
+// package, which imports this one.
+var serverVersion string
+
+// SetVersion sets the version string reported by the /health endpoint
+func SetVersion(v string) {
+	serverVersion = v
+}
+
+// capabilities returns the feature flags reported by /health so clients can
+// progressively enable functionality based on what this server supports
+func (s *Server) capabilities() []string {
+	caps := []string{
+		"full-dsl",          // /process, /yaml/process parse the complete DSL (parallel, loops, defer, workflow)
+		"yaml-validate",     // POST /yaml/validate
+		"log-events",        // SSE "log" events with stream-log lines during streaming execution
+		"progress-metrics",  // SSE "progress" events include per-step performance metrics
+		"stream-no-timeout", // streaming runs are not time-limited unless configured
+	}
+	if s.config.OpenAICompat.Enabled {
+		caps = append(caps, "openai-compat")
+	}
+	return caps
+}
+
 // routes sets up the server routes
 func (s *Server) routes() {
 	// Health check endpoint - no auth required
 	s.mux.HandleFunc("/health", s.combinedMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(HealthResponse{
-			Status:    "ok",
-			Timestamp: time.Now().Format(time.RFC3339),
+			Status:       "ok",
+			Timestamp:    time.Now().Format(time.RFC3339),
+			Version:      serverVersion,
+			Capabilities: s.capabilities(),
 		})
 	}))
 
@@ -374,6 +402,7 @@ func (s *Server) routes() {
 	// YAML operations - require auth
 	s.mux.HandleFunc("/yaml/upload", s.combinedMiddleware(s.handleYAMLUpload))
 	s.mux.HandleFunc("/yaml/process", s.combinedMiddleware(s.handleYAMLProcess))
+	s.mux.HandleFunc("/yaml/validate", s.combinedMiddleware(s.handleYAMLValidate))
 
 	// Process endpoint - requires auth
 	s.mux.HandleFunc("/process", s.combinedMiddleware(func(w http.ResponseWriter, r *http.Request) {

--- a/utils/server/types.go
+++ b/utils/server/types.go
@@ -27,8 +27,10 @@ type ProcessResponse struct {
 
 // HealthResponse represents the health check response
 type HealthResponse struct {
-	Status    string `json:"status"`
-	Timestamp string `json:"timestamp"`
+	Status       string   `json:"status"`
+	Timestamp    string   `json:"timestamp"`
+	Version      string   `json:"version,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // FileInfo represents detailed information about a file
@@ -155,6 +157,11 @@ func (fw *flushingResponseWriter) Flush() {
 	fw.flusher.Flush()
 }
 
+// Unwrap exposes the underlying writer so http.ResponseController can reach it
+func (fw *flushingResponseWriter) Unwrap() http.ResponseWriter {
+	return fw.ResponseWriter
+}
+
 // responseWriter wraps http.ResponseWriter to capture the status code and implement http.Flusher
 type responseWriter struct {
 	http.ResponseWriter
@@ -167,6 +174,11 @@ func (rw *responseWriter) Flush() {
 	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// Unwrap exposes the underlying writer so http.ResponseController can reach it
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
@@ -362,6 +374,28 @@ func (sw *sseWriter) SendHeartbeat() (n int, err error) {
 	}
 	sw.f.Flush()
 	debugLog("[SSE] Successfully sent heartbeat event: bytes=%d", n)
+	return
+}
+
+// SendLog sends a stream log line (loop iterations, context usage, tool
+// activity) as a structured SSE event. Lines use the same format as the
+// CLI's --stream-log file output.
+func (sw *sseWriter) SendLog(line string) (n int, err error) {
+	data := map[string]string{
+		"line": line,
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		debugLog("[SSE] Error marshaling log data: %v", err)
+		return 0, err
+	}
+	event := fmt.Sprintf("event: log\ndata: %s\n\n", string(jsonData))
+	n, err = sw.w.Write([]byte(event))
+	if err != nil {
+		debugLog("[SSE] Error writing log event: %v", err)
+		return
+	}
+	sw.f.Flush()
 	return
 }
 

--- a/utils/server/validate_handler.go
+++ b/utils/server/validate_handler.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/models"
+	"github.com/kris-hansen/comanda/utils/processor"
+)
+
+// ValidateRequest represents the request body for the validate endpoint
+type ValidateRequest struct {
+	Content string `json:"content"`
+	// CheckModels also validates model names against the models configured
+	// on this server (plus any detected CLI providers)
+	CheckModels bool `json:"checkModels,omitempty"`
+}
+
+// ValidationIssue represents a single validation error with actionable feedback
+type ValidationIssue struct {
+	Line    int    `json:"line,omitempty"`
+	Field   string `json:"field,omitempty"`
+	Message string `json:"message"`
+	Fix     string `json:"fix,omitempty"`
+}
+
+// ValidateResponse represents the response for the validate endpoint
+type ValidateResponse struct {
+	Success       bool              `json:"success"`
+	Valid         bool              `json:"valid"`
+	Errors        []ValidationIssue `json:"errors,omitempty"`
+	InvalidModels []string          `json:"invalidModels,omitempty"`
+	Error         string            `json:"error,omitempty"`
+}
+
+// collectAvailableModels returns all models configured on this server plus
+// models provided by locally detected CLI providers
+func collectAvailableModels(envConfig *config.EnvConfig) []string {
+	availableModels := envConfig.GetAllConfiguredModels()
+
+	// Add Claude Code models if the claude binary is available
+	if models.IsClaudeCodeAvailable() {
+		claudeCodeModels := []string{"claude-code", "claude-code-opus", "claude-code-sonnet", "claude-code-haiku"}
+		availableModels = append(availableModels, claudeCodeModels...)
+	}
+
+	// Add Gemini CLI models if the gemini binary is available
+	if models.IsGeminiCLIAvailable() {
+		geminiCLIModels := []string{"gemini-cli", "gemini-cli-pro", "gemini-cli-flash", "gemini-cli-flash-lite"}
+		availableModels = append(availableModels, geminiCLIModels...)
+	}
+
+	// Add OpenAI Codex models if the codex binary is available
+	if models.IsOpenAICodexAvailable() {
+		availableModels = append(availableModels, models.GetOpenAICodexModels()...)
+	}
+
+	// Add Kimi Code models if the kimi binary is available
+	if models.IsKimiCodeAvailable() {
+		kimiCodeModels := []string{"kimi-code"}
+		availableModels = append(availableModels, kimiCodeModels...)
+	}
+
+	return availableModels
+}
+
+// handleYAMLValidate validates workflow YAML without executing it.
+// It runs the same structural validation used by the generate endpoint's
+// retry loop and, optionally, checks model names against this server's
+// configured models.
+func (s *Server) handleYAMLValidate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(ValidateResponse{
+			Success: false,
+			Error:   "Method not allowed. Use POST.",
+		})
+		return
+	}
+
+	var req ValidateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ValidateResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	if req.Content == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ValidateResponse{
+			Success: false,
+			Error:   "content is required",
+		})
+		return
+	}
+
+	result := processor.ValidateWorkflowStructure(req.Content)
+
+	response := ValidateResponse{
+		Success: true,
+		Valid:   result.Valid,
+	}
+	for _, e := range result.Errors {
+		response.Errors = append(response.Errors, ValidationIssue{
+			Line:    e.Line,
+			Field:   e.Field,
+			Message: e.Message,
+			Fix:     e.Fix,
+		})
+	}
+
+	if req.CheckModels {
+		availableModels := collectAvailableModels(s.envConfig)
+		invalidModels := processor.ValidateWorkflowModels(req.Content, availableModels)
+		if len(invalidModels) > 0 {
+			response.Valid = false
+			response.InvalidModels = invalidModels
+			for _, m := range invalidModels {
+				response.Errors = append(response.Errors, ValidationIssue{
+					Field:   m,
+					Message: fmt.Sprintf("Model '%s' is not configured on this server", m),
+					Fix:     "Use a model from this server's configured providers, or configure the model first",
+				})
+			}
+		}
+	}
+
+	config.DebugLog("Validated workflow YAML: valid=%v errors=%d", response.Valid, len(response.Errors))
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}

--- a/utils/server/validate_handler_test.go
+++ b/utils/server/validate_handler_test.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+)
+
+func newValidateTestServer(t *testing.T) *Server {
+	t.Helper()
+	server := &Server{
+		mux: http.NewServeMux(),
+		config: &config.ServerConfig{
+			DataDir:     t.TempDir(),
+			BearerToken: "test-token",
+			Enabled:     true,
+		},
+		envConfig: &config.EnvConfig{
+			Providers: map[string]*config.Provider{
+				"openai": {
+					APIKey: "test-key",
+					Models: []config.Model{
+						{
+							Name:  "gpt-4o",
+							Modes: []config.ModelMode{config.TextMode},
+						},
+					},
+				},
+			},
+		},
+	}
+	server.routes()
+	return server
+}
+
+func postValidate(t *testing.T, server *Server, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/yaml/validate", bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandleYAMLValidateValidWorkflow(t *testing.T) {
+	server := newValidateTestServer(t)
+
+	validYAML := `
+analyze:
+  input: STDIN
+  model: gpt-4o
+  action: "Analyze this text"
+  output: STDOUT
+`
+	w := postValidate(t, server, ValidateRequest{Content: validYAML})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ValidateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Success {
+		t.Errorf("Expected success=true, got false: %s", resp.Error)
+	}
+	if !resp.Valid {
+		t.Errorf("Expected valid=true, got false with errors: %+v", resp.Errors)
+	}
+}
+
+func TestHandleYAMLValidateInvalidWorkflow(t *testing.T) {
+	server := newValidateTestServer(t)
+
+	// Step missing required model/action fields
+	invalidYAML := `
+broken_step:
+  input: STDIN
+`
+	w := postValidate(t, server, ValidateRequest{Content: invalidYAML})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ValidateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Success {
+		t.Errorf("Expected success=true, got false: %s", resp.Error)
+	}
+	if resp.Valid {
+		t.Error("Expected valid=false for workflow with missing fields")
+	}
+	if len(resp.Errors) == 0 {
+		t.Error("Expected validation errors to be reported")
+	}
+	for _, e := range resp.Errors {
+		if e.Message == "" {
+			t.Error("Validation errors should include a message")
+		}
+	}
+}
+
+func TestHandleYAMLValidateModelCheck(t *testing.T) {
+	server := newValidateTestServer(t)
+
+	yamlWithUnknownModel := `
+analyze:
+  input: STDIN
+  model: totally-unknown-model
+  action: "Analyze this text"
+  output: STDOUT
+`
+	w := postValidate(t, server, ValidateRequest{Content: yamlWithUnknownModel, CheckModels: true})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ValidateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Valid {
+		t.Error("Expected valid=false for workflow using an unconfigured model")
+	}
+	found := false
+	for _, m := range resp.InvalidModels {
+		if m == "totally-unknown-model" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Expected invalidModels to contain 'totally-unknown-model', got %v", resp.InvalidModels)
+	}
+}
+
+func TestHandleYAMLValidateMissingContent(t *testing.T) {
+	server := newValidateTestServer(t)
+
+	w := postValidate(t, server, ValidateRequest{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleYAMLValidateMethodNotAllowed(t *testing.T) {
+	server := newValidateTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/yaml/validate", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status 405, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHealthEndpointReportsVersionAndCapabilities(t *testing.T) {
+	server := newValidateTestServer(t)
+	SetVersion("v1.2.3-test")
+	defer SetVersion("")
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp HealthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("Expected status ok, got %s", resp.Status)
+	}
+	if resp.Version != "v1.2.3-test" {
+		t.Errorf("Expected version v1.2.3-test, got %s", resp.Version)
+	}
+
+	want := []string{"full-dsl", "yaml-validate", "log-events", "progress-metrics", "stream-no-timeout"}
+	caps := make(map[string]bool)
+	for _, c := range resp.Capabilities {
+		caps[c] = true
+	}
+	for _, c := range want {
+		if !caps[c] {
+			t.Errorf("Expected capability %q in %v", c, resp.Capabilities)
+		}
+	}
+	if caps["openai-compat"] {
+		t.Error("openai-compat capability should not be reported when disabled")
+	}
+}


### PR DESCRIPTION
## Summary

Brings the HTTP server API up to parity with the CLI and makes long-running workflows observable and controllable over HTTP. These gaps surfaced while building an API client for remote workflow execution.

### Full workflow DSL over HTTP
`/process`, `/yaml/process`, and `/v1/chat/completions` previously unmarshaled workflow YAML into `map[string]processor.StepConfig`, which meant:
- Top-level blocks (`parallel:`, `agentic-loop:`, `loops:`, `execute_loops:`, `defer:`, `workflow:`, worktrees) failed or were silently mis-parsed server-side.
- Go map iteration executed even plain linear workflows in nondeterministic order.

All three endpoints now unmarshal into `processor.DSLConfig` via its custom unmarshaler — the exact same parse path as `comanda process` — so any workflow that runs locally runs identically over HTTP. This also fixes the OpenAI-compat endpoint, which inherited the flat-map limitation.

### No more 5-minute streaming cutoff
- The hardcoded `context.WithTimeout(..., 5*time.Minute)` on streaming `/process` and `/v1/chat/completions` is gone. Agentic loops routinely run for tens of minutes; streams now run until completion or client disconnect (the existing 15s SSE heartbeats keep the connection alive).
- A new optional `streamTimeoutSeconds` server config setting restores a server-side limit for operators who want one.
- SSE responses clear the per-response write deadline (`http.ResponseController`), so the global 120s `WriteTimeout` on the `http.Server` no longer kills long streams either (the response-writer wrappers gained `Unwrap()` to support this).

### Structured progress for long-running workflows
- New `log` SSE event streams the same lines the CLI writes to its `--stream-log` file — `ITERATION x/y - name`, `CONTEXT: ...`, tool activity, `★ EXIT: ...` — via a new callback sink on `StreamLogger` (`Processor.SetStreamLogCallback`). Clients that already parse the stream-log file format can reuse the parser for remote runs.
- Step `progress` events now include the `PerformanceMetrics` that were previously captured but dropped from the SSE payload (`metrics: {input_ms, model_ms, action_ms, output_ms, total_ms}`).

### New `POST /yaml/validate`
Validates workflow YAML without executing it, reusing `ValidateWorkflowStructure` (already used internally by `/generate`'s retry loop) and optionally `ValidateWorkflowModels` against the server's configured models. Returns structured `{line, field, message, fix}` errors suitable for inline display in editors.

### `/health` version + capabilities
`/health` now reports the comanda version and a capabilities list (`full-dsl`, `yaml-validate`, `log-events`, `progress-metrics`, `stream-no-timeout`, `openai-compat`) so API clients can feature-detect and progressively enable functionality against older servers.

### Docs
Updated `docs/server-api.md` and `docs/openapi.yaml`: new endpoint and events, health schema (the old documented schema didn't match the actual response), and corrected `ProcessRequest.input` to optional (it always was).

## Test plan
- [x] `go test ./...` passes
- [x] New tests: server-side parsing of complex workflows (parallel groups, loops, `execute_loops`, `defer`), ordered-parity test between CLI and server parsing, `/yaml/validate` (valid, invalid structure, unknown model, missing content, wrong method), `/health` version/capabilities, `StreamLogger` callback sink (callback-only and file+callback)
- [x] `docs/openapi.yaml` parses as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)