### PR TITLE
fix: resolve process files from runtime dir

### DIFF
--- a/utils/server/handlers.go
+++ b/utils/server/handlers.go
@@ -91,16 +91,23 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 	config.VerboseLog("Processing file: %s", filename)
 	config.DebugLog("Starting process request for file: %s", filename)
 
-	// Clean the path to remove any . or .. components
+	// A bare filename belongs to the requested runtime directory when one is
+	// supplied. File uploads use the same convention: uploading workflow.yaml
+	// with runtimeDir=run-123 stores it at DataDir/run-123/workflow.yaml.
+	// Previously /process only used runtimeDir after reading the workflow, so
+	// it looked in DataDir/workflow.yaml and failed before processing began.
+	runtimeDir := r.URL.Query().Get("runtimeDir")
 	cleanPath := filepath.Clean(filename)
-
-	// Check if the path contains directory separators
 	if !strings.Contains(cleanPath, string(filepath.Separator)) {
-		// No directory specified, assume it's in the root of DataDir
-		cleanPath = filepath.Join(serverConfig.DataDir, cleanPath)
-		config.DebugLog("Using file in data directory: %s", cleanPath)
+		if runtimeDir != "" {
+			cleanPath = filepath.Join(serverConfig.DataDir, runtimeDir, cleanPath)
+			config.DebugLog("Using file in runtime directory: %s", cleanPath)
+		} else {
+			cleanPath = filepath.Join(serverConfig.DataDir, cleanPath)
+			config.DebugLog("Using file in data directory: %s", cleanPath)
+		}
 	} else {
-		// Path contains separators, prepend DataDir
+		// Paths with their own directory are already relative to DataDir.
 		cleanPath = filepath.Join(serverConfig.DataDir, cleanPath)
 		config.DebugLog("Using path with directories: %s", cleanPath)
 	}
@@ -255,7 +262,6 @@ func handleProcess(w http.ResponseWriter, r *http.Request, serverConfig *config.
 		len(dslConfig.Steps), len(dslConfig.ParallelSteps), len(dslConfig.Loops))
 
 	// Get runtime directory from query parameter or calculate from path
-	runtimeDir := r.URL.Query().Get("runtimeDir")
 	if runtimeDir == "" {
 		// Calculate from path if not provided
 		runtimeDir = filepath.Dir(relPath) // Use relPath which is relative to DataDir

--- a/utils/server/handlers_test.go
+++ b/utils/server/handlers_test.go
@@ -362,6 +362,13 @@ step_one:
 	if err := os.WriteFile(fmt.Sprintf("%s/stdin.yaml", tempDir), []byte(stdinYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
+	const canvasRuntimeDir = "canvas_run_20260812_151723"
+	if err := os.MkdirAll(fmt.Sprintf("%s/%s", tempDir, canvasRuntimeDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fmt.Sprintf("%s/%s/canvas-workflow.yaml", tempDir, canvasRuntimeDir), []byte(stdinYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create test environment config with OpenAI provider
 	envConfig := &config.EnvConfig{
@@ -391,6 +398,7 @@ step_one:
 	tests := []struct {
 		name           string
 		filename       string
+		runtimeDir     string
 		input          string
 		streaming      bool
 		method         string
@@ -403,6 +411,18 @@ step_one:
 			input:     "test input",
 			streaming: true,
 			method:    http.MethodPost,
+			expectedEvents: []string{
+				"Starting workflow processing",
+				"Workflow processing completed successfully",
+			},
+		},
+		{
+			name:       "Valid POST request finds bare filename in runtime directory",
+			filename:   "canvas-workflow.yaml",
+			runtimeDir: canvasRuntimeDir,
+			input:      "test input",
+			streaming:  true,
+			method:     http.MethodPost,
 			expectedEvents: []string{
 				"Starting workflow processing",
 				"Workflow processing completed successfully",
@@ -479,6 +499,9 @@ step_one:
 
 			// Create request
 			url := fmt.Sprintf("/process?filename=%s&streaming=true", tt.filename)
+			if tt.runtimeDir != "" {
+				url += fmt.Sprintf("&runtimeDir=%s", tt.runtimeDir)
+			}
 			req := httptest.NewRequest(tt.method, url, bytes.NewBuffer(body))
 			req.Header.Set("Authorization", "Bearer test-token")
 			req.Header.Set("Accept", "text/event-stream")


### PR DESCRIPTION
## Summary
- resolve bare `/process` filenames relative to the supplied `runtimeDir`
- keep explicit directory paths relative to the data directory
- add a streaming regression test matching Canvas upload-and-run behavior

## Verification
- `go test ./...`
- `go vet ./...`

`golangci-lint run ./...` is currently blocked before analysis because the repository's legacy `output.formats` config is incompatible with installed golangci-lint v2.12.2.