### PR TITLE
perf(graph): accelerate graph build and update pipeline

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -247,6 +247,11 @@ func buildKnowledgeGraph(indexName, repoPath string, enhance bool, enhanceModel 
 	cfg.Verbose = verbose
 	cfg.MaxFiles = indexMaxFiles
 	cfg.MaxFilesPerDir = indexMaxFilesPerDir
+	// A graph needs file metadata and extracted symbols, but never the file
+	// hashes used by markdown index diffs. Reuse the previous graph scan's
+	// symbols when size and mtime prove a candidate has not changed.
+	cfg.SkipFileHash = true
+	cfg.SymbolCache = codebaseindex.LoadSymbolCache(repoPath, indexName)
 	progress := newGraphBuildProgress(indexName)
 	defer progress.Stop()
 	cfg.Progress = progress.UpdateIndex
@@ -263,6 +268,9 @@ func buildKnowledgeGraph(indexName, repoPath string, enhance bool, enhanceModel 
 	scan, _, err := manager.Scan()
 	if err != nil {
 		return fmt.Errorf("graph scan failed: %w", err)
+	}
+	if err := codebaseindex.SaveSymbolCache(repoPath, indexName, scan.Candidates); err != nil && verbose {
+		log.Printf("Warning: could not save graph symbol cache: %v\n", err)
 	}
 
 	progress.Update("Building graph relationships", fmt.Sprintf("%d indexed files", len(scan.Candidates)), 0, 0)

--- a/utils/codebaseindex/extract.go
+++ b/utils/codebaseindex/extract.go
@@ -7,47 +7,115 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
+	"sync"
 )
 
 // extractSymbols extracts symbols from all candidate files
 func (m *Manager) extractSymbols(candidates []*FileEntry) error {
-	for i, entry := range candidates {
-		path := entry.Path
-		if !strings.HasPrefix(path, "/") {
-			path = m.config.Root + "/" + path
-		}
-
-		content, err := readFilePartial(path, maxSymbolReadSize)
-		if err != nil {
-			m.reportProgress(ProgressEvent{
-				Phase:     "Extracting symbols",
-				Current:   entry.Path,
-				Completed: i + 1,
-				Total:     len(candidates),
-			})
-			continue // Skip files we can't read
-		}
-
-		// Find the appropriate adapter
-		for _, adapter := range m.adapters {
-			if adapter.Name() == entry.Language {
-				symbols, err := adapter.ExtractSymbols(entry.Path, content)
-				if err == nil {
-					entry.Symbols = symbols
-				}
-				break
-			}
-		}
-		m.reportProgress(ProgressEvent{
-			Phase:     "Extracting symbols",
-			Current:   entry.Path,
-			Completed: i + 1,
-			Total:     len(candidates),
-		})
+	if len(candidates) == 0 {
+		return nil
 	}
 
+	adapterByLanguage := make(map[string]Adapter, len(m.adapters))
+	for _, adapter := range m.adapters {
+		adapterByLanguage[adapter.Name()] = adapter
+	}
+
+	type workItem struct {
+		entry *FileEntry
+	}
+	work := make(chan workItem)
+	completed := 0
+	results := make(chan string, len(candidates))
+	workers := minInt(runtime.GOMAXPROCS(0), len(candidates))
+	if workers < 1 {
+		workers = 1
+	}
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range work {
+				entry := item.entry
+				path := entry.Path
+				if !strings.HasPrefix(path, "/") {
+					path = m.config.Root + "/" + path
+				}
+				if content, err := readFilePartial(path, maxSymbolReadSize); err == nil {
+					if adapter := adapterByLanguage[entry.Language]; adapter != nil {
+						if symbols, err := adapter.ExtractSymbols(entry.Path, content); err == nil {
+							entry.Symbols = symbols
+						}
+					}
+				}
+				results <- entry.Path
+			}
+		}()
+	}
+
+	uncached := make([]*FileEntry, 0, len(candidates))
+	for _, entry := range candidates {
+		if cached, ok := m.config.SymbolCache[entry.Path]; ok &&
+			cached.Language == entry.Language && cached.Size == entry.Size &&
+			cached.ModTime == entry.ModTime.UnixNano() {
+			entry.Symbols = cached.Symbols
+			completed++
+			m.reportExtractionProgress(entry.Path, completed, len(candidates))
+			continue
+		}
+		uncached = append(uncached, entry)
+	}
+	go func() {
+		for _, entry := range uncached {
+			work <- workItem{entry: entry}
+		}
+		close(work)
+		wg.Wait()
+		close(results)
+	}()
+	for path := range results {
+		completed++
+		m.reportExtractionProgress(path, completed, len(candidates))
+	}
 	return nil
+}
+
+func (m *Manager) reportExtractionProgress(path string, completed, total int) {
+	m.reportProgress(ProgressEvent{
+		Phase:     "Extracting symbols",
+		Current:   path,
+		Completed: completed,
+		Total:     total,
+	})
+}
+
+// BuildSymbolCache turns an extracted candidate list into a cache that can be
+// serialized alongside a graph. Callers should only reuse it with the same
+// repository root.
+func BuildSymbolCache(candidates []*FileEntry) map[string]SymbolCacheEntry {
+	cache := make(map[string]SymbolCacheEntry, len(candidates))
+	for _, entry := range candidates {
+		if entry == nil || entry.Symbols == nil {
+			continue
+		}
+		cache[entry.Path] = SymbolCacheEntry{
+			Language: entry.Language,
+			Size:     entry.Size,
+			ModTime:  entry.ModTime.UnixNano(),
+			Symbols:  entry.Symbols,
+		}
+	}
+	return cache
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // readFilePartial reads up to maxBytes from a file

--- a/utils/codebaseindex/manager_test.go
+++ b/utils/codebaseindex/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewManager(t *testing.T) {
@@ -58,6 +59,56 @@ func TestScanReportsCurrentFileDuringSymbolExtraction(t *testing.T) {
 		}
 	}
 	t.Fatalf("expected extraction progress for main.go, got %#v", events)
+}
+
+func TestExtractSymbolsReusesFreshSymbolCacheWithoutReadingFile(t *testing.T) {
+	modified := time.Unix(1_700_000_000, 0)
+	entry := &FileEntry{
+		Path:     "missing.go",
+		Language: "go",
+		Size:     123,
+		ModTime:  modified,
+	}
+	cached := &SymbolInfo{Package: "cached", Types: []TypeInfo{{Name: "Cached", Kind: "struct"}}}
+	manager := &Manager{
+		config: &Config{
+			Root: "/does-not-exist",
+			SymbolCache: map[string]SymbolCacheEntry{
+				"missing.go": {Language: "go", Size: 123, ModTime: modified.UnixNano(), Symbols: cached},
+			},
+		},
+		adapters: []Adapter{&GoAdapter{}},
+	}
+
+	if err := manager.extractSymbols([]*FileEntry{entry}); err != nil {
+		t.Fatal(err)
+	}
+	if entry.Symbols != cached {
+		t.Fatalf("symbols = %#v, want cached symbol pointer", entry.Symbols)
+	}
+}
+
+func TestSymbolCacheRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	modified := time.Unix(1_700_000_000, 0)
+	candidates := []*FileEntry{{
+		Path:     "main.go",
+		Language: "go",
+		Size:     42,
+		ModTime:  modified,
+		Symbols:  &SymbolInfo{Package: "main", Functions: []FunctionInfo{{Name: "main"}}},
+	}}
+	if err := SaveSymbolCache(root, "example", candidates); err != nil {
+		t.Fatal(err)
+	}
+	cache := LoadSymbolCache(root, "example")
+	entry, ok := cache["main.go"]
+	if !ok || entry.Symbols == nil || entry.Symbols.Package != "main" {
+		t.Fatalf("loaded cache = %#v, want main.go symbols", cache)
+	}
+	if got, want := entry.ModTime, modified.UnixNano(); got != want {
+		t.Fatalf("cached mtime = %d, want %d", got, want)
+	}
 }
 
 func TestSelectCandidatesHonorsMaxFiles(t *testing.T) {

--- a/utils/codebaseindex/scan.go
+++ b/utils/codebaseindex/scan.go
@@ -221,8 +221,11 @@ func (m *Manager) processFile(path string) *FileEntry {
 	entry.IsEntrypoint = m.isEntrypoint(name, relPath)
 	entry.IsConfig = m.isConfigFile(name)
 
-	// Compute hash (use xxhash by default for speed)
-	entry.Hash = m.computeFileHash(path)
+	// Graph-only scans do not consume file hashes. Avoid a second source read
+	// when callers have explicitly opted into size/mtime-backed symbol caching.
+	if !m.config.SkipFileHash {
+		entry.Hash = m.computeFileHash(path)
+	}
 
 	// Score the file
 	entry.Score = m.scoreFile(entry)

--- a/utils/codebaseindex/symbol_cache.go
+++ b/utils/codebaseindex/symbol_cache.go
@@ -1,0 +1,74 @@
+package codebaseindex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+const symbolCacheVersion = 1
+
+type symbolCacheFile struct {
+	Version int                         `json:"version"`
+	Root    string                      `json:"root"`
+	Symbols map[string]SymbolCacheEntry `json:"symbols"`
+}
+
+// SymbolCachePath is the project-local sidecar used by graph builds to avoid
+// re-extracting unchanged source symbols. It is deliberately separate from an
+// index's metadata because graph builds can run without generating markdown.
+func SymbolCachePath(root, namespace string) string {
+	safe := regexp.MustCompile(`[^a-zA-Z0-9._-]+`).ReplaceAllString(namespace, "-")
+	return filepath.Join(root, ".comanda", "memory", safe+".graph-symbols.json")
+}
+
+// LoadSymbolCache returns a cache only when it belongs to this exact root and
+// schema version. A missing or malformed cache is a cache miss, never a graph
+// build failure.
+func LoadSymbolCache(root, namespace string) map[string]SymbolCacheEntry {
+	data, err := os.ReadFile(SymbolCachePath(root, namespace))
+	if err != nil {
+		return nil
+	}
+	var cache symbolCacheFile
+	if json.Unmarshal(data, &cache) != nil || cache.Version != symbolCacheVersion || cache.Root != root {
+		return nil
+	}
+	return cache.Symbols
+}
+
+// SaveSymbolCache atomically persists the reusable extracted symbols from a
+// successful graph scan.
+func SaveSymbolCache(root, namespace string, candidates []*FileEntry) error {
+	path := SymbolCachePath(root, namespace)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(symbolCacheFile{
+		Version: symbolCacheVersion,
+		Root:    root,
+		Symbols: BuildSymbolCache(candidates),
+	})
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".graph-symbols-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/utils/codebaseindex/types.go
+++ b/utils/codebaseindex/types.go
@@ -72,6 +72,15 @@ type Config struct {
 	HashAlgorithm HashAlgorithm
 	Incremental   bool
 	Verbose       bool
+	// SkipFileHash avoids reading source contents only to compute metadata that
+	// a caller does not consume. Graph scans use file size and modification time
+	// to validate their symbol cache, so hashing every source file is redundant.
+	SkipFileHash bool
+
+	// SymbolCache lets repeat consumers reuse symbols for unchanged files. The
+	// cache is validated against path, language, size, and modification time;
+	// missing or stale entries are extracted normally.
+	SymbolCache map[string]SymbolCacheEntry
 
 	// Progress receives deterministic scan milestones. It is optional so index
 	// generation stays quiet and script-friendly unless a CLI or UI opts in.
@@ -98,6 +107,17 @@ type Config struct {
 	// Derived values (computed at runtime)
 	RepoFileSlug string // lowercase slug for filenames
 	RepoVarSlug  string // uppercase slug for variables
+}
+
+// SymbolCacheEntry is the durable, content-derived portion of a file scan.
+// It intentionally excludes hashes: callers that use the cache already have a
+// cheaper freshness key (size + modification time) and do not need to reread
+// each file just to compute one.
+type SymbolCacheEntry struct {
+	Language string      `json:"language"`
+	Size     int64       `json:"size"`
+	ModTime  int64       `json:"mod_time"`
+	Symbols  *SymbolInfo `json:"symbols"`
 }
 
 // ProgressEvent describes the current deterministic indexing operation.

--- a/utils/knowledgegraph/builder.go
+++ b/utils/knowledgegraph/builder.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/kris-hansen/comanda/utils/codebaseindex"
 	"github.com/kris-hansen/comanda/utils/semanticmemory"
@@ -142,18 +143,21 @@ func inferUses(g *Graph, scan *codebaseindex.ScanResult, namespace string) {
 		if f.Symbols == nil {
 			continue
 		}
-		haystack := referenceText(f.Symbols)
-		if haystack == "" {
+		// Normalize the signature text into exact identifier tokens once. The
+		// previous approach searched every unique type name through every file's
+		// text, which is quadratic for large repositories. A token set gives the
+		// same whole-identifier semantics without lossy graph compression.
+		tokens := identifierTokens(referenceText(f.Symbols))
+		if len(tokens) == 0 {
 			continue
 		}
 		fileID := NodeID(namespace, "file:"+f.Path)
-		for name, d := range defs {
-			if counts[name] != 1 || d.defFile == f.Path {
+		for name := range tokens {
+			d, ok := defs[name]
+			if !ok || counts[name] != 1 || d.defFile == f.Path {
 				continue
 			}
-			if wordMatch(haystack, name) {
-				g.AddEdge(fileID, d.nodeID, EdgeUses, ConfidenceInferred, "references "+name)
-			}
+			g.AddEdge(fileID, d.nodeID, EdgeUses, ConfidenceInferred, "references "+name)
 		}
 	}
 }
@@ -179,6 +183,30 @@ func referenceText(s *codebaseindex.SymbolInfo) string {
 		}
 	}
 	return b.String()
+}
+
+// identifierTokens splits language signatures and member lists into exact
+// identifier-like tokens. It mirrors wordMatch's definition of a word
+// character and therefore preserves inferred-edge behavior while avoiding a
+// repeated full-text scan for each known type.
+func identifierTokens(text string) map[string]struct{} {
+	tokens := make(map[string]struct{})
+	var token strings.Builder
+	flush := func() {
+		if token.Len() > 0 {
+			tokens[token.String()] = struct{}{}
+			token.Reset()
+		}
+	}
+	for _, r := range text {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			token.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return tokens
 }
 
 var wordBoundary = regexp.MustCompile(`[\p{L}\p{N}_]`)
@@ -443,11 +471,25 @@ func Rebuild(ctx context.Context, store *semanticmemory.Store, g *Graph) error {
 
 // RebuildWithProgress replaces a graph and reports its persistence phases.
 func RebuildWithProgress(ctx context.Context, store *semanticmemory.Store, g *Graph, progress ProgressFunc) error {
-	if progress != nil {
-		progress(ProgressEvent{Phase: "Removing stale graph data"})
+	nodes := make([]semanticmemory.GraphNode, 0, len(g.Nodes))
+	for _, node := range g.Nodes {
+		nodes = append(nodes, *node)
 	}
-	if err := store.DeleteGraphNamespace(ctx, g.Namespace); err != nil {
-		return err
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+	edges := make([]semanticmemory.GraphEdge, 0, len(g.Edges))
+	for _, edge := range g.Edges {
+		edges = append(edges, *edge)
 	}
-	return save(ctx, store, g, progress)
+	sort.Slice(edges, func(i, j int) bool { return edges[i].ID < edges[j].ID })
+
+	return store.ReplaceGraph(ctx, g.Namespace, nodes, edges, func(event semanticmemory.GraphWriteProgress) {
+		if progress != nil {
+			progress(ProgressEvent{
+				Phase:     event.Phase,
+				Current:   event.Current,
+				Completed: event.Completed,
+				Total:     event.Total,
+			})
+		}
+	})
 }

--- a/utils/knowledgegraph/knowledgegraph_test.go
+++ b/utils/knowledgegraph/knowledgegraph_test.go
@@ -247,3 +247,23 @@ func TestWordMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestIdentifierTokensPreserveWholeIdentifierMatching(t *testing.T) {
+	tokens := identifierTokens("func Run(s *store.Store) error; Storage StoreManager")
+	if _, ok := tokens["Store"]; !ok {
+		t.Fatalf("tokens = %#v, want Store", tokens)
+	}
+	if _, ok := tokens["Storage"]; !ok {
+		t.Fatalf("tokens = %#v, want Storage", tokens)
+	}
+
+	scan := fixtureScan()
+	scan.Candidates[0].Symbols.Functions = []codebaseindex.FunctionInfo{{
+		Name: "Run", Signature: "func Run(Storage StoreManager) error",
+	}}
+	graph := Build(scan, "proj")
+	usesID := EdgeID("proj", NodeID("proj", "file:cmd/server.go"), NodeID("proj", "type:Store@utils/store/store.go"), EdgeUses)
+	if graph.Edges[usesID] != nil {
+		t.Fatal("inferred uses edge matched Store inside a longer identifier")
+	}
+}

--- a/utils/semanticmemory/graph.go
+++ b/utils/semanticmemory/graph.go
@@ -213,11 +213,16 @@ func (s *Store) UpsertGraphEdge(ctx context.Context, edge GraphEdge) (GraphEdge,
 // namespace from the current edge set. Call once after a batch of edge writes.
 func (s *Store) RefreshGraphDegrees(ctx context.Context, namespace string) error {
 	namespace = normalizeNamespace(namespace)
-	_, err := s.db.ExecContext(ctx, `UPDATE graph_nodes SET degree = (
-        SELECT COUNT(*) FROM graph_edges
-        WHERE graph_edges.namespace = graph_nodes.namespace
-          AND (graph_edges.source_id = graph_nodes.id OR graph_edges.target_id = graph_nodes.id)
-    ) WHERE namespace = ?`, namespace)
+	_, err := s.db.ExecContext(ctx, `WITH endpoint_counts AS (
+        SELECT source_id AS id, COUNT(*) AS degree FROM graph_edges WHERE namespace = ? GROUP BY source_id
+        UNION ALL
+        SELECT target_id AS id, COUNT(*) AS degree FROM graph_edges WHERE namespace = ? GROUP BY target_id
+    ), degrees AS (
+        SELECT id, SUM(degree) AS degree FROM endpoint_counts GROUP BY id
+    )
+    UPDATE graph_nodes
+    SET degree = COALESCE((SELECT degree FROM degrees WHERE degrees.id = graph_nodes.id), 0)
+    WHERE namespace = ?`, namespace, namespace, namespace)
 	if err != nil {
 		return fmt.Errorf("refresh graph degrees: %w", err)
 	}

--- a/utils/semanticmemory/graph_bulk.go
+++ b/utils/semanticmemory/graph_bulk.go
@@ -1,0 +1,151 @@
+package semanticmemory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// GraphWriteProgress reports bounded milestones from a bulk graph replace.
+// It intentionally does not expose a database transaction to callers.
+type GraphWriteProgress struct {
+	Phase     string
+	Current   string
+	Completed int
+	Total     int
+}
+
+// ReplaceGraph atomically replaces one namespace using a single SQLite
+// transaction. Rebuilds previously committed once per node, once per mirrored
+// memory record, and once per edge; large graphs therefore spent most of their
+// time in transaction overhead rather than graph work.
+func (s *Store) ReplaceGraph(ctx context.Context, namespace string, nodes []GraphNode, edges []GraphEdge, progress func(GraphWriteProgress)) error {
+	namespace = normalizeNamespace(namespace)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("start graph replacement transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if progress != nil {
+		progress(GraphWriteProgress{Phase: "Removing stale graph data"})
+	}
+	for _, stmt := range []struct {
+		query string
+		args  []any
+	}{
+		{`DELETE FROM graph_edges WHERE namespace = ?`, []any{namespace}},
+		{`DELETE FROM graph_nodes_fts WHERE namespace = ?`, []any{namespace}},
+		{`DELETE FROM graph_nodes WHERE namespace = ?`, []any{namespace}},
+		{`DELETE FROM memory_fts WHERE id IN (SELECT id FROM memories WHERE namespace = ? AND source_ref = ?)`, []any{namespace, graphMirrorSourceRef(namespace)}},
+		{`DELETE FROM memories WHERE namespace = ? AND source_ref = ?`, []any{namespace, graphMirrorSourceRef(namespace)}},
+	} {
+		if _, err := tx.ExecContext(ctx, stmt.query, stmt.args...); err != nil {
+			return fmt.Errorf("delete graph namespace: %w", err)
+		}
+	}
+
+	nodeStmt, err := tx.PrepareContext(ctx, `INSERT INTO graph_nodes (
+        id, namespace, kind, name, path, package, summary, degree, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare graph node write: %w", err)
+	}
+	defer nodeStmt.Close()
+	graphFTSStmt, err := tx.PrepareContext(ctx, `INSERT INTO graph_nodes_fts(id, namespace, name, summary) VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare graph node index: %w", err)
+	}
+	defer graphFTSStmt.Close()
+	memoryStmt, err := tx.PrepareContext(ctx, `INSERT INTO memories (
+        id, namespace, type, priority, confidence, content, source_run_id, source_step, source_ref, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare graph memory mirror: %w", err)
+	}
+	defer memoryStmt.Close()
+	memoryFTSStmt, err := tx.PrepareContext(ctx, `INSERT INTO memory_fts(id, namespace, content) VALUES (?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare graph memory index: %w", err)
+	}
+	defer memoryFTSStmt.Close()
+	edgeStmt, err := tx.PrepareContext(ctx, `INSERT INTO graph_edges (
+        id, namespace, source_id, target_id, kind, confidence, evidence, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare graph edge write: %w", err)
+	}
+	defer edgeStmt.Close()
+
+	total := len(nodes) + len(edges)
+	completed := 0
+	report := func(phase, current string) {
+		if progress != nil && (completed%100 == 0 || completed == total) {
+			progress(GraphWriteProgress{Phase: phase, Current: current, Completed: completed, Total: total})
+		}
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, node := range nodes {
+		node.Namespace = namespace
+		node.Kind = strings.TrimSpace(strings.ToLower(node.Kind))
+		node.Name = strings.TrimSpace(node.Name)
+		if node.ID == "" || node.Name == "" {
+			return fmt.Errorf("graph node ID and name are required")
+		}
+		if _, err := nodeStmt.ExecContext(ctx, node.ID, namespace, node.Kind, node.Name, node.Path, node.Package, node.Summary, 0, now, now); err != nil {
+			return fmt.Errorf("write graph node: %w", err)
+		}
+		if _, err := graphFTSStmt.ExecContext(ctx, node.ID, namespace, node.Name, node.Summary); err != nil {
+			return fmt.Errorf("index graph node: %w", err)
+		}
+		content := node.Name
+		if node.Summary != "" {
+			content += " — " + node.Summary
+		}
+		mirrorID := graphMirrorRecordPrefix + node.ID
+		if _, err := memoryStmt.ExecContext(ctx, mirrorID, namespace, "graph_node", 50, 1.0, content, "", "", graphMirrorSourceRef(namespace), now, now); err != nil {
+			return fmt.Errorf("mirror graph node into memory: %w", err)
+		}
+		if _, err := memoryFTSStmt.ExecContext(ctx, mirrorID, namespace, content); err != nil {
+			return fmt.Errorf("index graph memory mirror: %w", err)
+		}
+		completed++
+		report("Writing graph nodes", node.Name)
+	}
+	for _, edge := range edges {
+		edge.Namespace = namespace
+		edge.Kind = strings.TrimSpace(strings.ToLower(edge.Kind))
+		if edge.ID == "" || edge.SourceID == "" || edge.TargetID == "" {
+			return fmt.Errorf("graph edge ID, source, and target are required")
+		}
+		confidence := edge.Confidence
+		if confidence == "" {
+			confidence = GraphConfidenceExtracted
+		}
+		if _, err := edgeStmt.ExecContext(ctx, edge.ID, namespace, edge.SourceID, edge.TargetID, edge.Kind, confidence, edge.Evidence, now, now); err != nil {
+			return fmt.Errorf("write graph edge: %w", err)
+		}
+		completed++
+		report("Writing graph edges", edge.Kind)
+	}
+	if progress != nil {
+		progress(GraphWriteProgress{Phase: "Refreshing graph relationships", Completed: completed, Total: total})
+	}
+	if _, err := tx.ExecContext(ctx, `WITH endpoint_counts AS (
+        SELECT source_id AS id, COUNT(*) AS degree FROM graph_edges WHERE namespace = ? GROUP BY source_id
+        UNION ALL
+        SELECT target_id AS id, COUNT(*) AS degree FROM graph_edges WHERE namespace = ? GROUP BY target_id
+    ), degrees AS (
+        SELECT id, SUM(degree) AS degree FROM endpoint_counts GROUP BY id
+    )
+    UPDATE graph_nodes
+    SET degree = COALESCE((SELECT degree FROM degrees WHERE degrees.id = graph_nodes.id), 0)
+    WHERE namespace = ?`, namespace, namespace, namespace); err != nil {
+		return fmt.Errorf("refresh graph degrees: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit graph replacement: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary\n- parallelize uncached symbol extraction with a bounded Go worker pool\n- persist and reuse extracted graph symbols for unchanged files; graph scans no longer hash source files they do not consume\n- replace quadratic type-reference matching with exact identifier token lookup\n- atomically replace graph nodes, FTS entries, memory mirrors, edges, and degrees in one SQLite transaction\n- refresh degrees with grouped endpoint counts instead of a correlated per-node edge scan\n\n## Quantization review\n- Evaluated the existing TurboQuant vector implementation. Graph build has no numeric embeddings, so applying lossy vector quantization to exact symbolic relationships would be inappropriate. This PR uses exact token normalization instead, preserving graph fidelity.\n\n## Verification\n- go test ./...\n- go test -race ./...\n- go vet ./...\n- local golangci-lint is v2 and cannot parse the repository's legacy config; CI lint remains required.