### PR TITLE
fix: allow selected project roots in codebase indexes

### DIFF
--- a/utils/processor/input_handler.go
+++ b/utils/processor/input_handler.go
@@ -468,34 +468,54 @@ func (p *Processor) processRegularInput(inputPath string) error {
 }
 
 // ResolveProjectPath confines an untrusted workflow path to the source root
-// selected by the server. In addition to rejecting absolute paths and lexical
-// traversal, it resolves symlinks before checking the final boundary. That
-// prevents a project-local symlink from turning a selected project into an
-// alias for another part of the host filesystem.
+// selected by the server. Relative paths are confined to that root. Absolute
+// paths are accepted only when they lexically name the selected root (or a
+// child of it), which keeps existing local workflows portable without turning
+// this resolver into a host-filesystem probe. In every case, symlinks are
+// resolved before the final boundary check. That prevents a project-local
+// symlink from turning a selected project into an alias for another part of
+// the host filesystem.
 //
 // The leaf need not exist: this is useful when callers want an actionable
 // missing-path diagnostic. In that case, the nearest existing ancestor is
 // canonicalized first, so an existing symlink in the path cannot escape.
 func ResolveProjectPath(sourceRoot, inputPath string) (string, error) {
 	cleaned := filepath.Clean(inputPath)
-	if filepath.IsAbs(cleaned) || !filepath.IsLocal(cleaned) {
-		return "", fmt.Errorf("path %q escapes the selected project root", inputPath)
-	}
-
 	canonicalRoot, err := filepath.EvalSymlinks(sourceRoot)
 	if err != nil {
 		return "", fmt.Errorf("resolve selected project root: %w", err)
 	}
-	candidate := filepath.Join(canonicalRoot, cleaned)
+
+	var candidate string
+	if filepath.IsAbs(cleaned) {
+		// Reject an arbitrary absolute path before evaluating it. Checking both
+		// spellings supports a registered root that itself contains symlinks.
+		if !isWithinProjectRoot(filepath.Clean(sourceRoot), cleaned) &&
+			!isWithinProjectRoot(canonicalRoot, cleaned) {
+			return "", fmt.Errorf("path %q escapes the selected project root", inputPath)
+		}
+		candidate = cleaned
+	} else {
+		if !filepath.IsLocal(cleaned) {
+			return "", fmt.Errorf("path %q escapes the selected project root", inputPath)
+		}
+		candidate = filepath.Join(canonicalRoot, cleaned)
+	}
 	canonicalCandidate, err := canonicalizeProjectCandidate(candidate)
 	if err != nil {
 		return "", err
 	}
-	relative, err := filepath.Rel(canonicalRoot, canonicalCandidate)
-	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+	if !isWithinProjectRoot(canonicalRoot, canonicalCandidate) {
 		return "", fmt.Errorf("path %q escapes the selected project root", inputPath)
 	}
 	return canonicalCandidate, nil
+}
+
+func isWithinProjectRoot(root, candidate string) bool {
+	relative, err := filepath.Rel(root, candidate)
+	return err == nil && relative != ".." &&
+		!strings.HasPrefix(relative, ".."+string(filepath.Separator)) &&
+		!filepath.IsAbs(relative)
 }
 
 func canonicalizeProjectCandidate(candidate string) (string, error) {

--- a/utils/processor/source_root_test.go
+++ b/utils/processor/source_root_test.go
@@ -38,12 +38,26 @@ func TestProjectInputPathCannotEscapeSelectedRoot(t *testing.T) {
 	}
 }
 
-func TestResolveProjectPathRejectsAbsoluteAndSymlinkEscapes(t *testing.T) {
+func TestResolveProjectPathAllowsAbsolutePathsWithinSelectedRoot(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()
 
+	resolvedRoot, err := ResolveProjectPath(root, root)
+	if err != nil {
+		t.Fatalf("resolve absolute project root: %v", err)
+	}
+	if resolvedRoot != root {
+		t.Fatalf("resolved root = %q, want %q", resolvedRoot, root)
+	}
+	resolvedChild, err := ResolveProjectPath(root, filepath.Join(root, "src"))
+	if err != nil {
+		t.Fatalf("resolve absolute project child: %v", err)
+	}
+	if resolvedChild != filepath.Join(root, "src") {
+		t.Fatalf("resolved child = %q, want %q", resolvedChild, filepath.Join(root, "src"))
+	}
 	if _, err := ResolveProjectPath(root, outside); err == nil {
-		t.Fatal("expected absolute project path to be rejected")
+		t.Fatal("expected outside absolute project path to be rejected")
 	}
 	if _, err := ResolveProjectPath(root, "../outside"); err == nil {
 		t.Fatal("expected project traversal to be rejected")
@@ -56,6 +70,9 @@ func TestResolveProjectPathRejectsAbsoluteAndSymlinkEscapes(t *testing.T) {
 	}
 	if _, err := ResolveProjectPath(root, "escape"); err == nil {
 		t.Fatal("expected symlink escape to be rejected")
+	}
+	if _, err := ResolveProjectPath(root, filepath.Join(root, "escape")); err == nil {
+		t.Fatal("expected absolute symlink escape to be rejected")
 	}
 }
 


### PR DESCRIPTION
## What changed
- accept an absolute codebase index root only when it is the selected project root or a child of it
- retain lexical traversal protection and canonical symlink-boundary enforcement
- add coverage for in-project absolute roots, outside paths, and absolute symlink escapes

## Verification
- go test ./...
- go vet ./...