### PR TITLE
fix: panic in request logging on short Authorization header

### DIFF
--- a/utils/server/logging.go
+++ b/utils/server/logging.go
@@ -14,6 +14,17 @@ import (
 // logger is a custom logger for HTTP requests, shared across the package
 var logger = log.New(os.Stdout, "", log.LstdFlags)
 
+// maskAuthHeader redacts the credential portion of an Authorization
+// header value. It tolerates malformed or truncated values (e.g. a bare
+// "Bearer" with no token) instead of panicking.
+func maskAuthHeader(auth string) string {
+	const bearerPrefix = "Bearer "
+	if rest, ok := strings.CutPrefix(auth, bearerPrefix); ok && rest != "" {
+		return bearerPrefix + "********"
+	}
+	return "********"
+}
+
 func logRequest(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -22,7 +33,7 @@ func logRequest(handler http.HandlerFunc) http.HandlerFunc {
 		// Build auth info string, masking the token
 		var authInfo string
 		if auth := r.Header.Get("Authorization"); auth != "" {
-			authInfo = strings.Replace(auth, auth[7:], "********", 1)
+			authInfo = maskAuthHeader(auth)
 		}
 
 		// Debug level logging - more detailed internal information

--- a/utils/server/logging_test.go
+++ b/utils/server/logging_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMaskAuthHeader(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bearer token", "Bearer abc123secret", "Bearer ********"},
+		{"bearer with trailing space only", "Bearer ", "********"},
+		{"bare bearer, no space", "Bearer", "********"},
+		{"shorter than prefix", "Bear", "********"},
+		{"basic scheme", "Basic dXNlcjpwYXNz", "********"},
+		{"empty", "", "********"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maskAuthHeader(tt.input); got != tt.want {
+				t.Errorf("maskAuthHeader(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// Regression test: a short/malformed Authorization header must not panic
+// the request logger (previously: slice bounds out of range [7:6]).
+func TestLogRequestDoesNotPanicOnShortAuthHeader(t *testing.T) {
+	handler := logRequest(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for _, header := range []string{"Bearer", "Bearer ", "Bear", "Basic xyz"} {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Authorization", header)
+		rec := httptest.NewRecorder()
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("logRequest panicked for Authorization: %q: %v", header, r)
+				}
+			}()
+			handler(rec, req)
+		}()
+	}
+}


### PR DESCRIPTION
## Summary

`logRequest` (`utils/server/logging.go:25`) masked the bearer token via `auth[7:]`, panicking with `slice bounds out of range [7:6]` whenever the `Authorization` header was shorter than 7 chars. Trigger: a client sending `Authorization: Bearer ` with an empty API key — Go's header parsing trims the trailing space, leaving `Bearer` (6 chars). The panic killed the connection mid-response, surfacing client-side as `ClientException: Connection closed before full header was received` on every endpoint (`/providers`, `/list`, …).

## Fix

New `maskAuthHeader` helper: masks the credential only when a non-empty token follows the `Bearer ` prefix, tolerates malformed/short values (returns `********`). `strings.CutPrefix` instead of fixed-position slicing.

## Testing

- New `utils/server/logging_test.go`: table-driven `maskAuthHeader` cases plus a no-panic regression test driving `logRequest` with `Bearer`, `Bearer `, `Bear`, `Basic xyz`.
- `go test ./utils/server/` and `go vet` clean.