### PR TITLE
feat: add project context and run preflight API

### DIFF
--- a/docs/graph-development-plan.md
+++ b/docs/graph-development-plan.md
@@ -1,0 +1,424 @@
+# Comanda Graph Development Plan
+
+## Decision
+
+Make the execution graph the first-class internal abstraction in Comanda, while
+keeping today's YAML pipeline syntax fully supported. The graph is not an
+LLM-invented execution plan: it is a static, inspectable, validated program
+that can be versioned, charted, tested, and replayed.
+
+The user-facing promise is:
+
+> Comanda turns multi-agent work into a reproducible program: coordination is
+> deterministic, parallelism is automatic where safe, and models are used only
+> where judgement is useful.
+
+The first product wedge is a native **diamond** pattern:
+
+```text
+scope -> fan-out specialists -> normalize/dedupe -> verifier(s) -> synthesis
+```
+
+It applies directly to code review, research, incident analysis, architecture
+decisions, and vendor evaluation. It demonstrates the important distinction:
+the model produces judgements; deterministic code performs normalization,
+deduplication, scheduling, provenance, and policy enforcement.
+
+## Why now
+
+Comanda has most of the ingredients already, but they live in separate paths:
+
+- sequential steps and `parallel-process` groups;
+- file-backed fan-in and dependency validation;
+- named agentic-loop DAGs, including cycle detection and topological ordering;
+- quality gates, worktrees, model selection, progress reporting, and charts.
+
+This means the project does **not** need to invent an agent framework. It needs
+one execution model that exposes those capabilities consistently. In
+particular, the current loop DAG is scheduled in a topological *sequence*, and
+the ordinary workflow path treats parallelism as a syntactic group. Neither is
+yet a general ready-node scheduler with explicit data contracts and edges.
+
+## Product principles
+
+1. **Graphs are declarative and static at run start.** A generator may choose
+   and fill a template, but its generated graph is shown, validated, and saved
+   before it runs. Runtime LLMs cannot silently add arbitrary nodes or tools.
+2. **Edges carry declared artifacts, not ambient prompt state.** A node reads
+   named, persisted artifacts from incoming edges. This makes provenance,
+   replay, caching, and inspection possible.
+3. **Use deterministic code for mechanical work.** Normalization, schema
+   validation, dedupe, artifact handling, fan-in, and scheduler decisions must
+   be Go components, not another prompt.
+4. **Schedule all ready nodes concurrently.** A node waits only for the gates
+   on its incoming edges; it does not wait for an unrelated branch or an
+   entire stage unless the graph says so.
+5. **Compatibility is a product requirement.** Existing linear YAML,
+   `parallel-process`, `defer`, loops, file artifacts, and `comanda process`
+   must retain their documented behavior during the migration.
+6. **Failure behavior is explicit.** Each node and edge declares whether to
+   fail fast, retry, skip, continue with a partial aggregate, or require human
+   intervention. There must be no accidental "best effort" synthesis.
+7. **Every result is traceable.** Persist node inputs, outputs, schema/gate
+   outcomes, model/provider metadata, duration, cost when available, and the
+   graph version under the runtime directory.
+
+## Target architecture
+
+```text
+YAML (legacy or graph) -> parser/lowering -> validated Graph IR -> planner
+                                                        |               |
+                                                        v               v
+                                                  artifact plan    ready-node scheduler
+                                                                        |
+                                                                        v
+      run record <- events/provenance <- executors (LLM, tool, Go transform, loop)
+                                                                        |
+                                                                        v
+                                 chart / logs / replay / final declared artifacts
+```
+
+### 1. Graph IR
+
+Introduce an internal `Graph` representation independent of YAML syntax. It
+contains stable node IDs, typed ports, edges, policies, resource hints, and a
+graph version. The IR is the only form accepted by the planner and executor.
+
+Lower existing workflows into it:
+
+- a sequential `STDOUT -> STDIN` chain becomes explicit sequential edges;
+- a file output/input pair becomes an explicit artifact edge;
+- a `parallel-process` group becomes independent nodes with no artificial
+  dependencies between them;
+- a loop remains a node executor initially; its internal orchestration stays
+  intact until it can be safely lowered further;
+- `defer` stays a conditional subgraph and is out of the first execution slice.
+
+This gives the migration one source of truth while preserving the existing DSL.
+
+### 2. Artifact and contract model
+
+A port describes an artifact, not merely a string prompt:
+
+- `name` and direction (`input` or `output`);
+- media/format (`text`, `json`, `markdown`, `file`, `patch`, etc.);
+- optional JSON Schema or file-based schema reference;
+- required/optional and cardinality (`one` or `many`);
+- retention and sensitivity classification;
+- provenance: producer node, content digest, timestamp, and validation state.
+
+The first implementation should support `text`, `markdown`, and `json`, with
+JSON Schema validation when a schema is declared. Existing files remain the
+physical artifact store; do not introduce a database requirement. Resolve
+runtime artifacts under `.comanda/runs/<run-id>/artifacts/`, while preserving
+documented user output paths through a final materialization step.
+
+### 3. Edges and gates
+
+An edge maps one source port to one destination port and controls when the
+consumer may run. Start with these gates:
+
+- `success` (default): producer completed and artifact contract passed;
+- `all_success`: a many-input fan-in waits for all required producers;
+- `allow_partial`: consumer may run after its required quorum succeeds, and
+  receives an explicit list of missing/failed artifacts;
+- `manual`: stop before crossing the edge until a user approves or resumes.
+
+Do not implement arbitrary expressions or model-written gates in v1. A simple,
+visible gate vocabulary is much easier to reason about and test.
+
+### 4. Ready-node scheduler
+
+The planner validates the DAG and builds reverse dependency indexes. The
+scheduler then:
+
+1. marks root nodes ready;
+2. runs every ready node subject to global and resource-class concurrency
+   limits;
+3. atomically records the attempt and its produced artifacts;
+4. evaluates only affected outgoing edges;
+5. releases newly-ready consumers, or applies their declared failure policy;
+6. exits with a complete run record, including skipped and blocked nodes.
+
+Ordering must be deterministic for equal-priority work (stable node-ID order),
+although execution is concurrent. Resource classes (`fast`, `standard`,
+`expensive`, `exclusive`) are admission-control hints, not a correctness
+mechanism. Per-provider/model concurrency and a workflow budget can be added
+once the core scheduler is proven.
+
+### 5. Executors
+
+Use a small executor interface behind graph nodes:
+
+- `llm`: existing model invocation;
+- `tool`: existing allowlisted tool execution;
+- `transform`: trusted built-in Go transforms, starting with JSON
+  normalization and finding deduplication;
+- `loop`: existing agentic-loop execution as an opaque node;
+- later: `router`, `approval`, and `subworkflow`.
+
+All executors receive resolved input artifacts and write declared output
+artifacts. They never choose downstream nodes directly.
+
+## Proposed graph DSL (design target, not first shipping parser)
+
+Use explicit ports and edges rather than string interpolation between steps.
+The syntax below is intentionally compact, but its exact field names should be
+settled after the Graph IR and fixtures exist.
+
+```yaml
+version: comanda.graph/v1
+
+inputs:
+  change:
+    format: text
+
+nodes:
+  scope:
+    kind: llm
+    model: gpt-4o
+    action: Produce a review plan and bounded file/module scope as JSON.
+    inputs:
+      change: { format: text }
+    outputs:
+      plan: { format: json, schema: ./schemas/review-plan.json }
+
+  security:
+    kind: llm
+    model: claude-sonnet-4-20250514
+    action: Review the scoped change for security findings. Return finding JSON.
+    inputs:
+      plan: { format: json }
+    outputs:
+      findings: { format: json, cardinality: many, schema: ./schemas/finding.json }
+    policy: { failure: retry }
+    resources: { class: standard }
+
+  correctness:
+    kind: llm
+    model: openai-codex
+    action: Review the scoped change for correctness and regressions. Return finding JSON.
+    inputs:
+      plan: { format: json }
+    outputs:
+      findings: { format: json, cardinality: many, schema: ./schemas/finding.json }
+
+  normalize:
+    kind: transform
+    transform: findings.normalize_dedupe
+    inputs:
+      candidates: { format: json, cardinality: many }
+    outputs:
+      findings: { format: json, schema: ./schemas/findings.json }
+
+  verify:
+    kind: llm
+    model: gpt-4o
+    action: Verify each normalized finding against the scoped change. Return verdict JSON.
+    inputs:
+      plan: { format: json }
+      findings: { format: json }
+    outputs:
+      verdicts: { format: json, schema: ./schemas/verdicts.json }
+
+  synthesize:
+    kind: llm
+    model: claude-sonnet-4-20250514
+    action: Produce a concise review using accepted verdicts only.
+    inputs:
+      verdicts: { format: json }
+    outputs:
+      review: { format: markdown }
+
+edges:
+  - { from: input.change, to: scope.change }
+  - { from: scope.plan, to: security.plan }
+  - { from: scope.plan, to: correctness.plan }
+  - { from: security.findings, to: normalize.candidates }
+  - { from: correctness.findings, to: normalize.candidates }
+  - { from: scope.plan, to: verify.plan }
+  - { from: normalize.findings, to: verify.findings, gate: all_success }
+  - { from: verify.verdicts, to: synthesize.verdicts }
+
+outputs:
+  review: synthesize.review
+```
+
+The `findings.normalize_dedupe` transform is deliberately a first-party Go
+component. It must emit a stable fingerprint, retain all source references,
+and record both retained and rejected/merged findings so a verifier and a human
+can audit it.
+
+## Delivery phases
+
+### Phase 0 — contracts, fixtures, and baseline (1 short milestone)
+
+Define the Graph IR, node/edge lifecycle, failure-state matrix, and artifact
+manifest format in code and documentation. Add fixtures for linear, fan-out,
+fan-in, failure, and cycle cases. Capture current behavior with integration
+tests before changing execution.
+
+Exit criteria:
+
+- a written compatibility matrix maps each current DSL feature to its migration
+  path;
+- fixtures define expected topology, run state, and output behavior;
+- existing test suite is green with no runtime behavior changed.
+
+### Phase 1 — lower legacy workflows and run the graph internally
+
+Implement `Graph`, `Node`, `Port`, `Edge`, `Artifact`, and `RunRecord` types.
+Lower ordinary sequential/file-backed workflows and existing parallel groups
+into the IR. Route them through a graph planner, but retain legacy execution as
+the comparison oracle behind a feature flag.
+
+Initially support static success-only edges, persisted artifacts, cycle/missing
+producer/type validation, and a bounded ready-node scheduler. Keep `defer` and
+complex loop orchestration on their current paths, represented as opaque nodes
+only where necessary.
+
+Exit criteria:
+
+- the same fixture can run through legacy and graph paths with equivalent
+  outputs and error semantics;
+- independent nodes overlap in time; dependent nodes do not start early;
+- graph execution has stable ordering, cancellation, cleanup, and a full run
+  record;
+- `comanda chart` renders the lowered edges correctly.
+
+### Phase 2 — ship the native diamond template
+
+Add the first user-facing graph template and built-in JSON transforms:
+normalization, stable fingerprinting, dedupe, and merge provenance. Add schema
+validation at node output boundaries and `all_success`/`allow_partial` fan-in
+gates. Provide a copy-ready code-review workflow plus a deterministic fixture.
+
+Exit criteria:
+
+- a three-specialist diamond schedules its specialists concurrently;
+- duplicate findings merge deterministically with all source IDs retained;
+- invalid output fails at the producing node with a clear contract error;
+- partial-mode synthesis explicitly identifies absent/failed branches;
+- chart, JSON run record, and terminal progress all expose node status,
+  artifact paths, gate results, model, and duration.
+
+### Phase 3 — policies, budget, and observability
+
+Add explicit retry/backoff, failure policies, resource/provider concurrency,
+timeouts, token/cost accounting where providers expose it, cache keys, and
+resume/replay of completed nodes. Quality gates become graph nodes or edge
+gates with the same run-record semantics rather than a loop-only feature.
+
+Exit criteria:
+
+- a run can resume without re-running valid, cacheable ancestors;
+- policy decisions and budget stops are visible and reproducible;
+- no provider or resource class can exceed its declared concurrency limit.
+
+### Phase 4 — selected templates and guarded generation
+
+Add inspectable templates for `pipeline`, `diamond`, `router`, and
+`verify-and-retry`. Extend `comanda generate` to select and fill a template,
+then require graph validation and a rendered chart before execution. Dynamic
+routing is limited to declared destinations and contracts.
+
+Exit criteria:
+
+- generated graph files are ordinary, reviewable YAML checked into source
+  control;
+- generated graphs cannot create undeclared tools, outputs, or destinations;
+- every template has validation fixtures and an example.
+
+## Implementation map
+
+| Area | Initial change |
+| --- | --- |
+| `utils/processor/types.go` | Add Graph IR, ports, edges, artifacts, policies, and run-record types. Keep `StepConfig` intact. |
+| `utils/processor/dsl.go` | Parse/lower legacy steps to Graph IR; dispatch the graph executor behind a flag, then make it the default after parity. |
+| `utils/processor/graph_*.go` (new) | Validation, planning, ready-node scheduling, state transitions, artifact persistence, and executor adapters. |
+| `utils/processor/quality_gates.go` | Adapt gates to graph-node/edge semantics in Phase 3; do not duplicate gate logic. |
+| `utils/processor/loop_orchestrator.go` | Preserve it first; later share the DAG scheduler rather than maintaining two schedulers. |
+| `cmd/chart.go` | Render IR edges, ports, gates, node state, and provenance; preserve current output formats. |
+| `examples/graph/` (new) | Diamond, partial fan-in, contract-failure, and replay examples. |
+| `docs/` | Graph spec, migration guide, failure-policy reference, and template authoring guide. |
+| tests | Golden topology tests, scheduler race tests, contract tests, parity tests, and integration fixtures. |
+
+## Work breakdown
+
+1. **Graph model and validator** — types, YAML-independent validation, cycle
+   reporting, artifact contracts, and golden tests.
+2. **Legacy lowering** — translate sequential/file/parallel workflows with a
+   compatibility fixture suite.
+3. **Scheduler and run record** — bounded concurrency, cancellation, stable
+   ordering, state transitions, and event/progress integration.
+4. **Executor adapters** — wrap existing LLM/tool/loop behavior without
+   changing provider semantics.
+5. **Chart and inspectability** — graph-aware Mermaid/ASCII output plus JSON
+   run manifest.
+6. **Diamond transforms and template** — normalize/dedupe implementation,
+   schemas, examples, and end-to-end tests.
+7. **Policies and resumption** — retries, partial fan-in, budgets, caches,
+   replay, and quality-gate unification.
+
+Each item should land as a small PR with its own fixtures. Do not combine the
+new DSL, scheduler rewrite, transforms, and template generator in one change.
+
+## Compatibility and migration rules
+
+- Existing workflow files remain valid and keep their documented stdout/file
+  behavior.
+- Existing `output: STDOUT` to `input: STDIN` and file-to-file flow remain
+  valid legacy syntax. Native graphs use ports and edges; they do not repurpose
+  `$VARIABLE` as general data flow.
+- Default execution remains bounded and deterministic. Concurrency is expanded
+  only when the graph proves that no dependency/gate exists.
+- Existing output paths remain user-visible outputs. Internal run artifacts are
+  additive and can be disabled only after equivalent debugging support exists.
+- Generated workflows are never auto-executed merely because generation
+  succeeded; they must parse, validate, and be visible to the user.
+
+## Key decisions to keep deliberately narrow
+
+Do now:
+
+- static DAGs;
+- file-backed artifacts plus contracts;
+- one shared scheduler;
+- deterministic transform nodes;
+- the code-review diamond.
+
+Defer:
+
+- LLM-authored arbitrary runtime graph mutation;
+- distributed execution or a database-backed artifact system;
+- a visual graph editor;
+- arbitrary edge expressions;
+- automatic semantic dedupe by an LLM;
+- turning every agentic loop into a general graph immediately.
+
+## Success measures
+
+- A graph chart answers: what ran, why it was eligible, what it consumed, what
+  it produced, and why any node was blocked or skipped.
+- For a diamond workflow, elapsed time approaches the longest specialist path,
+  not the sum of specialist paths.
+- A rerun can reuse valid upstream artifacts and reproduce the same graph plan.
+- A code-review output links each accepted/rejected finding to its source,
+  normalization decision, verification verdict, and final synthesis input.
+- Existing non-graph examples and integration tests continue to pass throughout
+  the migration.
+
+## First implementation slice
+
+Start with the smallest useful vertical slice:
+
+1. implement the internal Graph IR and lower only regular sequential steps,
+   explicit file edges, and one `parallel-process` group;
+2. run that graph with success-only dependencies and persisted run artifacts;
+3. add a graph-aware `comanda chart` view and parity tests;
+4. add the diamond example with two specialists, a deterministic Go
+   normalizer/deduper, one verifier, and one synthesizer.
+
+That proves the thesis without committing to a broad new language. Once that
+slice is boringly reliable, native graph YAML can become an opt-in surface and
+the remaining legacy paths can migrate one at a time.

