### PR TITLE
feat(graph): add browser visualizer and navigation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,23 @@ comanda graph path main Store                   # shortest connection between no
 comanda graph query "what uses the store?"      # scoped subgraph for a question
 comanda graph stats                             # counts and hub nodes
 comanda graph export -o graph.json              # graphify-style JSON
+comanda graph visualize                          # interactive local graph navigator
 ```
+
+`comanda graph visualize` opens a localhost-only browser view for navigating
+complex code structures. Search finds symbols, files, packages, and concepts;
+selecting a result focuses its connected neighborhood rather than rendering an
+unusable all-symbol hairball. The same read-only contract is available to
+native clients through the visualizer and the configured Comanda server:
+
+```text
+GET /graph?namespace=myproject
+GET /graph/search?namespace=myproject&q=Store
+GET /graph/subgraph?namespace=myproject&focus=store&depth=2
+```
+
+The browser visualizer serves equivalent endpoints below `/api/v1/` and binds
+only to `127.0.0.1`. Graph reads never modify the database.
 
 Graph nodes are mirrored into the memory FTS index as `graph_node` records, so
 workflow steps recall them with the existing memory mapping

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -5,11 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/kris-hansen/comanda/utils/codebaseindex"
+	"github.com/kris-hansen/comanda/utils/graphviewer"
 	"github.com/kris-hansen/comanda/utils/knowledgegraph"
 	"github.com/kris-hansen/comanda/utils/processor"
 	"github.com/kris-hansen/comanda/utils/semanticmemory"
@@ -17,12 +23,14 @@ import (
 )
 
 var (
-	graphNamespace    string
-	graphDBPath       string
-	graphEnhance      bool
-	graphEnhanceModel string
-	graphJSON         bool
-	graphExportOutput string
+	graphNamespace       string
+	graphDBPath          string
+	graphEnhance         bool
+	graphEnhanceModel    string
+	graphJSON            bool
+	graphExportOutput    string
+	graphVisualizePort   int
+	graphVisualizeNoOpen bool
 )
 
 var graphCmd = &cobra.Command{
@@ -47,7 +55,8 @@ Examples:
   comanda graph path main Store              # Shortest connection between nodes
   comanda graph query "what uses the store?" # Scoped subgraph for a question
   comanda graph stats                        # Counts and hub nodes
-  comanda graph export -o graph.json         # graphify-style JSON export`,
+  comanda graph export -o graph.json         # graphify-style JSON export
+  comanda graph visualize                    # Browse the graph in a local browser`,
 }
 
 var graphBuildCmd = &cobra.Command{
@@ -208,9 +217,24 @@ var graphExportCmd = &cobra.Command{
 	},
 }
 
