### PR TITLE
Expose CLI agent providers in /providers API

### DIFF
--- a/utils/discovery/discovery.go
+++ b/utils/discovery/discovery.go
@@ -250,8 +250,26 @@ func GetVLLMModels() ([]VLLMModel, error) {
 	return response.Data, nil
 }
 
+// getCLIAgentModels returns the static model list for a CLI agent provider.
+// These mirror the models shown by `comanda configure --list`.
+func getCLIAgentModels(providerName string) ([]string, error) {
+	switch providerName {
+	case "claude-code":
+		return []string{"claude-code", "claude-code-opus", "claude-code-sonnet", "claude-code-haiku"}, nil
+	case "gemini-cli":
+		return []string{"gemini-cli", "gemini-cli-pro", "gemini-cli-flash", "gemini-cli-flash-lite"}, nil
+	case "openai-codex":
+		return models.GetOpenAICodexModels(), nil
+	case "kimi-code":
+		return []string{"kimi-code"}, nil
+	default:
+		return nil, fmt.Errorf("unknown CLI agent provider: %s", providerName)
+	}
+}
+
 // GetAvailableModels retrieves the list of available models for a given provider.
 // For providers like OpenAI and Ollama, it requires the API key or connection.
+// For CLI agents, it returns the static model list when the binary is detected.
 // For others, it returns a hardcoded list.
 func GetAvailableModels(providerName string, apiKey string) ([]string, error) {
 	switch providerName {
@@ -289,6 +307,8 @@ func GetAvailableModels(providerName string, apiKey string) ([]string, error) {
 		return modelNames, nil
 	case "llama.cpp":
 		return GetLlamaCPPModels()
+	case "claude-code", "gemini-cli", "openai-codex", "kimi-code":
+		return getCLIAgentModels(providerName)
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", providerName)
 	}

--- a/utils/server/provider_handlers.go
+++ b/utils/server/provider_handlers.go
@@ -21,7 +21,56 @@ func sendJSONError(w http.ResponseWriter, statusCode int, message string) {
 	})
 }
 
-// handleGetProviders returns the list of configured providers and their models
+// cliAgentInfo describes a CLI-based agent provider that is auto-detected
+// from the local environment rather than configured with an API key.
+type cliAgentInfo struct {
+	name      string
+	models    []string
+	available func() bool
+}
+
+// cliAgentProviders returns the supported CLI agent providers and their
+// model lists. These are kept in sync with the model registry and the
+// interactive configure command.
+func cliAgentProviders() []cliAgentInfo {
+	return []cliAgentInfo{
+		{
+			name:      "claude-code",
+			models:    []string{"claude-code", "claude-code-opus", "claude-code-sonnet", "claude-code-haiku"},
+			available: models.IsClaudeCodeAvailable,
+		},
+		{
+			name:      "gemini-cli",
+			models:    []string{"gemini-cli", "gemini-cli-pro", "gemini-cli-flash", "gemini-cli-flash-lite"},
+			available: models.IsGeminiCLIAvailable,
+		},
+		{
+			name:      "openai-codex",
+			models:    models.GetOpenAICodexModels(),
+			available: models.IsOpenAICodexAvailable,
+		},
+		{
+			name:      "kimi-code",
+			models:    []string{"kimi-code"},
+			available: models.IsKimiCodeAvailable,
+		},
+	}
+}
+
+// isCLIAgentProvider reports whether the given provider name is a CLI agent.
+func isCLIAgentProvider(name string) bool {
+	for _, agent := range cliAgentProviders() {
+		if agent.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// handleGetProviders returns the list of configured providers and their models.
+// CLI agent providers (claude-code, gemini-cli, openai-codex, kimi-code) are
+// included automatically when their binaries are detected, even if they have
+// not been explicitly added to the configuration file.
 func (s *Server) handleGetProviders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -30,6 +79,7 @@ func (s *Server) handleGetProviders(w http.ResponseWriter, r *http.Request) {
 	}
 
 	providers := []ProviderInfo{}
+	seen := make(map[string]bool)
 
 	// Get provider instances
 	providerList := []struct {
@@ -55,7 +105,33 @@ func (s *Server) handleGetProviders(w http.ResponseWriter, r *http.Request) {
 					Models:  getModelNames(provider.Models),
 					Enabled: provider.APIKey != "",
 				})
+				seen[p.name] = true
 			}
+		}
+	}
+
+	// Add CLI agent providers. If a CLI agent was also present in the
+	// configuration file, merge with the auto-detected entry and use binary
+	// availability as the enabled signal.
+	for _, agent := range cliAgentProviders() {
+		info := ProviderInfo{
+			Name:    agent.name,
+			Models:  agent.models,
+			Enabled: agent.available(),
+		}
+		if seen[agent.name] {
+			for i := range providers {
+				if providers[i].Name == agent.name {
+					// Preserve any configured models but reflect actual availability.
+					if len(providers[i].Models) > 0 {
+						info.Models = providers[i].Models
+					}
+					providers[i] = info
+					break
+				}
+			}
+		} else {
+			providers = append(providers, info)
 		}
 	}
 
