### PR TITLE
fix: write index registry to the active config path

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -353,12 +353,8 @@ func runCapture(cmd *cobra.Command, args []string) error {
 }
 
 func registerIndex(name, repoPath string, result *codebaseindex.Result, cfg *codebaseindex.Config) error {
-	// Load current config
-	comandaDir, err := config.GetComandaDir()
-	if err != nil {
-		return err
-	}
-	configPath := filepath.Join(comandaDir, "config.yaml")
+	// Load current config from the same path the CLI loaded at startup
+	configPath := config.GetEnvPath()
 
 	// Load existing config
 	envCfg, err := config.LoadEnvConfig(configPath)
@@ -752,11 +748,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	// Remove from config
-	comandaDir, err := config.GetComandaDir()
-	if err != nil {
-		return err
-	}
-	configPath := filepath.Join(comandaDir, "config.yaml")
+	configPath := config.GetEnvPath()
 
 	// Load config
 	envCfg, err := config.LoadEnvConfig(configPath)


### PR DESCRIPTION
## Problem

`comanda index capture` reports `Index registered as 'X'`, but `comanda index list` then shows `No indexes registered.`

Root cause: `registerIndex` and `runRemove` hardcoded `~/.comanda/config.yaml` when persisting the index registry, while startup (and every other command — `configure`, `server`) loads config via `config.GetEnvPath()`, which honors `COMANDA_ENV` and the legacy `.env` fallback. With `COMANDA_ENV` set (or only a legacy `.env` present), capture wrote the registry into a file that is never read back.

## Fix

Use `config.GetEnvPath()` in `registerIndex` and `runRemove` so the registry is written to the same file the CLI loads at startup.

## Verification

- With `COMANDA_ENV` pointed at a scratch config: `index capture` → `index list` shows the entry; `index remove` → registry empty again.
- `go vet ./cmd/` clean; `go test ./cmd/ ./utils/config/` passes.

Note for anyone hitting this bug: indexes previously captured with `COMANDA_ENV` set are stranded in `~/.comanda/config.yaml` — either re-capture or move the `indexes:` block into your active config file.