### PR TITLE
Fix Canvas knowledge graph API discovery and routing

### DIFF
--- a/utils/server/context_handlers.go
+++ b/utils/server/context_handlers.go
@@ -114,7 +114,7 @@ func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
 func (s *Server) contextInventory() ContextResponse {
 	response := ContextResponse{
 		APIVersion:   contextAPIVersion,
-		Capabilities: []string{"project-context", "codebase-indexes", "knowledge-graphs", "run-preflight"},
+		Capabilities: []string{"project-context", "codebase-indexes", "knowledge-graphs", "knowledge-graph-api", "run-preflight"},
 	}
 	if s.envConfig == nil {
 		return response

--- a/utils/server/context_handlers_test.go
+++ b/utils/server/context_handlers_test.go
@@ -40,6 +40,18 @@ func TestContextInventoryExposesRegisteredIndexAsProject(t *testing.T) {
 	if response.Projects[0].SourceRoot != root || response.Indexes[0].Status != "ready" {
 		t.Fatalf("project/index did not report ready source context: %#v", response)
 	}
+	if !hasCapability(response.Capabilities, "knowledge-graph-api") {
+		t.Fatalf("context capabilities = %v, want knowledge-graph-api", response.Capabilities)
+	}
+}
+
+func hasCapability(capabilities []string, want string) bool {
+	for _, capability := range capabilities {
+		if capability == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPreflightFindsMissingIndexBeforeRun(t *testing.T) {

--- a/utils/server/graph_handlers.go
+++ b/utils/server/graph_handlers.go
@@ -41,10 +41,7 @@ func (s *Server) graphQuerier(_ context.Context, namespace string) (*knowledgegr
 // read-only navigation contract consumed by `comanda graph visualize`.
 func (s *Server) handleGraphAPI(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/graph")
-	if path == "" || path == "/" {
-		path = "/graph"
-	}
 	clone := r.Clone(r.Context())
-	clone.URL.Path = "/api/v1" + path
+	clone.URL.Path = path
 	graphviewer.NewAPI(s.graphQuerier).ServeHTTP(w, clone)
 }

--- a/utils/server/graph_handlers_test.go
+++ b/utils/server/graph_handlers_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+)
+
+func TestGraphAPIProxiesRegisteredGraphForAuthenticatedClients(t *testing.T) {
+	root := t.TempDir()
+	indexPath := filepath.Join(root, ".comanda", "index.md")
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(indexPath, []byte("# Index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := semanticmemory.DefaultPath(root, "demo")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if _, err := store.UpsertGraphNode(context.Background(), semanticmemory.GraphNode{
+		ID: "demo|server", Namespace: "demo", Kind: semanticmemory.GraphNodeComponent, Name: "server",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	server := newContextTestServer(t, root, indexPath)
+	req := httptest.NewRequest(http.MethodGet, "/graph/api/v1/overview?namespace=demo", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	server.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("graph overview status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Namespace string `json:"namespace"`
+		Nodes     []struct {
+			Name string `json:"name"`
+		} `json:"nodes"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Namespace != "demo" || len(response.Nodes) != 1 || response.Nodes[0].Name != "server" {
+		t.Fatalf("unexpected graph overview: %#v", response)
+	}
+}


### PR DESCRIPTION
## Summary
- route Canvas graph requests without duplicating the API version prefix
- advertise knowledge-graph-api in the server context discovery response
- cover an authenticated graph overview request through the server mux

## Verification
- go test ./...
- go vet ./...

Canvas is distributed from comanda.sh; no App Store packaging change is involved.