### PR TITLE
fix: run canvas project workflows from source root

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ comanda improve feature-loop.yaml \
 
 Long-running work needs an observable exit criterion. Comanda's agentic loops persist state, refine subsequent prompts from prior results, and run automated quality gates after each iteration. Interrupt a run and resume it from its last checkpoint.
 
+When deterministic gates prepare files consumed by a loop's first step, set
+`quality_gates_before_steps: true`; the default remains post-step validation.
+
 ```yaml
 agentic-loop:
   config:

--- a/utils/processor/agentic_loop.go
+++ b/utils/processor/agentic_loop.go
@@ -203,6 +203,15 @@ func (p *Processor) processAgenticLoopWithFile(loopName string, config *AgenticL
 		// Build iteration input with context
 		iterationInput := p.buildIterationContext(loopCtx, contextWindow)
 
+		// Gates normally validate an iteration after its steps complete. Some
+		// workflows use deterministic gates to prepare facts consumed by those
+		// steps, and opt into the pre-step phase explicitly.
+		if config.QualityGatesBeforeSteps {
+			if err := p.runPreStepQualityGates(loopCtx, config, workflowFile); err != nil {
+				return finalOutput, err
+			}
+		}
+
 		// Execute the loop steps
 		output, err := p.executeLoopSteps(loopCtx, config, config.Steps, iterationInput)
 		if err != nil {
@@ -238,9 +247,9 @@ func (p *Processor) processAgenticLoopWithFile(loopName string, config *AgenticL
 		finalOutput = output
 
 		// Run quality gates
-		if len(config.QualityGates) > 0 {
+		if len(config.QualityGates) > 0 && !config.QualityGatesBeforeSteps {
 			p.debugf("Running %d quality gates for iteration %d", len(config.QualityGates), loopCtx.Iteration)
-			gateResults, err := RunQualityGates(config.QualityGates, p.runtimeDir)
+			gateResults, err := RunQualityGates(config.QualityGates, p.getEffectiveWorkDir())
 
 			if err != nil {
 				p.debugf("Quality gate failure: %v", err)
@@ -318,6 +327,30 @@ func (p *Processor) processAgenticLoopWithFile(loopName string, config *AgenticL
 	}
 
 	return finalOutput, nil
+}
+
+func (p *Processor) runPreStepQualityGates(loopCtx *LoopContext, config *AgenticLoopConfig, workflowFile string) error {
+	if len(config.QualityGates) == 0 {
+		return nil
+	}
+
+	p.debugf("Running %d pre-step quality gates for iteration %d", len(config.QualityGates), loopCtx.Iteration)
+	gateResults, err := RunQualityGates(config.QualityGates, p.getEffectiveWorkDir())
+	if err == nil {
+		return nil
+	}
+
+	p.debugf("Pre-step quality gate failure: %v", err)
+	if config.Stateful {
+		stateManager := NewLoopStateManager(p.getLoopStateDir())
+		state := loopStateFromContext(loopCtx, config.Name, config, workflowFile, p.variables)
+		state.Status = "failed"
+		state.QualityGateResults = gateResults
+		if saveErr := stateManager.SaveState(state); saveErr != nil {
+			p.debugf("Warning: Failed to save failed state: %v", saveErr)
+		}
+	}
+	return fmt.Errorf("pre-step quality gate failed in iteration %d: %w", loopCtx.Iteration, err)
 }
 
 // createNewLoopContext initializes a fresh loop context

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -75,15 +76,22 @@ func (p *Processor) SetSourceRoot(root string) {
 // SourceRoot returns the stable project source tree, when one was selected.
 func (p *Processor) SourceRoot() string { return p.sourceRoot }
 
-// getEffectiveWorkDir returns the working directory for the current step
-// If a worktree is set for the current step, returns that path
-// Otherwise returns the default runtimeDir
+// getEffectiveWorkDir returns the working directory for commands and agentic
+// tools. A selected project is the stable workspace for a Canvas run; the
+// runtime directory is only the server-private location for uploaded workflow
+// files and transient output. Worktrees take precedence over the project.
 func (p *Processor) getEffectiveWorkDir() string {
 	if p.currentStepWorktree != "" && p.worktreeHandler != nil {
 		if path, err := p.worktreeHandler.GetWorktreePath(p.currentStepWorktree); err == nil {
 			p.debugf("Using worktree path for step: %s -> %s", p.currentStepWorktree, path)
 			return path
 		}
+	}
+	if p.sourceRoot != "" {
+		return p.sourceRoot
+	}
+	if p.serverConfig != nil && p.serverConfig.Enabled && p.runtimeDir != "" {
+		return filepath.Join(p.serverConfig.DataDir, p.runtimeDir)
 	}
 	return p.runtimeDir
 }

--- a/utils/processor/loop_unmarshal_test.go
+++ b/utils/processor/loop_unmarshal_test.go
@@ -18,6 +18,7 @@ loops:
     codex_timeout_seconds: 1800
     stateful: true
     checkpoint_interval: 3
+    quality_gates_before_steps: true
     exit_condition: llm_decides
     allowed_paths: ["/tmp", "."]
     tools: [Read, Write, Edit]
@@ -80,6 +81,9 @@ execute_loops:
 	}
 	if backend.CheckpointInterval != 3 {
 		t.Errorf("backend.CheckpointInterval = %d, want 3", backend.CheckpointInterval)
+	}
+	if !backend.QualityGatesBeforeSteps {
+		t.Error("backend.QualityGatesBeforeSteps should be true")
 	}
 	if backend.ExitCondition != "llm_decides" {
 		t.Errorf("backend.ExitCondition = %q, want 'llm_decides'", backend.ExitCondition)

--- a/utils/processor/source_root_test.go
+++ b/utils/processor/source_root_test.go
@@ -24,6 +24,70 @@ func TestCodebaseIndexRelativeRootUsesSelectedProject(t *testing.T) {
 	}
 }
 
+func TestEffectiveWorkDirUsesSelectedProjectOverCanvasRuntime(t *testing.T) {
+	projectRoot := t.TempDir()
+	dataDir := t.TempDir()
+	processor := NewProcessor(
+		&DSLConfig{},
+		&config.EnvConfig{},
+		&config.ServerConfig{Enabled: true, DataDir: dataDir},
+		false,
+		"canvas-run",
+	)
+	processor.SetSourceRoot(projectRoot)
+
+	if got := processor.getEffectiveWorkDir(); got != projectRoot {
+		t.Fatalf("effective work dir = %q, want selected project %q", got, projectRoot)
+	}
+}
+
+func TestEffectiveWorkDirUsesDataDirectoryForUnscopedServerRuntime(t *testing.T) {
+	dataDir := t.TempDir()
+	processor := NewProcessor(
+		&DSLConfig{},
+		&config.EnvConfig{},
+		&config.ServerConfig{Enabled: true, DataDir: dataDir},
+		false,
+		"canvas-run",
+	)
+
+	want := filepath.Join(dataDir, "canvas-run")
+	if got := processor.getEffectiveWorkDir(); got != want {
+		t.Fatalf("effective work dir = %q, want runtime directory %q", got, want)
+	}
+}
+
+func TestPreStepQualityGatesUseSelectedProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	dataDir := t.TempDir()
+	processor := NewProcessor(
+		&DSLConfig{},
+		&config.EnvConfig{},
+		&config.ServerConfig{Enabled: true, DataDir: dataDir},
+		false,
+		"canvas-run",
+	)
+	processor.SetSourceRoot(projectRoot)
+
+	loopConfig := &AgenticLoopConfig{
+		QualityGates: []QualityGateConfig{{
+			Name:    "prepare-project-state",
+			Command: "mkdir -p .comanda/qmd/state && printf ready > .comanda/qmd/state/coverage.txt",
+			OnFail:  "abort",
+		}},
+	}
+	if err := processor.runPreStepQualityGates(&LoopContext{Iteration: 1}, loopConfig, "workflow.yaml"); err != nil {
+		t.Fatalf("runPreStepQualityGates() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(projectRoot, ".comanda/qmd/state/coverage.txt")); err != nil {
+		t.Fatalf("project state was not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "canvas-run/.comanda/qmd/state/coverage.txt")); !os.IsNotExist(err) {
+		t.Fatalf("runtime directory unexpectedly received project state, stat error = %v", err)
+	}
+}
+
 func TestProjectInputPathCannotEscapeSelectedRoot(t *testing.T) {
 	root := t.TempDir()
 	if _, err := resolveProjectInputPath(root, "../outside.txt"); err == nil {

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -46,10 +46,11 @@ type AgenticLoopConfig struct {
 	PromptImprovement   *PromptImprovementConfig `yaml:"prompt_improvement,omitempty"` // Optional prompt refinement between iterations
 
 	// State persistence & quality gates
-	Name               string              `yaml:"name,omitempty"`                // Loop name (required for stateful loops)
-	Stateful           bool                `yaml:"stateful,omitempty"`            // Enable state persistence
-	CheckpointInterval int                 `yaml:"checkpoint_interval,omitempty"` // Save state every N iterations (default: 5)
-	QualityGates       []QualityGateConfig `yaml:"quality_gates,omitempty"`       // Quality gates to run after each iteration
+	Name                    string              `yaml:"name,omitempty"`                       // Loop name (required for stateful loops)
+	Stateful                bool                `yaml:"stateful,omitempty"`                   // Enable state persistence
+	CheckpointInterval      int                 `yaml:"checkpoint_interval,omitempty"`        // Save state every N iterations (default: 5)
+	QualityGates            []QualityGateConfig `yaml:"quality_gates,omitempty"`              // Quality gates to run after each iteration
+	QualityGatesBeforeSteps bool                `yaml:"quality_gates_before_steps,omitempty"` // Run gates before loop steps instead
 
 	// Multi-loop orchestration
 	DependsOn   []string `yaml:"depends_on,omitempty"`   // Wait for these loops to complete


### PR DESCRIPTION
## Summary

- Run Canvas quality gates and agentic tools from the selected project root instead of the temporary upload runtime directory.
- Resolve unscoped server runtime work directories beneath the server data directory.
- Add `quality_gates_before_steps` for deterministic setup gates that produce inputs for the first loop step.

For workflows like qmd-index, set `quality_gates_before_steps: true` on the `refresh` loop so coverage facts exist before `record_refresh_state` reads them.

## Verification

- `go test ./...`
- `go vet ./...`

Local `golangci-lint run ./...` cannot load the repository's legacy `output.formats` configuration with the installed golangci-lint v2.12.2; GitHub CI uses the compatible configured version.
