### PR TITLE
docs: use file-backed fan-in in multi-agent examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,25 +55,25 @@ parallel-process:
     input: STDIN
     model: claude-code
     action: "Analyze system design aspects"
-    output: $CLAUDE_RESULT
+    output: .comanda/claude-analysis.md
 
   gemini-analysis:
     input: STDIN
     model: gemini-cli
     action: "Analyze patterns and best practices"
-    output: $GEMINI_RESULT
+    output: .comanda/gemini-analysis.md
 
   codex-analysis:
     input: STDIN
     model: openai-codex
     action: "Analyze implementation structure"
-    output: $CODEX_RESULT
+    output: .comanda/codex-analysis.md
 
 synthesize:
-  input: |
-    Claude: $CLAUDE_RESULT
-    Gemini: $GEMINI_RESULT
-    Codex: $CODEX_RESULT
+  input:
+    - .comanda/claude-analysis.md
+    - .comanda/gemini-analysis.md
+    - .comanda/codex-analysis.md
   model: claude-code
   action: "Synthesize into unified recommendation"
   output: STDOUT

--- a/examples/multi-agent/README.md
+++ b/examples/multi-agent/README.md
@@ -167,27 +167,27 @@ parallel-process:
     input: STDIN
     model: claude-code
     action: "Your prompt here"
-    output: $AGENT_ONE_RESULT
+    output: .comanda/agent-one-result.md
 
   agent-two:
     input: STDIN
     model: gemini-cli
     action: "Your prompt here"
-    output: $AGENT_TWO_RESULT
+    output: .comanda/agent-two-result.md
 
   agent-three:
     input: STDIN
     model: openai-codex
     action: "Your prompt here"
-    output: $AGENT_THREE_RESULT
+    output: .comanda/agent-three-result.md
 
 combine-results:
-  input: |
-    Agent 1: $AGENT_ONE_RESULT
-    Agent 2: $AGENT_TWO_RESULT
-    Agent 3: $AGENT_THREE_RESULT
+  input:
+    - .comanda/agent-one-result.md
+    - .comanda/agent-two-result.md
+    - .comanda/agent-three-result.md
   model: claude-code
-  action: "Synthesize the above into a final answer"
+  action: "Synthesize the three analyses into a final answer"
   output: STDOUT
 ```
 


### PR DESCRIPTION
Fixes #241.

Updates the two multi-agent documentation snippets so each parallel branch writes to a unique `.comanda/` file and the synthesis step reads those files directly.

Validation:
- Extracted each changed YAML fence and ran `CGO_ENABLED=0 go run . chart <temp-file> --format mermaid` (2/2 passed)
- `CGO_ENABLED=0 go test ./examples`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 go build ./...`

`CGO_ENABLED=0 go test ./...` still has unrelated Windows-only path/shell failures and a `utils/server` timeout.