### PR TITLE
Improve missing graph database errors

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -398,9 +398,26 @@ func openGraphQuerier() (*knowledgegraph.Querier, func() error, error) {
 		dbPath = semanticmemory.DefaultPath(root, namespace)
 	}
 
+	// Graph reads must not create a memory directory or an empty SQLite file.
+	// An index can be registered before its graph is built, which is a normal
+	// first-use state rather than a database or machine-resource failure.
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, graphNotBuiltError(namespace)
+		}
+		return nil, nil, fmt.Errorf("inspect graph database %q: %w", dbPath, err)
+	}
+
 	store, err := semanticmemory.Open(dbPath)
 	if err != nil {
 		return nil, nil, err
 	}
 	return knowledgegraph.NewQuerier(store, namespace), store.Close, nil
+}
+
+func graphNotBuiltError(namespace string) error {
+	if namespace == "" {
+		return fmt.Errorf("no graph exists for the selected database; build one with: comanda graph build <index-name>")
+	}
+	return fmt.Errorf("no graph exists for namespace %q. Build it with: comanda graph build %s", namespace, namespace)
 }

--- a/cmd/graph_test.go
+++ b/cmd/graph_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+func TestOpenGraphQuerierMissingGraphGuidesBuildWithoutCreatingMemoryDirectory(t *testing.T) {
+	root := t.TempDir()
+	originalConfig, originalNamespace, originalDBPath := envConfig, graphNamespace, graphDBPath
+	t.Cleanup(func() {
+		envConfig, graphNamespace, graphDBPath = originalConfig, originalNamespace, originalDBPath
+	})
+	envConfig = &config.EnvConfig{Indexes: map[string]*config.IndexEntry{
+		"vault": {Path: root},
+	}}
+	graphNamespace = "vault"
+	graphDBPath = ""
+
+	_, _, err := openGraphQuerier()
+	if err == nil {
+		t.Fatal("openGraphQuerier() succeeded for a graph that has not been built")
+	}
+	want := `no graph exists for namespace "vault". Build it with: comanda graph build vault`
+	if err.Error() != want {
+		t.Fatalf("openGraphQuerier() error = %q, want %q", err, want)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, ".comanda", "memory")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("graph read created a memory directory: stat error = %v", statErr)
+	}
+}
+
+func TestOpenGraphQuerierOpensExistingGraphDatabase(t *testing.T) {
+	root := t.TempDir()
+	dbPath := semanticmemory.DefaultPath(root, "vault")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	originalConfig, originalNamespace, originalDBPath := envConfig, graphNamespace, graphDBPath
+	t.Cleanup(func() {
+		envConfig, graphNamespace, graphDBPath = originalConfig, originalNamespace, originalDBPath
+	})
+	envConfig = &config.EnvConfig{Indexes: map[string]*config.IndexEntry{
+		"vault": {Path: root},
+	}}
+	graphNamespace = "vault"
+	graphDBPath = ""
+
+	_, closeStore, err := openGraphQuerier()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := closeStore(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGraphNotBuiltErrorUsesNamespaceBuildCommand(t *testing.T) {
+	if got := graphNotBuiltError("vault").Error(); !strings.Contains(got, "comanda graph build vault") {
+		t.Fatalf("graphNotBuiltError() = %q", got)
+	}
+}

--- a/utils/semanticmemory/store.go
+++ b/utils/semanticmemory/store.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	_ "modernc.org/sqlite"
+	"modernc.org/sqlite"
 )
 
 const defaultNamespace = "default"
@@ -64,11 +64,11 @@ func Open(path string) (*Store, error) {
 	db.SetMaxOpenConns(1)
 	if _, err := db.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("configure memory database: %w", err)
+		return nil, configureMemoryDatabaseError(err)
 	}
 	if _, err := db.Exec(`PRAGMA journal_mode = WAL`); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("configure memory database: %w", err)
+		return nil, configureMemoryDatabaseError(err)
 	}
 	store := &Store{db: db}
 	if err := store.migrate(context.Background()); err != nil {
@@ -76,6 +76,17 @@ func Open(path string) (*Store, error) {
 		return nil, err
 	}
 	return store, nil
+}
+
+func configureMemoryDatabaseError(err error) error {
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == 14 {
+		// SQLite result code 14 is SQLITE_CANTOPEN. Never report it as an
+		// allocation failure: that sends users looking for memory pressure when
+		// the actual issue is a missing or inaccessible database path.
+		return fmt.Errorf("configure memory database: unable to open database file (SQLITE_CANTOPEN, code 14)")
+	}
+	return fmt.Errorf("configure memory database: %w", err)
 }
 
 // Close releases the database connection.

--- a/utils/semanticmemory/store_test.go
+++ b/utils/semanticmemory/store_test.go
@@ -3,6 +3,7 @@ package semanticmemory
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -33,6 +34,20 @@ func TestStoreSearchHonorsNamespaceAndTypes(t *testing.T) {
 	}
 	if results[0].Type != "decision" || results[0].Namespace != "repo" {
 		t.Fatalf("unexpected record: %#v", results[0])
+	}
+}
+
+func TestOpenMissingParentReportsCantOpenRatherThanOutOfMemory(t *testing.T) {
+	_, err := Open(filepath.Join(t.TempDir(), "missing", "memory.db"))
+	if err == nil {
+		t.Fatal("Open() succeeded with a missing database parent directory")
+	}
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "out of memory") {
+		t.Fatalf("Open() error = %q, should not mislabel SQLITE_CANTOPEN as out of memory", err)
+	}
+	if !strings.Contains(message, "unable to open database file") {
+		t.Fatalf("Open() error = %q, want an actionable database-path error", err)
 	}
 }
 


### PR DESCRIPTION
Make read-only graph commands recognize an indexed project whose graph has not yet been built.

Instead of attempting to open a missing SQLite path (and potentially surfacing a misleading low-level error), graph reads now return:

`No graph exists for namespace "vault". Build it with: comanda graph build vault`

The check deliberately performs no directory/database creation. SQLite CANTOPEN (result code 14) is also rendered correctly as an inaccessible database file, never as out of memory.

Tests:
- missing graph emits the exact build command and leaves `.comanda/memory` absent
- existing graph database still opens
- missing database parent reports CANTOPEN, not out of memory
- go vet ./...
- go test ./...