@@ -108,7 +184,7 @@ func (s *Server) handleGetAvailableModels(w http.ResponseWriter, r *http.Request
 	apiKey := ""
 	if err == nil { // Provider exists, get its key
 		apiKey = providerConfig.APIKey
-	} else if providerName != "ollama" && providerName != "vllm" && providerName != "llama.cpp" && providerName != "anthropic" && providerName != "google" && providerName != "xai" && providerName != "deepseek" && providerName != "sakana" {
+	} else if !isKeylessProvider(providerName) {
 		// If provider doesn't exist and requires a key, we can't proceed
 		sendJSONError(w, http.StatusBadRequest, fmt.Sprintf("Provider '%s' not configured or requires an API key to list models", providerName))
 		return
@@ -293,7 +369,41 @@ func (s *Server) handleDeleteModel(w http.ResponseWriter, r *http.Request, provi
 	})
 }
 
-// handleValidateProvider validates a provider's API key
+// createProviderByName returns a provider instance for the given provider name.
+// It recognizes both API/local providers and CLI agent providers.
+func createProviderByName(name string) models.Provider {
+	switch name {
+	case "openai":
+		return models.NewOpenAIProvider()
+	case "anthropic":
+		return models.NewAnthropicProvider()
+	case "google":
+		return models.NewGoogleProvider()
+	case "xai":
+		return models.NewXAIProvider()
+	case "sakana":
+		return models.NewSakanaProvider()
+	case "ollama":
+		return models.NewOllamaProvider()
+	case "vllm":
+		return models.NewVLLMProvider()
+	case "llama.cpp":
+		return models.NewLlamaCPPProvider()
+	case "claude-code":
+		return models.NewClaudeCodeProvider()
+	case "gemini-cli":
+		return models.NewGeminiCLIProvider()
+	case "openai-codex":
+		return models.NewOpenAICodexProvider()
+	case "kimi-code":
+		return models.NewKimiCodeProvider()
+	default:
+		return nil
+	}
+}
+
+// handleValidateProvider validates a provider's API key. For CLI agent
+// providers, it validates that the underlying CLI binary is available.
 func (s *Server) handleValidateProvider(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -311,29 +421,26 @@ func (s *Server) handleValidateProvider(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Create provider instance
-	var provider models.Provider
-	switch req.Name {
-	case "openai":
-		provider = models.NewOpenAIProvider()
-	case "anthropic":
-		provider = models.NewAnthropicProvider()
-	case "google":
-		provider = models.NewGoogleProvider()
-	case "xai":
-		provider = models.NewXAIProvider()
-	case "sakana":
-		provider = models.NewSakanaProvider()
-	case "ollama":
-		provider = models.NewOllamaProvider()
-	case "vllm":
-		provider = models.NewVLLMProvider()
-	case "llama.cpp":
-		provider = models.NewLlamaCPPProvider()
-	default:
+	provider := createProviderByName(req.Name)
+	if provider == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]string{
 			"error": fmt.Sprintf("Unknown provider: %s", req.Name),
+		})
+		return
+	}
+
+	// CLI agents do not require an API key; verify the binary is available.
+	if isCLIAgentProvider(req.Name) {
+		if !isCLIAgentAvailable(req.Name) {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": fmt.Sprintf("%s CLI binary is not available", req.Name),
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": fmt.Sprintf("%s CLI binary is available", req.Name),
 		})
 		return
 	}
@@ -350,6 +457,33 @@ func (s *Server) handleValidateProvider(w http.ResponseWriter, r *http.Request) 
 	json.NewEncoder(w).Encode(map[string]string{
 		"message": "API key is valid",
 	})
+}
+
+// isCLIAgentAvailable reports whether the named CLI agent binary is installed.
+func isCLIAgentAvailable(name string) bool {
+	switch name {
+	case "claude-code":
+		return models.IsClaudeCodeAvailable()
+	case "gemini-cli":
+		return models.IsGeminiCLIAvailable()
+	case "openai-codex":
+		return models.IsOpenAICodexAvailable()
+	case "kimi-code":
+		return models.IsKimiCodeAvailable()
+	}
+	return false
+}
+
+// isKeylessProvider reports whether a provider can list models without an
+// API key (local providers and CLI agents).
+func isKeylessProvider(name string) bool {
+	switch name {
+	case "ollama", "vllm", "llama.cpp",
+		"anthropic", "google", "xai", "deepseek", "sakana",
+		"claude-code", "gemini-cli", "openai-codex", "kimi-code":
+		return true
+	}
+	return false
 }
 
 // getModelNames extracts model names from config.Model slice
@@ -389,6 +523,26 @@ func (s *Server) handleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 		s.envConfig.AddProvider(req.Name, *provider)
 	}
 