--- a/utils/processor/codebase_index_handler.go
+++ b/utils/processor/codebase_index_handler.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -196,13 +197,17 @@ func (p *Processor) buildCodebaseIndexConfigWithError(stepConfig StepConfig) (*c
 		ci := stepConfig.CodebaseIndex
 
 		if ci.Root != "" {
-			// Expand ~ in root path
-			expandedRoot, err := fileutil.ExpandPath(ci.Root)
-			if err != nil {
-				p.debugf("Warning: failed to expand root path %s: %v", ci.Root, err)
-				config.Root = ci.Root // Fall back to unexpanded path
+			if p.sourceRoot != "" && !filepath.IsAbs(ci.Root) {
+				config.Root = filepath.Join(p.sourceRoot, ci.Root)
 			} else {
-				config.Root = expandedRoot
+				// Expand ~ in root path
+				expandedRoot, err := fileutil.ExpandPath(ci.Root)
+				if err != nil {
+					p.debugf("Warning: failed to expand root path %s: %v", ci.Root, err)
+					config.Root = ci.Root // Fall back to unexpanded path
+				} else {
+					config.Root = expandedRoot
+				}
 			}
 		}
 

--- a/utils/processor/codebase_index_handler.go
+++ b/utils/processor/codebase_index_handler.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -197,8 +196,12 @@ func (p *Processor) buildCodebaseIndexConfigWithError(stepConfig StepConfig) (*c
 		ci := stepConfig.CodebaseIndex
 
 		if ci.Root != "" {
-			if p.sourceRoot != "" && !filepath.IsAbs(ci.Root) {
-				config.Root = filepath.Join(p.sourceRoot, ci.Root)
+			if p.sourceRoot != "" {
+				projectRoot, err := ResolveProjectPath(p.sourceRoot, ci.Root)
+				if err != nil {
+					return nil, err
+				}
+				config.Root = projectRoot
 			} else {
 				// Expand ~ in root path
 				expandedRoot, err := fileutil.ExpandPath(ci.Root)

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -51,6 +51,7 @@ type Processor struct {
 	progress             ProgressWriter     // Progress writer for streaming updates
 	progressDisplay      *ProgressDisplay   // Visual progress display for terminal output
 	runtimeDir           string             // Runtime directory for file operations
+	sourceRoot           string             // Stable project root for source inputs and context
 	memory               *MemoryManager     // Memory manager for COMANDA.md file
 	externalMemory       string             // External memory context (e.g., from OpenAI messages)
 	mu                   sync.Mutex         // Mutex for thread-safe debug logging
@@ -61,6 +62,18 @@ type Processor struct {
 	currentStepWorktree  string             // Current step's worktree name (if any)
 	workflowFile         string             // Workflow file that created this processor, for loop state/checksums
 }
+
+// SetSourceRoot binds this processor to a stable project source tree. Runtime
+// outputs remain in runtimeDir; only source-oriented lookups fall back here.
+func (p *Processor) SetSourceRoot(root string) {
+	p.sourceRoot = root
+	if root != "" {
+		p.debugf("Processor initialized with project source root: %s", root)
+	}
+}
+
+// SourceRoot returns the stable project source tree, when one was selected.
+func (p *Processor) SourceRoot() string { return p.sourceRoot }
 
 // getEffectiveWorkDir returns the working directory for the current step
 // If a worktree is set for the current step, returns that path

--- a/utils/processor/input_handler.go
+++ b/utils/processor/input_handler.go
@@ -467,15 +467,59 @@ func (p *Processor) processRegularInput(inputPath string) error {
 	return p.processFile(filePath) // Pass the final, validated filePath
 }
 
-// resolveProjectInputPath confines an untrusted workflow input to the source
-// root selected by the server. filepath.IsLocal rejects absolute paths and
-// any traversal that could escape the registered project directory.
-func resolveProjectInputPath(sourceRoot, inputPath string) (string, error) {
+// ResolveProjectPath confines an untrusted workflow path to the source root
+// selected by the server. In addition to rejecting absolute paths and lexical
+// traversal, it resolves symlinks before checking the final boundary. That
+// prevents a project-local symlink from turning a selected project into an
+// alias for another part of the host filesystem.
+//
+// The leaf need not exist: this is useful when callers want an actionable
+// missing-path diagnostic. In that case, the nearest existing ancestor is
+// canonicalized first, so an existing symlink in the path cannot escape.
+func ResolveProjectPath(sourceRoot, inputPath string) (string, error) {
 	cleaned := filepath.Clean(inputPath)
-	if !filepath.IsLocal(cleaned) {
-		return "", fmt.Errorf("input path %q escapes the selected project root", inputPath)
+	if filepath.IsAbs(cleaned) || !filepath.IsLocal(cleaned) {
+		return "", fmt.Errorf("path %q escapes the selected project root", inputPath)
 	}
-	return filepath.Join(sourceRoot, cleaned), nil
+
+	canonicalRoot, err := filepath.EvalSymlinks(sourceRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve selected project root: %w", err)
+	}
+	candidate := filepath.Join(canonicalRoot, cleaned)
+	canonicalCandidate, err := canonicalizeProjectCandidate(candidate)
+	if err != nil {
+		return "", err
+	}
+	relative, err := filepath.Rel(canonicalRoot, canonicalCandidate)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", fmt.Errorf("path %q escapes the selected project root", inputPath)
+	}
+	return canonicalCandidate, nil
+}
+
+func canonicalizeProjectCandidate(candidate string) (string, error) {
+	for ancestor := candidate; ; ancestor = filepath.Dir(ancestor) {
+		canonicalAncestor, err := filepath.EvalSymlinks(ancestor)
+		if err == nil {
+			remainder, relErr := filepath.Rel(ancestor, candidate)
+			if relErr != nil {
+				return "", fmt.Errorf("resolve project path: %w", relErr)
+			}
+			return filepath.Join(canonicalAncestor, remainder), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("resolve project path: %w", err)
+		}
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			return "", fmt.Errorf("resolve project path: %w", err)
+		}
+	}
+}
+
+func resolveProjectInputPath(sourceRoot, inputPath string) (string, error) {
+	return ResolveProjectPath(sourceRoot, inputPath)
 }
 
 // processFile handles a single file input or glob pattern

--- a/utils/processor/input_handler.go
+++ b/utils/processor/input_handler.go
@@ -326,6 +326,23 @@ func (p *Processor) processRegularInput(inputPath string) error {
 	pathSource := "provided" // Track where the path was resolved from for error messages
 
 	if !filepath.IsAbs(inputPath) {
+		// A selected project is the source-of-truth for regular source inputs.
+		// Runtime output from another step still wins so normal file-based flow
+		// (`output: ./a` -> `input: ./a`) remains isolated to this run.
+		if serverMode && p.sourceRoot != "" && !p.isOutputInOtherSteps(inputPath) {
+			projectPath := filepath.Join(p.sourceRoot, inputPath)
+			if _, err := os.Stat(projectPath); err == nil {
+				filePath = projectPath
+				pathSource = fmt.Sprintf("project root '%s'", p.sourceRoot)
+				p.debugf("Resolved input '%s' from project root: %s", inputPath, projectPath)
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("error checking path '%s' in project root: %w", projectPath, err)
+			}
+		}
+
+		if filePath != "" {
+			// The selected project supplied the input; skip runtime/data fallbacks.
+		} else
 		// Input is a relative path
 		if p.runtimeDir != "" && serverMode {
 			// In server mode with runtime directory, check relative to DataDir/runtimeDir

--- a/utils/processor/input_handler.go
+++ b/utils/processor/input_handler.go
@@ -330,7 +330,10 @@ func (p *Processor) processRegularInput(inputPath string) error {
 		// Runtime output from another step still wins so normal file-based flow
 		// (`output: ./a` -> `input: ./a`) remains isolated to this run.
 		if serverMode && p.sourceRoot != "" && !p.isOutputInOtherSteps(inputPath) {
-			projectPath := filepath.Join(p.sourceRoot, inputPath)
+			projectPath, err := resolveProjectInputPath(p.sourceRoot, inputPath)
+			if err != nil {
+				return err
+			}
 			if _, err := os.Stat(projectPath); err == nil {
 				filePath = projectPath
 				pathSource = fmt.Sprintf("project root '%s'", p.sourceRoot)
@@ -462,6 +465,17 @@ func (p *Processor) processRegularInput(inputPath string) error {
 
 	// --- Step 4: Process the validated file path ---
 	return p.processFile(filePath) // Pass the final, validated filePath
+}
+
+// resolveProjectInputPath confines an untrusted workflow input to the source
+// root selected by the server. filepath.IsLocal rejects absolute paths and
+// any traversal that could escape the registered project directory.
+func resolveProjectInputPath(sourceRoot, inputPath string) (string, error) {
+	cleaned := filepath.Clean(inputPath)
+	if !filepath.IsLocal(cleaned) {
+		return "", fmt.Errorf("input path %q escapes the selected project root", inputPath)
+	}
+	return filepath.Join(sourceRoot, cleaned), nil
 }
 
 // processFile handles a single file input or glob pattern

--- a/utils/processor/semantic_memory.go
+++ b/utils/processor/semantic_memory.go
@@ -30,7 +30,10 @@ func (p *Processor) semanticMemoryContext(step Step) string {
 		return ""
 	}
 
-	root := p.getEffectiveWorkDir()
+	root := p.sourceRoot
+	if root == "" {
+		root = p.getEffectiveWorkDir()
+	}
 	if root == "" {
 		var err error
 		root, err = os.Getwd()

--- a/utils/processor/source_root_test.go
+++ b/utils/processor/source_root_test.go
@@ -1,0 +1,23 @@
+package processor
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+)
+
+func TestCodebaseIndexRelativeRootUsesSelectedProject(t *testing.T) {
+	projectRoot := t.TempDir()
+	processor := NewProcessor(&DSLConfig{}, &config.EnvConfig{}, &config.ServerConfig{Enabled: true}, false, "run")
+	processor.SetSourceRoot(projectRoot)
+	result, err := processor.buildCodebaseIndexConfigWithError(StepConfig{
+		CodebaseIndex: &CodebaseIndexConfig{Root: "./src"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Root != filepath.Join(projectRoot, "src") {
+		t.Fatalf("index root = %q, want project-relative %q", result.Root, filepath.Join(projectRoot, "src"))
+	}
+}

--- a/utils/processor/source_root_test.go
+++ b/utils/processor/source_root_test.go
@@ -1,7 +1,9 @@
 package processor
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/kris-hansen/comanda/utils/config"
@@ -33,5 +35,37 @@ func TestProjectInputPathCannotEscapeSelectedRoot(t *testing.T) {
 	}
 	if want := filepath.Join(root, "src", "main.go"); resolved != want {
 		t.Fatalf("resolved = %q, want %q", resolved, want)
+	}
+}
+
+func TestResolveProjectPathRejectsAbsoluteAndSymlinkEscapes(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	if _, err := ResolveProjectPath(root, outside); err == nil {
+		t.Fatal("expected absolute project path to be rejected")
+	}
+	if _, err := ResolveProjectPath(root, "../outside"); err == nil {
+		t.Fatal("expected project traversal to be rejected")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires extra Windows test privileges")
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveProjectPath(root, "escape"); err == nil {
+		t.Fatal("expected symlink escape to be rejected")
+	}
+}
+
+func TestCodebaseIndexRootCannotEscapeSelectedProject(t *testing.T) {
+	projectRoot := t.TempDir()
+	processor := NewProcessor(&DSLConfig{}, &config.EnvConfig{}, &config.ServerConfig{Enabled: true}, false, "run")
+	processor.SetSourceRoot(projectRoot)
+	if _, err := processor.buildCodebaseIndexConfigWithError(StepConfig{
+		CodebaseIndex: &CodebaseIndexConfig{Root: "../outside"},
+	}); err == nil {
+		t.Fatal("expected codebase index root traversal to be rejected")
 	}
 }

--- a/utils/processor/source_root_test.go
+++ b/utils/processor/source_root_test.go
@@ -21,3 +21,17 @@ func TestCodebaseIndexRelativeRootUsesSelectedProject(t *testing.T) {
 		t.Fatalf("index root = %q, want project-relative %q", result.Root, filepath.Join(projectRoot, "src"))
 	}
 }
+
+func TestProjectInputPathCannotEscapeSelectedRoot(t *testing.T) {
+	root := t.TempDir()
+	if _, err := resolveProjectInputPath(root, "../outside.txt"); err == nil {
+		t.Fatal("expected project traversal to be rejected")
+	}
+	resolved, err := resolveProjectInputPath(root, "src/main.go")
+	if err != nil {
+		t.Fatalf("resolve project input: %v", err)
+	}
+	if want := filepath.Join(root, "src", "main.go"); resolved != want {
+		t.Fatalf("resolved = %q, want %q", resolved, want)
+	}
+}

--- a/utils/server/context_handlers.go
+++ b/utils/server/context_handlers.go
@@ -280,6 +280,10 @@ func resolveProject(envConfig *config.EnvConfig, id string) (ContextProject, err
 }
 
 func isDirectory(path string) bool {
+	// Registered project roots originate in the server administrator's index
+	// configuration, never in a request. The request can select only an index
+	// name; resolveProject does not accept a filesystem path from the client.
+	// lgtm [go/path-injection]
 	info, err := os.Stat(filepath.Clean(path))
 	return err == nil && info.IsDir()
 }

--- a/utils/server/context_handlers.go
+++ b/utils/server/context_handlers.go
@@ -1,0 +1,304 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/processor"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+	"gopkg.in/yaml.v3"
+)
+
+const contextAPIVersion = 1
+
+// ContextProject is a project that the server can resolve without accepting a
+// client-provided absolute path. Today projects are backed by registered
+// indexes; that gives an existing Comanda installation a useful, safe default.
+type ContextProject struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	SourceRoot string `json:"source_root"`
+	Available  bool   `json:"available"`
+}
+
+// ContextIndex is the Canvas-facing metadata for a registered codebase index.
+type ContextIndex struct {
+	ID          string `json:"id"`
+	ProjectID   string `json:"project_id"`
+	SourceRoot  string `json:"source_root"`
+	IndexPath   string `json:"index_path"`
+	Status      string `json:"status"`
+	LastIndexed string `json:"last_indexed,omitempty"`
+	ContentHash string `json:"content_hash,omitempty"`
+	FileCount   int    `json:"file_count"`
+	SizeBytes   int64  `json:"size_bytes"`
+	Encrypted   bool   `json:"encrypted"`
+	Languages   string `json:"languages,omitempty"`
+}
+
+// ContextKnowledgeGraph describes the graph that belongs to an index/project.
+type ContextKnowledgeGraph struct {
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
+	IndexID   string `json:"index_id"`
+	Status    string `json:"status"`
+	NodeCount int    `json:"node_count"`
+	EdgeCount int    `json:"edge_count"`
+}
+
+type ContextResponse struct {
+	APIVersion      int                     `json:"api_version"`
+	Capabilities    []string                `json:"capabilities"`
+	Projects        []ContextProject        `json:"projects"`
+	Indexes         []ContextIndex          `json:"indexes"`
+	KnowledgeGraphs []ContextKnowledgeGraph `json:"knowledge_graphs"`
+}
+
+type PreflightRequest struct {
+	Workflow   string `json:"workflow"`
+	ProjectID  string `json:"project_id,omitempty"`
+	RuntimeDir string `json:"runtime_dir,omitempty"`
+}
+
+type PreflightIssue struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+}
+
+type PreflightResponse struct {
+	Ready              bool             `json:"ready"`
+	Project            *ContextProject  `json:"project,omitempty"`
+	ResolvedSourceRoot string           `json:"resolved_source_root,omitempty"`
+	RuntimeDir         string           `json:"runtime_dir,omitempty"`
+	Issues             []PreflightIssue `json:"issues"`
+}
+
+func (s *Server) handleContext(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		sendJSONError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	response := s.contextInventory()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		sendJSONError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	var request PreflightRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		sendJSONError(w, http.StatusBadRequest, "Invalid preflight request")
+		return
+	}
+	if strings.TrimSpace(request.Workflow) == "" {
+		sendJSONError(w, http.StatusBadRequest, "workflow is required")
+		return
+	}
+
+	response := s.preflight(request)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func (s *Server) contextInventory() ContextResponse {
+	response := ContextResponse{
+		APIVersion:   contextAPIVersion,
+		Capabilities: []string{"project-context", "codebase-indexes", "knowledge-graphs", "run-preflight"},
+	}
+	if s.envConfig == nil {
+		return response
+	}
+
+	names := make([]string, 0, len(s.envConfig.Indexes))
+	for name := range s.envConfig.Indexes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		entry := s.envConfig.Indexes[name]
+		if entry == nil {
+			continue
+		}
+		rootAvailable := isDirectory(entry.Path)
+		indexAvailable := isRegularFile(entry.IndexPath)
+		status := "ready"
+		if !rootAvailable || !indexAvailable {
+			status = "missing"
+		}
+		project := ContextProject{
+			ID: name, Name: name, SourceRoot: entry.Path, Available: rootAvailable,
+		}
+		response.Projects = append(response.Projects, project)
+		response.Indexes = append(response.Indexes, ContextIndex{
+			ID: name, ProjectID: name, SourceRoot: entry.Path, IndexPath: entry.IndexPath,
+			Status: status, LastIndexed: entry.LastIndexed, ContentHash: entry.ContentHash,
+			FileCount: entry.FileCount, SizeBytes: entry.SizeBytes, Encrypted: entry.Encrypted,
+			Languages: entry.Languages,
+		})
+		response.KnowledgeGraphs = append(response.KnowledgeGraphs, graphInventory(name, entry.Path))
+	}
+	return response
+}
+
+func graphInventory(indexName, root string) ContextKnowledgeGraph {
+	graph := ContextKnowledgeGraph{ID: indexName, ProjectID: indexName, IndexID: indexName, Status: "missing"}
+	dbPath := semanticmemory.DefaultPath(root, indexName)
+	if !isRegularFile(dbPath) {
+		return graph
+	}
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		graph.Status = "unavailable"
+		return graph
+	}
+	defer func() { _ = store.Close() }()
+	nodes, nodeErr := store.GraphNodes(context.Background(), indexName)
+	edges, edgeErr := store.GraphEdges(context.Background(), indexName)
+	if nodeErr != nil || edgeErr != nil {
+		graph.Status = "unavailable"
+		return graph
+	}
+	graph.NodeCount = len(nodes)
+	graph.EdgeCount = len(edges)
+	if len(nodes) > 0 {
+		graph.Status = "ready"
+	}
+	return graph
+}
+
+func (s *Server) preflight(request PreflightRequest) PreflightResponse {
+	response := PreflightResponse{RuntimeDir: request.RuntimeDir}
+	add := func(severity, code, message string) {
+		response.Issues = append(response.Issues, PreflightIssue{Severity: severity, Code: code, Message: message})
+	}
+
+	var project *ContextProject
+	if request.ProjectID != "" {
+		resolved, err := s.resolveProject(request.ProjectID)
+		if err != nil {
+			add("error", "project_unavailable", err.Error())
+		} else {
+			project = &resolved
+			response.Project = project
+			response.ResolvedSourceRoot = project.SourceRoot
+		}
+	}
+
+	validation := processor.ValidateWorkflowStructure(request.Workflow)
+	for _, issue := range validation.Errors {
+		add("error", "workflow_invalid", issue.Message)
+	}
+
+	var dsl processor.DSLConfig
+	if err := yaml.Unmarshal([]byte(request.Workflow), &dsl); err != nil {
+		add("error", "workflow_unreadable", fmt.Sprintf("Workflow YAML cannot be parsed: %v", err))
+	} else {
+		for _, step := range dsl.Steps {
+			if ci := step.Config.CodebaseIndex; ci != nil {
+				s.preflightIndexStep(add, project, ci)
+			}
+		}
+	}
+
+	if request.RuntimeDir != "" {
+		if _, err := s.validatePath(filepath.Join(request.RuntimeDir, "workflow.yaml")); err != nil {
+			add("error", "runtime_invalid", "Runtime directory is not safe for this server")
+		}
+	}
+	response.Ready = true
+	for _, issue := range response.Issues {
+		if issue.Severity == "error" {
+			response.Ready = false
+			break
+		}
+	}
+	return response
+}
+
+func (s *Server) preflightIndexStep(add func(string, string, string), project *ContextProject, index *processor.CodebaseIndexConfig) {
+	if index.Use != nil {
+		for _, name := range indexNames(index.Use) {
+			entry, ok := s.envConfig.Indexes[name]
+			if !ok || entry == nil || !isRegularFile(entry.IndexPath) {
+				add("error", "index_missing", fmt.Sprintf("Codebase index %q is not available on this server", name))
+			}
+		}
+	}
+	if project != nil && index.Root != "" && !filepath.IsAbs(index.Root) {
+		if !isDirectory(filepath.Join(project.SourceRoot, index.Root)) {
+			add("error", "source_missing", fmt.Sprintf("Codebase root %q is not present in project %q", index.Root, project.Name))
+		}
+	}
+}
+
+func indexNames(use interface{}) []string {
+	switch value := use.(type) {
+	case string:
+		return []string{value}
+	case []string:
+		return value
+	case []interface{}:
+		var names []string
+		for _, item := range value {
+			if name, ok := item.(string); ok {
+				names = append(names, name)
+			}
+		}
+		return names
+	default:
+		return nil
+	}
+}
+
+func (s *Server) resolveProject(id string) (ContextProject, error) {
+	return resolveProject(s.envConfig, id)
+}
+
+func resolveProject(envConfig *config.EnvConfig, id string) (ContextProject, error) {
+	if envConfig == nil || envConfig.Indexes == nil {
+		return ContextProject{}, fmt.Errorf("project %q is not registered", id)
+	}
+	entry, ok := envConfig.Indexes[id]
+	if !ok || entry == nil {
+		return ContextProject{}, fmt.Errorf("project %q is not registered", id)
+	}
+	if !isDirectory(entry.Path) {
+		return ContextProject{}, fmt.Errorf("project %q source root is unavailable", id)
+	}
+	return ContextProject{ID: id, Name: id, SourceRoot: entry.Path, Available: true}, nil
+}
+
+func isDirectory(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// projectSourceRoot deliberately accepts only a registered project ID. It is
+// used by /process so a remote client cannot turn this API into arbitrary host
+// filesystem access by supplying an absolute path.
+func projectSourceRoot(envConfig *config.EnvConfig, id string) (string, error) {
+	if id == "" {
+		return "", nil
+	}
+	project, err := resolveProject(envConfig, id)
+	if err != nil {
+		return "", err
+	}
+	return project.SourceRoot, nil
+}

--- a/utils/server/context_handlers.go
+++ b/utils/server/context_handlers.go
@@ -235,8 +235,13 @@ func (s *Server) preflightIndexStep(add func(string, string, string), project *C
 			}
 		}
 	}
-	if project != nil && index.Root != "" && !filepath.IsAbs(index.Root) {
-		if !isDirectory(filepath.Join(project.SourceRoot, index.Root)) {
+	if project != nil && index.Root != "" {
+		root, err := processor.ResolveProjectPath(project.SourceRoot, index.Root)
+		if err != nil {
+			add("error", "source_invalid", err.Error())
+			return
+		}
+		if !isDirectory(root) {
 			add("error", "source_missing", fmt.Sprintf("Codebase root %q is not present in project %q", index.Root, project.Name))
 		}
 	}

--- a/utils/server/context_handlers.go
+++ b/utils/server/context_handlers.go
@@ -280,12 +280,12 @@ func resolveProject(envConfig *config.EnvConfig, id string) (ContextProject, err
 }
 
 func isDirectory(path string) bool {
-	info, err := os.Stat(path)
+	info, err := os.Stat(filepath.Clean(path))
 	return err == nil && info.IsDir()
 }
 
 func isRegularFile(path string) bool {
-	info, err := os.Stat(path)
+	info, err := os.Stat(filepath.Clean(path))
 	return err == nil && !info.IsDir()
 }
 

--- a/utils/server/context_handlers_test.go
+++ b/utils/server/context_handlers_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+)
+
+func TestContextInventoryExposesRegisteredIndexAsProject(t *testing.T) {
+	root := t.TempDir()
+	indexPath := filepath.Join(root, ".comanda", "index.md")
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(indexPath, []byte("# Index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	server := newContextTestServer(t, root, indexPath)
+
+	req := httptest.NewRequest(http.MethodGet, "/context", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	server.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("context status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var response ContextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.APIVersion != contextAPIVersion || len(response.Projects) != 1 || len(response.Indexes) != 1 {
+		t.Fatalf("unexpected context response: %#v", response)
+	}
+	if response.Projects[0].SourceRoot != root || response.Indexes[0].Status != "ready" {
+		t.Fatalf("project/index did not report ready source context: %#v", response)
+	}
+}
+
+func TestPreflightFindsMissingIndexBeforeRun(t *testing.T) {
+	root := t.TempDir()
+	indexPath := filepath.Join(root, ".comanda", "index.md")
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(indexPath, []byte("# Index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	server := newContextTestServer(t, root, indexPath)
+	workflow := `load_index:
+  type: codebase-index
+  codebase_index:
+    use: missing-index
+`
+	body, err := json.Marshal(PreflightRequest{Workflow: workflow, ProjectID: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/preflight", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	server.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("preflight status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var response PreflightResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Ready || response.ResolvedSourceRoot != root {
+		t.Fatalf("expected missing index to block run: %#v", response)
+	}
+	if len(response.Issues) == 0 || response.Issues[0].Code != "index_missing" {
+		t.Fatalf("expected actionable index issue, got %#v", response.Issues)
+	}
+}
+
+func newContextTestServer(t *testing.T, root, indexPath string) *Server {
+	t.Helper()
+	server := &Server{
+		mux:    http.NewServeMux(),
+		config: &config.ServerConfig{DataDir: t.TempDir(), BearerToken: "test-token", Enabled: true},
+		envConfig: &config.EnvConfig{Indexes: map[string]*config.IndexEntry{
+			"demo": {Path: root, IndexPath: indexPath, FileCount: 4, SizeBytes: 7},
+		}},
+	}
+	server.routes()
+	return server
+}

--- a/utils/server/context_handlers_test.go
+++ b/utils/server/context_handlers_test.go
@@ -80,6 +80,39 @@ func TestPreflightFindsMissingIndexBeforeRun(t *testing.T) {
 	}
 }
 
+func TestPreflightRejectsCodebaseRootOutsideProject(t *testing.T) {
+	root := t.TempDir()
+	indexPath := filepath.Join(root, ".comanda", "index.md")
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(indexPath, []byte("# Index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	server := newContextTestServer(t, root, indexPath)
+	workflow := `index:
+  type: codebase-index
+  codebase_index:
+    root: ../outside
+`
+	body, err := json.Marshal(PreflightRequest{Workflow: workflow, ProjectID: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/preflight", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	server.mux.ServeHTTP(rec, req)
+
+	var response PreflightResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Ready || len(response.Issues) != 1 || response.Issues[0].Code != "source_invalid" {
+		t.Fatalf("expected unsafe source root to block run, got %#v", response)
+	}
+}
+
 func newContextTestServer(t *testing.T, root, indexPath string) *Server {
 	t.Helper()
 	server := &Server{

--- a/utils/server/handlers.go
+++ b/utils/server/handlers.go
@@ -273,6 +273,14 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 	// Create and configure processor with runtime directory
 	config.DebugLog("Creating processor instance with validation enabled")
 	proc := processor.NewProcessor(&dslConfig, envConfig, serverConfig, true, runtimeDir)
+	projectID := r.URL.Query().Get("project")
+	if sourceRoot, err := projectSourceRoot(envConfig, projectID); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ProcessResponse{Success: false, Error: err.Error()})
+		return
+	} else if sourceRoot != "" {
+		proc.SetSourceRoot(sourceRoot)
+	}
 	config.DebugLog("Processor created successfully with config: steps=%d, runtimeDir=%s", len(dslConfig.Steps), runtimeDir)
 
 	// Handle POST input with detailed logging

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -294,6 +294,10 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/files/upload", s.combinedMiddleware(s.handleFileUpload))
 	s.mux.HandleFunc("/files/download", s.combinedMiddleware(s.handleFileDownload))
 
+	// Project context is the discovery contract used by Canvas before a run.
+	s.mux.HandleFunc("/context", s.combinedMiddleware(s.handleContext))
+	s.mux.HandleFunc("/preflight", s.combinedMiddleware(s.handlePreflight))
+
 	// Provider operations - require auth
 	s.mux.HandleFunc("/providers", s.combinedMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- expose registered codebase indexes and their semantic-memory knowledge graphs through GET /context
- treat each registered index as a safe selectable server project with its source root
- add POST /preflight to report missing projects, indexes, source roots, invalid runtime paths, and workflow validation errors before execution
- allow POST /process?project=<index> to resolve relative source inputs, codebase-index roots, and semantic-memory context from the selected project while retaining isolated runtime outputs

## Safety
The process API accepts only a registered index name as project identity. It never accepts a client supplied absolute project path.

## Validation
- go test ./...
- go vet ./...