### PR TITLE
feat: expose workflow validation over server API

### DIFF
--- a/utils/processor/preflight.go
+++ b/utils/processor/preflight.go
@@ -343,11 +343,28 @@ func (p *Processor) preflightTool(value string, toolConfig *ToolListConfig, inpu
 }
 
 func (p *Processor) preflightResolvePath(path string) (string, error) {
-	if p.sourceRoot != "" {
-		return ResolveProjectPath(p.sourceRoot, path)
-	}
 	if filepath.IsAbs(path) {
 		return path, nil
+	}
+	if p.serverConfig != nil && p.serverConfig.Enabled {
+		if p.sourceRoot != "" && !p.isOutputInOtherSteps(path) {
+			projectPath, err := ResolveProjectPath(p.sourceRoot, path)
+			if err != nil {
+				return "", err
+			}
+			if _, err := os.Stat(projectPath); err == nil {
+				return projectPath, nil
+			} else if !os.IsNotExist(err) {
+				return "", err
+			}
+		}
+		if p.runtimeDir != "" {
+			return filepath.Join(p.serverConfig.DataDir, p.runtimeDir, path), nil
+		}
+		return filepath.Join(p.serverConfig.DataDir, path), nil
+	}
+	if p.sourceRoot != "" {
+		return ResolveProjectPath(p.sourceRoot, path)
 	}
 	if p.runtimeDir != "" {
 		return filepath.Join(p.runtimeDir, path), nil

--- a/utils/server/context_handlers.go
+++ b/utils/server/context_handlers.go
@@ -111,10 +111,33 @@ func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(response)
 }
 
+// handleValidate performs the same non-processing preflight as
+// `comanda validate`, scoped to the server's runtime directory and optional
+// registered project. It deliberately does not execute workflow actions.
+func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		sendJSONError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	var request PreflightRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		sendJSONError(w, http.StatusBadRequest, "Invalid validate request")
+		return
+	}
+	if strings.TrimSpace(request.Workflow) == "" {
+		sendJSONError(w, http.StatusBadRequest, "workflow is required")
+		return
+	}
+
+	response := s.validate(request)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
 func (s *Server) contextInventory() ContextResponse {
 	response := ContextResponse{
 		APIVersion:   contextAPIVersion,
-		Capabilities: []string{"project-context", "codebase-indexes", "knowledge-graphs", "knowledge-graph-api", "run-preflight"},
+		Capabilities: []string{"project-context", "codebase-indexes", "knowledge-graphs", "knowledge-graph-api", "run-preflight", "workflow-validate"},
 	}
 	if s.envConfig == nil {
 		return response
@@ -215,6 +238,41 @@ func (s *Server) preflight(request PreflightRequest) PreflightResponse {
 		if _, err := s.validatePath(filepath.Join(request.RuntimeDir, "workflow.yaml")); err != nil {
 			add("error", "runtime_invalid", "Runtime directory is not safe for this server")
 		}
+	}
+	response.Ready = true
+	for _, issue := range response.Issues {
+		if issue.Severity == "error" {
+			response.Ready = false
+			break
+		}
+	}
+	return response
+}
+
+func (s *Server) validate(request PreflightRequest) PreflightResponse {
+	response := s.preflight(request)
+	add := func(severity, code, message string) {
+		response.Issues = append(response.Issues, PreflightIssue{Severity: severity, Code: code, Message: message})
+	}
+
+	var dsl processor.DSLConfig
+	if err := yaml.Unmarshal([]byte(request.Workflow), &dsl); err != nil {
+		response.Ready = false
+		return response
+	}
+
+	processorInstance := processor.NewProcessor(
+		&dsl,
+		s.envConfig,
+		s.config,
+		false,
+		request.RuntimeDir,
+	)
+	if response.Project != nil {
+		processorInstance.SetSourceRoot(response.Project.SourceRoot)
+	}
+	if err := processorInstance.Preflight(); err != nil {
+		add("error", "workflow_not_runnable", err.Error())
 	}
 	response.Ready = true
 	for _, issue := range response.Issues {

--- a/utils/server/context_handlers_test.go
+++ b/utils/server/context_handlers_test.go
@@ -125,6 +125,51 @@ func TestPreflightRejectsCodebaseRootOutsideProject(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsMissingWorkflowInputWithoutProcessing(t *testing.T) {
+	root := t.TempDir()
+	indexPath := filepath.Join(root, ".comanda", "index.md")
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(indexPath, []byte("# Index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	server := newContextTestServer(t, root, indexPath)
+	workflow := `summarize:
+  input: missing.txt
+  model: NA
+  action: Do not execute this action
+  output: STDOUT
+`
+	body, err := json.Marshal(PreflightRequest{Workflow: workflow, ProjectID: "demo", RuntimeDir: "canvas_validate"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	server.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("validate status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var response PreflightResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Ready || !hasIssue(response.Issues, "workflow_not_runnable") {
+		t.Fatalf("expected missing input to block validation, got %#v", response)
+	}
+}
+
+func hasIssue(issues []PreflightIssue, code string) bool {
+	for _, issue := range issues {
+		if issue.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
 func newContextTestServer(t *testing.T, root, indexPath string) *Server {
 	t.Helper()
 	server := &Server{

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -298,6 +298,7 @@ func (s *Server) routes() {
 	// Project context is the discovery contract used by Canvas before a run.
 	s.mux.HandleFunc("/context", s.combinedMiddleware(s.handleContext))
 	s.mux.HandleFunc("/preflight", s.combinedMiddleware(s.handlePreflight))
+	s.mux.HandleFunc("/validate", s.combinedMiddleware(s.handleValidate))
 
 	// Knowledge-graph navigation API. Requests require the same authentication
 	// as other server data endpoints and can address registered namespaces only.


### PR DESCRIPTION
Adds POST /validate for clients such as Canvas to perform the same full, non-processing validation as the Comanda validate command. The endpoint advertises workflow-validate, honors project/runtime file resolution, checks actual workflow prerequisites, and never starts processing.

Verified locally: go test ./..., go vet ./..., and go build ./....

Follow-up to #277; required by comanda-canvas#54.