+	// Validate that the provider name is known before mutating config.
+	providerInstance := createProviderByName(req.Name)
+	if providerInstance == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": fmt.Sprintf("Unknown provider: %s", req.Name),
+		})
+		return
+	}
+
+	// CLI agents do not use API keys; ensure the binary is available when
+	// explicitly configuring one.
+	if isCLIAgentProvider(req.Name) && !isCLIAgentAvailable(req.Name) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": fmt.Sprintf("%s CLI binary is not available", req.Name),
+		})
+		return
+	}
+
 	// Update API key if provided
 	if req.APIKey != "" {
 		if err := s.envConfig.UpdateAPIKey(req.Name, req.APIKey); err != nil {
@@ -399,41 +553,12 @@ func (s *Server) handleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Configure the provider with the new API key
-		var provider models.Provider
-		switch req.Name {
-		case "openai":
-			provider = models.NewOpenAIProvider()
-		case "anthropic":
-			provider = models.NewAnthropicProvider()
-		case "google":
-			provider = models.NewGoogleProvider()
-		case "xai":
-			provider = models.NewXAIProvider()
-		case "sakana":
-			provider = models.NewSakanaProvider()
-		case "ollama":
-			provider = models.NewOllamaProvider()
-		case "vllm":
-			provider = models.NewVLLMProvider()
-		case "llama.cpp":
-			provider = models.NewLlamaCPPProvider()
-		default:
-			w.WriteHeader(http.StatusBadRequest)
+		if err := providerInstance.Configure(req.APIKey); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{
-				"error": fmt.Sprintf("Unknown provider: %s", req.Name),
+				"error": fmt.Sprintf("Error configuring provider: %v", err),
 			})
 			return
-		}
-
-		if provider != nil {
-			if err := provider.Configure(req.APIKey); err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				json.NewEncoder(w).Encode(map[string]string{
-					"error": fmt.Sprintf("Error configuring provider: %v", err),
-				})
-				return
-			}
 		}
 	}
 

--- a/utils/server/provider_handlers_test.go
+++ b/utils/server/provider_handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/models"
 )
 
 func setTestComandaEnv(t *testing.T, envConfig *config.EnvConfig) {
@@ -249,5 +250,76 @@ func TestProviderRouteHandling(t *testing.T) {
 			}
 			// No need to check success response body for these tests yet
 		})
+	}
+}
+
+func TestHandleGetProvidersIncludesCLIAgents(t *testing.T) {
+	// Create test configuration with both an API provider and a CLI agent provider.
+	testConfig := &config.EnvConfig{
+		Providers: map[string]*config.Provider{
+			"openai": {
+				APIKey: "test-key",
+				Models: []config.Model{
+					{Name: "gpt-4", Modes: []config.ModelMode{config.TextMode}},
+				},
+			},
+			"kimi-code": {
+				APIKey: "",
+				Models: []config.Model{
+					{Name: "kimi-code", Type: "external", Modes: []config.ModelMode{config.TextMode, config.VisionMode, config.MultiMode, config.FileMode}},
+				},
+			},
+		},
+	}
+	setTestComandaEnv(t, testConfig)
+
+	server := &Server{
+		mux: http.NewServeMux(),
+		config: &config.ServerConfig{
+			BearerToken: "test-token",
+			Enabled:     true,
+		},
+		envConfig: testConfig,
+	}
+	server.routes()
+
+	req := httptest.NewRequest(http.MethodGet, "/providers", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	server.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status code %d, got %d. Body: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var response ProviderListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v. Body: %s", err, rec.Body.String())
+	}
+	if !response.Success {
+		t.Fatalf("Expected success response, got error: %s", response.Error)
+	}
+
+	providerNames := make(map[string]bool)
+	for _, p := range response.Providers {
+		providerNames[p.Name] = true
+	}
+
+	// API provider should be present.
+	if !providerNames["openai"] {
+		t.Errorf("Expected 'openai' provider in response")
+	}
+
+	// The configured CLI agent provider should be present.
+	if !providerNames["kimi-code"] {
+		t.Errorf("Expected 'kimi-code' provider in response")
+	}
+
+	// Auto-detected CLI agents that are installed should also be present.
+	if models.IsClaudeCodeAvailable() && !providerNames["claude-code"] {
+		t.Errorf("Expected 'claude-code' provider in response when CLI is available")
+	}
+	if models.IsOpenAICodexAvailable() && !providerNames["openai-codex"] {
+		t.Errorf("Expected 'openai-codex' provider in response when CLI is available")
 	}
 }


### PR DESCRIPTION
The HTTP server's /providers endpoint only listed API/local providers (openai, anthropic, ollama, etc.) and omitted CLI agents such as claude-code, gemini-cli, openai-codex, and kimi-code. These agents are already implemented as providers, auto-detected by , and usable from workflow YAML, but remote clients could not discover them through the API.

Changes:
- Include CLI agents in GET /providers with Enabled reflecting binary availability instead of an API key.
- Allow PUT /providers and validation to recognize CLI agent names.
- Allow GET /providers/{name}/models to return static model lists for CLI agents via the discovery package.
- Add test covering provider list inclusion of CLI agents.

Fixes the gap where locally installed CLI agents were invisible to the remote API.