+var graphVisualizeCmd = &cobra.Command{
+	Use:   "visualize",
+	Short: "Open an interactive local graph navigator",
+	Long: `Serve a read-only graph navigation API and browser UI on localhost.
+
+The visualizer supports full-graph exploration, FTS-backed search, filters,
+and focused one-to-three-hop subgraphs. Its API is also available to local
+clients such as Canvas:
+  GET /api/v1/graph
+  GET /api/v1/search?q=<text>
+  GET /api/v1/subgraph?focus=<node-id-or-name>&depth=1..3`,
+	Args: cobra.NoArgs,
+	RunE: runGraphVisualize,
+}
+
 func init() {
 	rootCmd.AddCommand(graphCmd)
-	graphCmd.AddCommand(graphBuildCmd, graphUpdateCmd, graphExplainCmd, graphPathCmd, graphQueryCmd, graphStatsCmd, graphExportCmd)
+	graphCmd.AddCommand(graphBuildCmd, graphUpdateCmd, graphExplainCmd, graphPathCmd, graphQueryCmd, graphStatsCmd, graphExportCmd, graphVisualizeCmd)
 
 	graphCmd.PersistentFlags().StringVarP(&graphNamespace, "namespace", "n", "", "Graph namespace (default: index registered for current directory)")
 	graphCmd.PersistentFlags().StringVar(&graphDBPath, "db", "", "Path to the graph/memory SQLite database (default: project-local)")
@@ -225,6 +249,8 @@ func init() {
 	graphQueryCmd.Flags().BoolVar(&graphJSON, "json", false, "Output JSON subgraph")
 
 	graphExportCmd.Flags().StringVarP(&graphExportOutput, "output", "o", "", "Write export to a file instead of stdout")
+	graphVisualizeCmd.Flags().IntVar(&graphVisualizePort, "port", 0, "Local port to listen on (0 selects a free port)")
+	graphVisualizeCmd.Flags().BoolVar(&graphVisualizeNoOpen, "no-open", false, "Start the API without opening a browser")
 }
 
 // buildKnowledgeGraph scans the repo behind a registered index and rebuilds
@@ -370,8 +396,12 @@ func runGraphBuild(_ *cobra.Command, args []string) error {
 // openGraphQuerier resolves the namespace (flag, or the index registered for
 // the current directory) and opens a querier on the right database.
 func openGraphQuerier() (*knowledgegraph.Querier, func() error, error) {
-	namespace := graphNamespace
-	dbPath := graphDBPath
+	return openGraphQuerierFor(graphNamespace, graphDBPath)
+}
+
+// openGraphQuerierFor resolves and opens a graph without mutating command
+// globals, so the local visualizer and HTTP API can serve requests safely.
+func openGraphQuerierFor(namespace, dbPath string) (*knowledgegraph.Querier, func() error, error) {
 
 	if dbPath == "" {
 		root := ""
@@ -413,6 +443,54 @@ func openGraphQuerier() (*knowledgegraph.Querier, func() error, error) {
 		return nil, nil, err
 	}
 	return knowledgegraph.NewQuerier(store, namespace), store.Close, nil
+}
+
+func runGraphVisualize(_ *cobra.Command, _ []string) error {
+	if graphVisualizePort < 0 || graphVisualizePort > 65535 {
+		return fmt.Errorf("port must be between 0 and 65535")
+	}
+	open := func(_ context.Context, requestedNamespace string) (*knowledgegraph.Querier, func() error, error) {
+		if graphNamespace != "" && requestedNamespace != "" && requestedNamespace != graphNamespace {
+			return nil, nil, fmt.Errorf("this visualizer is bound to namespace %q", graphNamespace)
+		}
+		if requestedNamespace == "" {
+			requestedNamespace = graphNamespace
+		}
+		return openGraphQuerierFor(requestedNamespace, graphDBPath)
+	}
+	handler, err := graphviewer.VisualizationHandler(open)
+	if err != nil {
+		return err
+	}
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(graphVisualizePort)))
+	if err != nil {
+		return fmt.Errorf("start graph visualizer: %w", err)
+	}
+	url := "http://" + listener.Addr().String()
+	fmt.Printf("Comanda graph visualizer: %s\nPress Ctrl-C to stop.\n", url)
+	if !graphVisualizeNoOpen {
+		if err := openBrowser(url); err != nil {
+			log.Printf("Could not open browser automatically: %v\n", err)
+		}
+	}
+	server := &http.Server{Handler: handler}
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("serve graph visualizer: %w", err)
+	}
+	return nil
+}
+
+func openBrowser(url string) error {
+	var command *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		command = exec.Command("open", url)
+	case "windows":
+		command = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		command = exec.Command("xdg-open", url)
+	}
+	return command.Start()
 }
 
 func graphNotBuiltError(namespace string) error {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -25,6 +25,9 @@ configured port (default: 8080).
 Endpoints:
   POST /process                Execute a workflow (multipart form or JSON)
   GET  /health                 Health check endpoint
+  GET  /graph                  Read a knowledge graph (namespace query parameter)
+  GET  /graph/search           Search graph nodes
+  GET  /graph/subgraph         Fetch a focused graph neighborhood
 
 OpenAI-Compatible Endpoints (when enabled):
   GET  /v1/models              List available workflows as models

--- a/examples/knowledge-graph/README.md
+++ b/examples/knowledge-graph/README.md
@@ -25,6 +25,17 @@ comanda graph path main Store              # shortest connection between nodes
 comanda graph query "what uses the store?" # scoped subgraph for a question
 comanda graph stats                        # counts and hub nodes
 comanda graph export -o graph.json         # graphify-style JSON export
+comanda graph visualize                     # search and browse locally in a browser
+```
+
+`visualize` serves a localhost-only, read-only navigator. Search for a symbol,
+file, package, or concept and click a result to inspect its focused
+neighborhood. The graph API is reusable by native clients:
+
+```text
+GET /graph?namespace=myproject
+GET /graph/search?namespace=myproject&q=Store
+GET /graph/subgraph?namespace=myproject&focus=store&depth=2
 ```
 
 Edges are confidence-tagged: `EXTRACTED` (explicit in the source) vs.

--- a/utils/graphviewer/server.go
+++ b/utils/graphviewer/server.go
@@ -1,0 +1,174 @@
+// Package graphviewer exposes a local, read-only HTTP API for navigating a
+// Comanda knowledge graph. Both the browser visualizer and future native
+// clients (such as Canvas) consume this contract.
+package graphviewer
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/kris-hansen/comanda/utils/knowledgegraph"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+// OpenQuerier opens a read-only graph query session for namespace. A blank
+// namespace asks the caller to select its default graph.
+type OpenQuerier func(context.Context, string) (*knowledgegraph.Querier, func() error, error)
+
+// API provides the graph navigation contract. It does not write the graph or
+// expose arbitrary files.
+type API struct {
+	open OpenQuerier
+}
+
+// NewAPI creates a graph navigation API with these endpoints:
+//
+//	GET /api/v1/graph?namespace=<name>
+//	GET /api/v1/search?q=<text>&limit=<n>&namespace=<name>
+//	GET /api/v1/subgraph?focus=<node-id-or-name>&depth=1..3&namespace=<name>
+func NewAPI(open OpenQuerier) *API {
+	return &API{open: open}
+}
+
+func (a *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	switch r.URL.Path {
+	case "/api/v1/graph":
+		a.handleGraph(w, r)
+	case "/api/v1/search":
+		a.handleSearch(w, r)
+	case "/api/v1/subgraph":
+		a.handleSubgraph(w, r)
+	default:
+		writeError(w, http.StatusNotFound, "graph API endpoint not found")
+	}
+}
+
+func (a *API) withQuerier(w http.ResponseWriter, r *http.Request, run func(*knowledgegraph.Querier)) {
+	q, closeStore, err := a.open(r.Context(), r.URL.Query().Get("namespace"))
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	defer func() { _ = closeStore() }()
+	run(q)
+}
+
+func (a *API) handleGraph(w http.ResponseWriter, r *http.Request) {
+	a.withQuerier(w, r, func(q *knowledgegraph.Querier) {
+		graph, err := q.Export(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, graph)
+	})
+}
+
+func (a *API) handleSearch(w http.ResponseWriter, r *http.Request) {
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	if query == "" {
+		writeError(w, http.StatusBadRequest, "q is required")
+		return
+	}
+	limit := parseBoundedInt(r.URL.Query().Get("limit"), 20, 1, 50)
+	a.withQuerier(w, r, func(q *knowledgegraph.Querier) {
+		nodes, err := q.FindNodes(r.Context(), query, limit)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		out := make([]knowledgegraph.ExportNode, 0, len(nodes))
+		for _, node := range nodes {
+			out = append(out, exportNode(node))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"namespace": q.Namespace(), "query": query, "nodes": out})
+	})
+}
+
+func (a *API) handleSubgraph(w http.ResponseWriter, r *http.Request) {
+	focus := strings.TrimSpace(r.URL.Query().Get("focus"))
+	if focus == "" {
+		writeError(w, http.StatusBadRequest, "focus is required")
+		return
+	}
+	depth := parseBoundedInt(r.URL.Query().Get("depth"), 1, 1, 3)
+	a.withQuerier(w, r, func(q *knowledgegraph.Querier) {
+		node, err := q.NodeByID(r.Context(), focus)
+		if err != nil {
+			node, err = q.Resolve(r.Context(), focus)
+		}
+		if err != nil {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		graph, err := q.ScopedExport(r.Context(), []semanticmemory.GraphNode{*node}, depth)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"focus": exportNode(*node), "depth": depth, "graph": graph})
+	})
+}
+
+func exportNode(node semanticmemory.GraphNode) knowledgegraph.ExportNode {
+	return knowledgegraph.ExportNode{ID: knowledgegraph.LocalID(node.ID), Kind: node.Kind, Name: node.Name, Path: node.Path, Package: node.Package, Summary: node.Summary, Degree: node.Degree}
+}
+
+func parseBoundedInt(raw string, fallback, min, max int) int {
+	value, err := strconv.Atoi(raw)
+	if err != nil || value == 0 {
+		return fallback
+	}
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+//go:embed web/*
+var webFiles embed.FS
+
+// VisualizationHandler serves the interactive browser UI and its API from one
+// localhost origin. The API remains usable independently through NewAPI.
+func VisualizationHandler(open OpenQuerier) (http.Handler, error) {
+	assets, err := fs.Sub(webFiles, "web")
+	if err != nil {
+		return nil, fmt.Errorf("load graph visualizer assets: %w", err)
+	}
+	api := NewAPI(open)
+	mux := http.NewServeMux()
+	mux.Handle("/api/", api)
+	mux.Handle("/", http.FileServer(http.FS(assets)))
+	return mux, nil
+}

--- a/utils/graphviewer/server_test.go
+++ b/utils/graphviewer/server_test.go
@@ -1,0 +1,90 @@
+package graphviewer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/knowledgegraph"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+func TestAPIExportsSearchesAndFocusesGraph(t *testing.T) {
+	store, err := semanticmemory.Open(filepath.Join(t.TempDir(), "graph.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	alpha, err := store.UpsertGraphNode(ctx, semanticmemory.GraphNode{ID: "demo|alpha", Namespace: "demo", Kind: semanticmemory.GraphNodeFunction, Name: "Alpha", Path: "alpha.go", Summary: "entry point"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	beta, err := store.UpsertGraphNode(ctx, semanticmemory.GraphNode{ID: "demo|beta", Namespace: "demo", Kind: semanticmemory.GraphNodeType, Name: "Beta", Path: "beta.go", Summary: "shared type"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertGraphEdge(ctx, semanticmemory.GraphEdge{ID: "demo|edge", Namespace: "demo", SourceID: alpha.ID, TargetID: beta.ID, Kind: semanticmemory.GraphEdgeUses, Confidence: semanticmemory.GraphConfidenceExtracted}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RefreshGraphDegrees(ctx, "demo"); err != nil {
+		t.Fatal(err)
+	}
+
+	api := NewAPI(func(_ context.Context, namespace string) (*knowledgegraph.Querier, func() error, error) {
+		if namespace != "" && namespace != "demo" {
+			return nil, nil, &notFoundError{namespace}
+		}
+		return knowledgegraph.NewQuerier(store, "demo"), func() error { return nil }, nil
+	})
+
+	graph := requestJSON(t, api, "/api/v1/graph")
+	if got := len(graph["nodes"].([]any)); got != 2 {
+		t.Fatalf("graph nodes = %d, want 2", got)
+	}
+	search := requestJSON(t, api, "/api/v1/search?q=Alpha")
+	if got := len(search["nodes"].([]any)); got != 1 {
+		t.Fatalf("search node count = %d, want 1", got)
+	}
+	focused := requestJSON(t, api, "/api/v1/subgraph?focus=alpha&depth=2")
+	subgraph := focused["graph"].(map[string]any)
+	if got := len(subgraph["nodes"].([]any)); got != 2 {
+		t.Fatalf("focused graph nodes = %d, want 2", got)
+	}
+}
+
+func TestAPIValidatesSearchAndFocus(t *testing.T) {
+	api := NewAPI(func(context.Context, string) (*knowledgegraph.Querier, func() error, error) {
+		return nil, func() error { return nil }, nil
+	})
+	for _, path := range []string{"/api/v1/search", "/api/v1/subgraph"} {
+		r := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		api.ServeHTTP(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("%s status = %d, want %d", path, w.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func requestJSON(t *testing.T, api http.Handler, path string) map[string]any {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET %s status = %d, body = %s", path, w.Code, w.Body.String())
+	}
+	var out map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+type notFoundError struct{ namespace string }
+
+func (e *notFoundError) Error() string { return "namespace not found: " + e.namespace }

--- a/utils/graphviewer/web/index.html
+++ b/utils/graphviewer/web/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Comanda Graph</title>
+  <style>
+    :root { color-scheme: dark; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:#0d1017; color:#e9edf5; }
+    * { box-sizing:border-box } body { margin:0; height:100vh; display:grid; grid-template-columns:300px 1fr 310px; overflow:hidden }
+    aside { background:#131824; border-right:1px solid #293143; padding:18px; overflow:auto } aside:last-child { border-left:1px solid #293143; border-right:0 }
+    h1 { font-size:18px; margin:0 0 6px } h2 { font-size:13px; letter-spacing:.06em; text-transform:uppercase; color:#91a0bd; margin:22px 0 10px }
+    p,small { color:#aab5ca; line-height:1.45 } input { width:100%; padding:10px; border:1px solid #38435b; background:#0d1017; color:white; border-radius:7px }
+    button,.result { width:100%; text-align:left; padding:9px; margin-top:6px; color:#dce4f5; border:1px solid transparent; background:#1b2231; border-radius:6px; cursor:pointer }
+    button:hover,.result:hover { background:#28334a; border-color:#4c5f81 } label { display:block; margin:8px 0; font-size:13px; color:#c1cbe0 }
+    main { position:relative; overflow:hidden; background:radial-gradient(circle at 50% 40%,#1b263b 0,#0d1017 55%) }
+    #canvas { width:100%; height:100%; cursor:grab } .edge { stroke:#596883; stroke-opacity:.38 } .edge.inferred { stroke-dasharray:4 5; stroke:#e1a553 } .node { cursor:pointer; stroke:#e9edf5; stroke-width:1.2 } .node.selected { stroke:#fff; stroke-width:3 }
+    .label { fill:#cdd7ea; font-size:11px; pointer-events:none } #status { position:absolute; top:14px; left:16px; padding:7px 10px; background:#111827cc; border:1px solid #31405a; border-radius:6px; color:#b7c4dc; font-size:12px }
+    .muted { opacity:.7 } .tag { display:inline-block; padding:3px 6px; background:#25314a; border-radius:4px; margin:2px; font-size:11px } #details { white-space:pre-wrap; font-size:13px; line-height:1.5 } .path { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:11px; word-break:break-all }
+  </style>
+</head>
+<body>
+  <aside>
+    <h1>Comanda Graph</h1><small id="namespace">Loading graph…</small>
+    <h2>Search</h2><input id="search" placeholder="Symbol, file, package, concept"><div id="results"></div>
+    <h2>Display</h2><label><input type="checkbox" id="inferred" checked> inferred relationships</label><label><input type="checkbox" id="labels" checked> node labels</label>
+    <h2>Node kinds</h2><div id="kinds"></div>
+    <p class="muted">Click a node or a search result to focus its connected neighborhood. Scroll to zoom; drag empty space to pan.</p>
+  </aside>
+  <main><div id="status">Loading…</div><svg id="canvas" aria-label="Knowledge graph"></svg></main>
+  <aside><h2>Inspector</h2><div id="details"><p>Select a node to see why it is connected, its source path, and its relationships.</p></div></aside>
+  <script>
+  const svg=document.querySelector('#canvas'), status=document.querySelector('#status'), details=document.querySelector('#details');
+  const palette={component:'#8d72e8',package:'#45b6e8',file:'#46c794',type:'#ff9a58',function:'#f0ce54',concept:'#e177c3'};
+  let full, shown, transform={x:0,y:0,scale:1}, drag, kinds=new Set(), includeInferred=true, showLabels=true;
+  const esc=s=>String(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  async function json(url){const r=await fetch(url);const v=await r.json();if(!r.ok)throw new Error(v.error||r.statusText);return v}
+  async function load(){try{full=await json('/api/v1/graph');shown=full;document.querySelector('#namespace').textContent=full.namespace+' · '+full.nodes.length+' nodes · '+full.edges.length+' edges';full.nodes.forEach(n=>kinds.add(n.kind)); filters();render()}catch(e){status.textContent='Unable to load graph: '+e.message}}
+  function filters(){const holder=document.querySelector('#kinds');holder.innerHTML='';[...kinds].sort().forEach(kind=>{const id='kind-'+kind;holder.insertAdjacentHTML('beforeend',`<label><input id="${id}" type="checkbox" checked> <span style="color:${palette[kind]||'#ccd'}">●</span> ${esc(kind)}</label>`);document.querySelector('#'+id).onchange=()=>render()})}
+  function activeKinds(){return new Set([...kinds].filter(k=>document.querySelector('#kind-'+k)?.checked))}
+  function render(){if(!shown)return;const allowed=activeKinds();const nodes=shown.nodes.filter(n=>allowed.has(n.kind));const ids=new Set(nodes.map(n=>n.id));const edges=shown.edges.filter(e=>ids.has(e.source)&&ids.has(e.target)&&(includeInferred||e.confidence!=='inferred'));
+    const w=svg.clientWidth||900,h=svg.clientHeight||700,cx=w/2,cy=h/2,r=Math.min(w,h)*.37;const degree=new Map(nodes.map(n=>[n.id,n.degree||0]));const ordered=[...nodes].sort((a,b)=>(degree.get(b.id)-degree.get(a.id))||a.name.localeCompare(b.name));
+    const pos=new Map(ordered.map((n,i)=>{const a=(Math.PI*2*i)/Math.max(ordered.length,1)-Math.PI/2;const rr=r*(.35+.65*((i%11)/10));return[n.id,{x:cx+Math.cos(a)*rr,y:cy+Math.sin(a)*rr}]}));
+    svg.innerHTML=`<g transform="translate(${transform.x} ${transform.y}) scale(${transform.scale})">${edges.map(e=>{const a=pos.get(e.source),b=pos.get(e.target);return a&&b?`<line class="edge ${e.confidence}" x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"><title>${esc(e.kind)} · ${esc(e.confidence)}</title></line>`:''}).join('')}${nodes.map(n=>{const p=pos.get(n.id),size=Math.max(5,Math.min(17,5+Math.sqrt(n.degree||0)*2));return `<g data-id="${esc(n.id)}"><circle class="node" fill="${palette[n.kind]||'#9ba8c5'}" cx="${p.x}" cy="${p.y}" r="${size}"><title>${esc(n.name)} (${esc(n.kind)})</title></circle>${showLabels?`<text class="label" x="${p.x+size+3}" y="${p.y+4}">${esc(n.name)}</text>`:''}</g>`}).join('')}</g>`;
+    svg.querySelectorAll('[data-id]').forEach(el=>el.onclick=e=>{e.stopPropagation();focus(el.dataset.id)});status.textContent=`${nodes.length} nodes · ${edges.length} relationships${shown!==full?' · focused view':''}`;
+  }
+  async function focus(id){try{const data=await json('/api/v1/subgraph?focus='+encodeURIComponent(id)+'&depth=2');shown=data.graph;render();const n=data.focus;details.innerHTML=`<h1>${esc(n.name)}</h1><span class="tag">${esc(n.kind)}</span><span class="tag">degree ${n.degree}</span>${n.package?`<p><b>Package</b><br>${esc(n.package)}</p>`:''}${n.path?`<p><b>Source</b><br><span class="path">${esc(n.path)}</span></p>`:''}${n.summary?`<p><b>Summary</b><br>${esc(n.summary)}</p>`:''}<button id="showall">Show full graph</button>`;document.querySelector('#showall').onclick=()=>{shown=full;render()}}catch(e){status.textContent=e.message}}
+  let timer;document.querySelector('#search').oninput=e=>{clearTimeout(timer);const q=e.target.value.trim();if(!q){document.querySelector('#results').innerHTML='';return}timer=setTimeout(async()=>{try{const data=await json('/api/v1/search?q='+encodeURIComponent(q));document.querySelector('#results').innerHTML=data.nodes.map(n=>`<button class="result" data-id="${esc(n.id)}"><b>${esc(n.name)}</b><br><small>${esc(n.kind)}${n.path?' · '+esc(n.path):''}</small></button>`).join('')||'<p>No graph nodes found.</p>';document.querySelectorAll('.result').forEach(b=>b.onclick=()=>focus(b.dataset.id))}catch(e){status.textContent=e.message}},180)};
+  document.querySelector('#inferred').onchange=e=>{includeInferred=e.target.checked;render()};document.querySelector('#labels').onchange=e=>{showLabels=e.target.checked;render()};
+  svg.addEventListener('wheel',e=>{e.preventDefault();const factor=e.deltaY<0?1.12:.89;transform.scale=Math.max(.25,Math.min(4,transform.scale*factor));render()},{passive:false});svg.addEventListener('pointerdown',e=>{drag={x:e.clientX,y:e.clientY,tx:transform.x,ty:transform.y};svg.setPointerCapture(e.pointerId)});svg.addEventListener('pointermove',e=>{if(drag){transform.x=drag.tx+e.clientX-drag.x;transform.y=drag.ty+e.clientY-drag.y;render()}});svg.addEventListener('pointerup',()=>drag=null);window.onresize=render;load();
+  </script>
+</body></html>

--- a/utils/knowledgegraph/query.go
+++ b/utils/knowledgegraph/query.go
@@ -20,6 +20,9 @@ func NewQuerier(store *semanticmemory.Store, namespace string) *Querier {
 	return &Querier{store: store, namespace: namespace}
 }
 
+// Namespace returns the graph namespace this querier is bound to.
+func (q *Querier) Namespace() string { return q.namespace }
+
 // resolve finds the single best node for a user-supplied name. Exact
 // case-sensitive matches win, then case-insensitive, then more specific kinds
 // (a type named "Store" beats a package named "store"), then FTS ranking.
@@ -320,6 +323,26 @@ func (q *Querier) Resolve(ctx context.Context, name string) (*semanticmemory.Gra
 // FindNodes returns the best matching nodes for a plain-text query.
 func (q *Querier) FindNodes(ctx context.Context, query string, limit int) ([]semanticmemory.GraphNode, error) {
 	return q.store.GraphFindNodes(ctx, q.namespace, query, limit)
+}
+
+// NodeByID returns a graph node by either its stable stored ID or its local
+// export ID. It rejects nodes from another namespace.
+func (q *Querier) NodeByID(ctx context.Context, id string) (*semanticmemory.GraphNode, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, fmt.Errorf("empty node ID")
+	}
+	if !strings.Contains(id, "|") {
+		id = NodeID(q.namespace, id)
+	}
+	node, err := q.store.GetGraphNode(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if node.Namespace != q.namespace {
+		return nil, fmt.Errorf("graph node not found")
+	}
+	return &node, nil
 }
 
 // PathHops returns the hop chain between two nodes for structured output.

--- a/utils/server/graph_handlers.go
+++ b/utils/server/graph_handlers.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/kris-hansen/comanda/utils/graphviewer"
+	"github.com/kris-hansen/comanda/utils/knowledgegraph"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+// graphQuerier opens only graphs registered in this server's Comanda config.
+// This keeps the HTTP API from becoming a path-based database reader.
+func (s *Server) graphQuerier(_ context.Context, namespace string) (*knowledgegraph.Querier, func() error, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil, nil, fmt.Errorf("namespace is required")
+	}
+	entry, ok := s.envConfig.Indexes[namespace]
+	if !ok || entry == nil {
+		return nil, nil, fmt.Errorf("no registered index named %q", namespace)
+	}
+	dbPath := semanticmemory.DefaultPath(entry.Path, namespace)
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, fmt.Errorf("no graph exists for namespace %q. Build it with: comanda graph build %s", namespace, namespace)
+		}
+		return nil, nil, fmt.Errorf("inspect graph database: %w", err)
+	}
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return knowledgegraph.NewQuerier(store, namespace), store.Close, nil
+}
+
+// handleGraphAPI maps the server's stable /graph endpoints to the same
+// read-only navigation contract consumed by `comanda graph visualize`.
+func (s *Server) handleGraphAPI(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/graph")
+	if path == "" || path == "/" {
+		path = "/graph"
+	}
+	clone := r.Clone(r.Context())
+	clone.URL.Path = "/api/v1" + path
+	graphviewer.NewAPI(s.graphQuerier).ServeHTTP(w, clone)
+}

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -259,11 +259,12 @@ func SetVersion(v string) {
 // progressively enable functionality based on what this server supports
 func (s *Server) capabilities() []string {
 	caps := []string{
-		"full-dsl",          // /process, /yaml/process parse the complete DSL (parallel, loops, defer, workflow)
-		"yaml-validate",     // POST /yaml/validate
-		"log-events",        // SSE "log" events with stream-log lines during streaming execution
-		"progress-metrics",  // SSE "progress" events include per-step performance metrics
-		"stream-no-timeout", // streaming runs are not time-limited unless configured
+		"full-dsl",            // /process, /yaml/process parse the complete DSL (parallel, loops, defer, workflow)
+		"yaml-validate",       // POST /yaml/validate
+		"log-events",          // SSE "log" events with stream-log lines during streaming execution
+		"progress-metrics",    // SSE "progress" events include per-step performance metrics
+		"stream-no-timeout",   // streaming runs are not time-limited unless configured
+		"knowledge-graph-api", // read-only /graph navigation endpoints
 	}
 	if s.config.OpenAICompat.Enabled {
 		caps = append(caps, "openai-compat")
@@ -297,6 +298,11 @@ func (s *Server) routes() {
 	// Project context is the discovery contract used by Canvas before a run.
 	s.mux.HandleFunc("/context", s.combinedMiddleware(s.handleContext))
 	s.mux.HandleFunc("/preflight", s.combinedMiddleware(s.handlePreflight))
+
+	// Knowledge-graph navigation API. Requests require the same authentication
+	// as other server data endpoints and can address registered namespaces only.
+	s.mux.HandleFunc("/graph", s.combinedMiddleware(s.handleGraphAPI))
+	s.mux.HandleFunc("/graph/", s.combinedMiddleware(s.handleGraphAPI))
 
 	// Provider operations - require auth
 	s.mux.HandleFunc("/providers", s.combinedMiddleware(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add `comanda graph visualize`, a localhost-only interactive graph browser
- expose read-only graph export, FTS-backed search, and focused subgraph endpoints for the visualizer and Canvas
- mount the same authenticated API on `comanda server` at `/graph`

## Validation
- `go vet ./...`
- `go test ./...`
- `go build -o /tmp/comanda-graph-visualize .`
- localhost visualizer smoke test

The visualizer binds to 127.0.0.1 only; graph reads do not create or modify state.