### PR TITLE
fix(tui): keep recent activity within its panel

### DIFF
--- a/utils/tui/dashboard.go
+++ b/utils/tui/dashboard.go
@@ -545,17 +545,29 @@ func (m *DashboardModel) renderActivity() string {
 				style = lipgloss.NewStyle().Foreground(m.theme.Muted)
 			}
 
-			msg := activity.Message
-			maxLen := m.width - 10
-			if len(msg) > maxLen {
-				msg = msg[:maxLen-3] + "..."
-			}
+			// The compact dashboard is an event preview, not a transcript. Agent
+			// output often contains newlines; rendering it verbatim makes the
+			// activity box grow past its intended boundary. The detailed Ctrl-R
+			// view retains and scrolls the complete, wrapped message.
+			msg := compactActivityMessage(activity.Message, max(1, m.width-10))
 
 			content.WriteString(fmt.Sprintf("  %s %s\n", icon, style.Render(msg)))
 		}
 	}
 
 	return boxStyle.Render(content.String())
+}
+
+func compactActivityMessage(message string, maxWidth int) string {
+	message = strings.Join(strings.Fields(message), " ")
+	runes := []rune(message)
+	if len(runes) <= maxWidth {
+		return message
+	}
+	if maxWidth <= 3 {
+		return string(runes[:maxWidth])
+	}
+	return string(runes[:maxWidth-3]) + "..."
 }
 
 func (m *DashboardModel) renderExpandedActivity() string {

--- a/utils/tui/dashboard_test.go
+++ b/utils/tui/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestDashboardActivityDetailsPreserveFullError(t *testing.T) {
@@ -22,6 +23,27 @@ func TestDashboardActivityDetailsPreserveFullError(t *testing.T) {
 	details := strings.Join(activityTexts(lines), "\n")
 	if !strings.Contains(details, "source") || !strings.Contains(details, "retrying") {
 		t.Fatal("detailed activity view did not retain the end of the error message")
+	}
+}
+
+func TestDashboardCompactActivityStaysWithinPreviewHeight(t *testing.T) {
+	model := NewDashboardModel("test", NewProgressReporter())
+	model.width = 80
+	model.addActivity("output", "first line\nsecond line\nthird line\nfourth line")
+
+	view := model.renderActivity()
+	// Rounded borders plus the label and single preview occupy five rows.
+	if got, want := lipgloss.Height(view), 5; got != want {
+		t.Fatalf("compact activity height = %d, want %d", got, want)
+	}
+	if !strings.Contains(view, "first line second line") {
+		t.Fatalf("compact activity did not retain a one-line preview: %q", view)
+	}
+
+	lines := model.activityDetailLines()
+	details := strings.Join(activityTexts(lines), "\n")
+	if !strings.Contains(details, "fourth line") {
+		t.Fatal("detailed activity view did not retain the complete message")
 	}
 }
 


### PR DESCRIPTION
## Summary\n- collapse multiline activity messages to one bounded preview row in the live dashboard\n- retain the full message in the existing Ctrl-R detailed, scrollable view\n- cover newline-heavy agent output with a regression test\n\n## Verification\n- go test ./...\n- go vet ./...