### PR TITLE
feat(index): support local parser plugins

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -28,6 +28,7 @@ var (
 	indexGraph          bool
 	indexMaxFiles       int
 	indexMaxFilesPerDir int
+	indexParserPlugins  []string
 
 	// Update flags
 	updateFull bool
@@ -180,6 +181,7 @@ func init() {
 	captureCmd.Flags().BoolVar(&indexGraph, "graph", false, "Also build a knowledge graph into semantic memory (namespace = index name)")
 	captureCmd.Flags().IntVar(&indexMaxFiles, "max-files", codebaseindex.DefaultMaxFiles, "Max source files included in the index (0 = unlimited)")
 	captureCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
+	captureCmd.Flags().StringSliceVar(&indexParserPlugins, "parser-plugin", nil, "Local YAML parser-plugin manifest (repeatable)")
 
 	// Update flags
 	updateCmd.Flags().BoolVar(&updateFull, "full", false, "Force full regeneration")
@@ -188,6 +190,7 @@ func init() {
 	updateCmd.Flags().BoolVar(&indexGraph, "graph", false, "Also rebuild the knowledge graph in semantic memory")
 	updateCmd.Flags().IntVar(&indexMaxFiles, "max-files", codebaseindex.DefaultMaxFiles, "Max source files included in the index (0 = unlimited)")
 	updateCmd.Flags().IntVar(&indexMaxFilesPerDir, "max-files-per-dir", codebaseindex.DefaultMaxFilesPerDir, "Max files listed per directory in the layout tree (0 = unlimited)")
+	updateCmd.Flags().StringSliceVar(&indexParserPlugins, "parser-plugin", nil, "Local YAML parser-plugin manifest (repeatable; replaces saved manifests)")
 
 	// Diff flags
 	diffCmd.Flags().StringVar(&diffSince, "since", "", "Show changes since date (YYYY-MM-DD)")
@@ -235,6 +238,9 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	cfg.Verbose = verbose
 	cfg.MaxFiles = indexMaxFiles
 	cfg.MaxFilesPerDir = indexMaxFilesPerDir
+	if err := configureParserPlugins(cfg, indexParserPlugins); err != nil {
+		return err
+	}
 
 	// Set format
 	switch indexFormat {
@@ -376,20 +382,46 @@ func registerIndex(name, repoPath string, result *codebaseindex.Result, cfg *cod
 
 	// Create/update entry
 	envCfg.Indexes[name] = &config.IndexEntry{
-		Path:        repoPath,
-		IndexPath:   result.OutputPath,
-		LastIndexed: time.Now().Format(time.RFC3339),
-		ContentHash: result.ContentHash,
-		Format:      string(result.Format),
-		FileCount:   result.FileCount,
-		SizeBytes:   sizeBytes,
-		VarPrefix:   cfg.RepoVarSlug,
-		Encrypted:   cfg.Encrypt,
-		Languages:   strings.Join(result.Languages, ", "),
+		Path:                  repoPath,
+		IndexPath:             result.OutputPath,
+		LastIndexed:           time.Now().Format(time.RFC3339),
+		ContentHash:           result.ContentHash,
+		Format:                string(result.Format),
+		FileCount:             result.FileCount,
+		SizeBytes:             sizeBytes,
+		VarPrefix:             cfg.RepoVarSlug,
+		Encrypted:             cfg.Encrypt,
+		Languages:             strings.Join(result.Languages, ", "),
+		ParserPluginManifests: append([]string(nil), cfg.ParserPluginPaths...),
 	}
 
 	// Write config back
 	return config.SaveEnvConfig(configPath, envCfg)
+}
+
+func configureParserPlugins(cfg *codebaseindex.Config, paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	expanded := make([]string, 0, len(paths))
+	for _, path := range paths {
+		value, err := fileutil.ExpandPath(path)
+		if err != nil {
+			return fmt.Errorf("failed to expand parser plugin manifest %q: %w", path, err)
+		}
+		absolute, err := filepath.Abs(value)
+		if err != nil {
+			return fmt.Errorf("failed to resolve parser plugin manifest %q: %w", path, err)
+		}
+		expanded = append(expanded, absolute)
+	}
+	plugins, err := codebaseindex.LoadParserPluginManifests(expanded)
+	if err != nil {
+		return err
+	}
+	cfg.ParserPlugins = plugins
+	cfg.ParserPluginPaths = expanded
+	return nil
 }
 
 func buildIndexEnhancer(requestedModel string) (string, func(string) (string, error), error) {
@@ -454,6 +486,13 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	cfg.Verbose = verbose
 	cfg.MaxFiles = indexMaxFiles
 	cfg.MaxFilesPerDir = indexMaxFilesPerDir
+	pluginPaths := indexParserPlugins
+	if len(pluginPaths) == 0 {
+		pluginPaths = entry.ParserPluginManifests
+	}
+	if err := configureParserPlugins(cfg, pluginPaths); err != nil {
+		return err
+	}
 
 	// Set format from entry
 	switch entry.Format {

--- a/examples/codebase-index/README.md
+++ b/examples/codebase-index/README.md
@@ -92,6 +92,12 @@ index_codebase:
           - testdata
         priority_files:
           - cmd/**/*.go
+    # Optional local parser executables for project-specific formats.
+    # Keep this workflow and parser source in your private project if needed.
+    parser_plugins:
+      - name: private-template
+        command: /absolute/path/to/private-template-parser
+        extensions: [.templatex]
     max_output_kb: 100         # Limit output size
     max_files: 10000            # Source files to index (0 = unlimited)
 ```
@@ -153,6 +159,70 @@ Per-language configuration overrides:
 - `ignore_globs`: File patterns to ignore (e.g., `*.generated.go`)
 - `priority_files`: Files to prioritize in scoring
 - `replace_defaults`: Replace default ignores instead of extending
+
+### `parser_plugins`
+
+`parser_plugins` adds an explicitly configured, locally executed parser for a
+project-specific source format. This is intended for private DSLs, templates,
+or generated-code formats that should never be added to Comanda itself.
+
+Each plugin has:
+
+- `name`: unique adapter name (it cannot replace a built-in adapter)
+- `command`: executable to run directly; no shell is involved
+- `args`: optional command arguments
+- `extensions`: file extensions it owns (for example, `[.templatex]`)
+- `detection_files`, `ignore_dirs`, `ignore_globs`, `entrypoint_patterns`,
+  `config_patterns`: optional scanner behavior
+- `priority`: optional score boost for matching files
+- `timeout_ms`: per-file timeout; defaults to 5000
+
+For CLI captures, keep the declaration in a local YAML file and point to it
+without committing either file:
+
+```bash
+comanda index capture ./my-project \
+  --parser-plugin ~/.config/comanda/private-template-parser.yaml
+```
+
+The manifest is saved with the local index registry so `comanda index update`
+uses it again. Pass `--parser-plugin` to `update` to replace the saved list.
+
+#### Parser protocol
+
+For each matching file, Comanda starts the configured command and writes one
+JSON request to stdin:
+
+```json
+{
+  "version": 1,
+  "root": "/absolute/path/to/project",
+  "path": "templates/page.templatex",
+  "content": "first 32KB of source",
+  "max_bytes": 32768
+}
+```
+
+The parser writes exactly one JSON response to stdout:
+
+```json
+{
+  "symbols": {
+    "package": "templates",
+    "imports": ["shared/layout"],
+    "functions": [{"name": "RenderPage", "signature": "RenderPage()"}],
+    "types": [],
+    "constants": [],
+    "variables": [],
+    "frameworks": [],
+    "risk_tags": []
+  }
+}
+```
+
+Or return `{"error":"explanation"}` for a per-file parser error. Plugin
+commands run only because you explicitly configured them; Comanda does not
+upload their code, source contents, or manifests.
 
 ### `max_output_kb`
 Maximum size of generated index in KB (default: 100).

--- a/utils/codebaseindex/extract.go
+++ b/utils/codebaseindex/extract.go
@@ -1,6 +1,7 @@
 package codebaseindex
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -28,7 +29,11 @@ func (m *Manager) extractSymbols(candidates []*FileEntry) error {
 	}
 	work := make(chan workItem)
 	completed := 0
-	results := make(chan string, len(candidates))
+	type extractionResult struct {
+		path string
+		err  error
+	}
+	results := make(chan extractionResult, len(candidates))
 	workers := minInt(runtime.GOMAXPROCS(0), len(candidates))
 	if workers < 1 {
 		workers = 1
@@ -44,27 +49,37 @@ func (m *Manager) extractSymbols(candidates []*FileEntry) error {
 				if !strings.HasPrefix(path, "/") {
 					path = m.config.Root + "/" + path
 				}
+				result := extractionResult{path: entry.Path}
 				if content, err := readFilePartial(path, maxSymbolReadSize); err == nil {
 					if adapter := adapterByLanguage[entry.Language]; adapter != nil {
 						if symbols, err := adapter.ExtractSymbols(entry.Path, content); err == nil {
 							entry.Symbols = symbols
+						} else if required, ok := adapter.(interface{ FailOnExtractionError() bool }); ok && required.FailOnExtractionError() {
+							result.err = err
 						}
 					}
 				}
-				results <- entry.Path
+				results <- result
 			}
 		}()
 	}
 
 	uncached := make([]*FileEntry, 0, len(candidates))
 	for _, entry := range candidates {
-		if cached, ok := m.config.SymbolCache[entry.Path]; ok &&
-			cached.Language == entry.Language && cached.Size == entry.Size &&
-			cached.ModTime == entry.ModTime.UnixNano() {
-			entry.Symbols = cached.Symbols
-			completed++
-			m.reportExtractionProgress(entry.Path, completed, len(candidates))
-			continue
+		adapter := adapterByLanguage[entry.Language]
+		cacheable := true
+		if sensitive, ok := adapter.(interface{ DisableSymbolCache() bool }); ok {
+			cacheable = !sensitive.DisableSymbolCache()
+		}
+		if cacheable {
+			if cached, ok := m.config.SymbolCache[entry.Path]; ok &&
+				cached.Language == entry.Language && cached.Size == entry.Size &&
+				cached.ModTime == entry.ModTime.UnixNano() {
+				entry.Symbols = cached.Symbols
+				completed++
+				m.reportExtractionProgress(entry.Path, completed, len(candidates))
+				continue
+			}
 		}
 		uncached = append(uncached, entry)
 	}
@@ -76,11 +91,15 @@ func (m *Manager) extractSymbols(candidates []*FileEntry) error {
 		wg.Wait()
 		close(results)
 	}()
-	for path := range results {
+	var firstErr error
+	for result := range results {
 		completed++
-		m.reportExtractionProgress(path, completed, len(candidates))
+		m.reportExtractionProgress(result.path, completed, len(candidates))
+		if firstErr == nil && result.err != nil {
+			firstErr = fmt.Errorf("extract symbols from %s: %w", result.path, result.err)
+		}
 	}
-	return nil
+	return firstErr
 }
 
 func (m *Manager) reportExtractionProgress(path string, completed, total int) {

--- a/utils/codebaseindex/manager.go
+++ b/utils/codebaseindex/manager.go
@@ -40,6 +40,20 @@ func NewManager(config *Config, verbose bool) (*Manager, error) {
 		verbose:  verbose,
 	}
 
+	for i, plugin := range config.ParserPlugins {
+		adapter, err := NewParserPluginAdapter(plugin, config.Root)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := m.registry.Get(adapter.Name()); exists {
+			return nil, fmt.Errorf("parser plugin %q conflicts with an existing adapter", adapter.Name())
+		}
+		m.registry.Register(adapter)
+		// Keep later adapter selection consistent with normalized plugin names
+		// and extensions (for example, "templatex" becomes ".templatex").
+		config.ParserPlugins[i] = adapter.config
+	}
+
 	return m, nil
 }
 
@@ -178,9 +192,21 @@ func (m *Manager) Generate() (*Result, error) {
 func (m *Manager) detectAdapters() []Adapter {
 	// If adapters are specified via overrides, use those
 	if len(m.config.AdapterOverrides) > 0 {
+		seen := make(map[string]bool)
 		var names []string
 		for name := range m.config.AdapterOverrides {
-			names = append(names, name)
+			if !seen[name] {
+				names = append(names, name)
+				seen[name] = true
+			}
+		}
+		// Parser plugins are an explicit opt-in. Keep them active even when a
+		// workflow also narrows the built-in adapter set with overrides.
+		for _, plugin := range m.config.ParserPlugins {
+			if !seen[plugin.Name] {
+				names = append(names, plugin.Name)
+				seen[plugin.Name] = true
+			}
 		}
 		adapters := m.registry.GetByNames(names)
 		if len(adapters) > 0 {

--- a/utils/codebaseindex/parser_plugin.go
+++ b/utils/codebaseindex/parser_plugin.go
@@ -1,0 +1,197 @@
+package codebaseindex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const defaultParserPluginTimeout = 5 * time.Second
+
+// ParserPluginRequest is sent to a parser plugin on standard input. Content is
+// intentionally capped by the indexer's normal symbol-read limit.
+type ParserPluginRequest struct {
+	Version  int    `json:"version"`
+	Root     string `json:"root"`
+	Path     string `json:"path"`
+	Content  string `json:"content"`
+	MaxBytes int64  `json:"max_bytes"`
+}
+
+// ParserPluginResponse is the single JSON object a parser plugin must write to
+// standard output. Error lets a plugin return a per-file diagnostic without
+// relying on stderr parsing.
+type ParserPluginResponse struct {
+	Symbols *SymbolInfo `json:"symbols"`
+	Error   string      `json:"error,omitempty"`
+}
+
+// LoadParserPluginManifests reads plugin declarations from local YAML files.
+// The manifests contain only launch configuration; parser source code remains
+// wherever the caller keeps it and is never copied into an index.
+func LoadParserPluginManifests(paths []string) ([]ParserPluginConfig, error) {
+	plugins := make([]ParserPluginConfig, 0, len(paths))
+	for _, path := range paths {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("resolve parser plugin manifest %q: %w", path, err)
+		}
+		data, err := os.ReadFile(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("read parser plugin manifest %q: %w", absPath, err)
+		}
+
+		var plugin ParserPluginConfig
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		decoder.KnownFields(true)
+		if err := decoder.Decode(&plugin); err != nil {
+			return nil, fmt.Errorf("parse parser plugin manifest %q: %w", absPath, err)
+		}
+		if err := validateParserPluginConfig(&plugin); err != nil {
+			return nil, fmt.Errorf("invalid parser plugin manifest %q: %w", absPath, err)
+		}
+		plugins = append(plugins, plugin)
+	}
+	return plugins, nil
+}
+
+// ParserPluginAdapter adapts a local executable to the normal indexing adapter
+// interface. Commands are always invoked directly, never via a shell.
+type ParserPluginAdapter struct {
+	config ParserPluginConfig
+	root   string
+}
+
+// NewParserPluginAdapter validates and initializes one local parser plugin.
+func NewParserPluginAdapter(config ParserPluginConfig, root string) (*ParserPluginAdapter, error) {
+	if err := validateParserPluginConfig(&config); err != nil {
+		return nil, fmt.Errorf("invalid parser plugin %q: %w", config.Name, err)
+	}
+	if _, err := exec.LookPath(config.Command); err != nil {
+		return nil, fmt.Errorf("parser plugin %q command %q is not executable: %w", config.Name, config.Command, err)
+	}
+	return &ParserPluginAdapter{config: config, root: root}, nil
+}
+
+func validateParserPluginConfig(config *ParserPluginConfig) error {
+	config.Name = strings.TrimSpace(config.Name)
+	config.Command = strings.TrimSpace(config.Command)
+	if config.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if strings.ContainsAny(config.Name, `/\\`) {
+		return fmt.Errorf("name must not contain path separators")
+	}
+	if config.Command == "" {
+		return fmt.Errorf("command is required")
+	}
+	if len(config.Extensions) == 0 {
+		return fmt.Errorf("at least one extension is required")
+	}
+	for i, extension := range config.Extensions {
+		extension = strings.TrimSpace(extension)
+		if extension == "" {
+			return fmt.Errorf("extensions must not contain empty values")
+		}
+		if !strings.HasPrefix(extension, ".") {
+			extension = "." + extension
+		}
+		config.Extensions[i] = strings.ToLower(extension)
+	}
+	if config.TimeoutMS < 0 {
+		return fmt.Errorf("timeout_ms must not be negative")
+	}
+	return nil
+}
+
+func (a *ParserPluginAdapter) Name() string { return a.config.Name }
+func (a *ParserPluginAdapter) DetectionFiles() []string {
+	return append([]string(nil), a.config.DetectionFiles...)
+}
+func (a *ParserPluginAdapter) FileExtensions() []string {
+	return append([]string(nil), a.config.Extensions...)
+}
+func (a *ParserPluginAdapter) IgnoreDirs() []string {
+	return append([]string(nil), a.config.IgnoreDirs...)
+}
+func (a *ParserPluginAdapter) IgnoreGlobs() []string {
+	return append([]string(nil), a.config.IgnoreGlobs...)
+}
+func (a *ParserPluginAdapter) EntrypointPatterns() []string {
+	return append([]string(nil), a.config.EntrypointPatterns...)
+}
+func (a *ParserPluginAdapter) ConfigPatterns() []string {
+	return append([]string(nil), a.config.ConfigPatterns...)
+}
+func (a *ParserPluginAdapter) DisableSymbolCache() bool { return true }
+func (a *ParserPluginAdapter) FailOnExtractionError() bool {
+	return true
+}
+
+func (a *ParserPluginAdapter) ScoreFile(_ string, _ int, isEntrypoint, isConfig bool) int {
+	score := a.config.Priority
+	if isEntrypoint {
+		score += 40
+	}
+	if isConfig {
+		score += 30
+	}
+	return score
+}
+
+// ExtractSymbols asks the plugin to extract a SymbolInfo value for one file.
+func (a *ParserPluginAdapter) ExtractSymbols(path string, content []byte) (*SymbolInfo, error) {
+	request, err := json.Marshal(ParserPluginRequest{
+		Version:  1,
+		Root:     a.root,
+		Path:     path,
+		Content:  string(content),
+		MaxBytes: maxSymbolReadSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+
+	timeout := defaultParserPluginTimeout
+	if a.config.TimeoutMS > 0 {
+		timeout = time.Duration(a.config.TimeoutMS) * time.Millisecond
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, a.config.Command, a.config.Args...)
+	cmd.Stdin = bytes.NewReader(request)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("parser plugin %q timed out after %s", a.Name(), timeout)
+		}
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return nil, fmt.Errorf("parser plugin %q failed: %w: %s", a.Name(), err, message)
+		}
+		return nil, fmt.Errorf("parser plugin %q failed: %w", a.Name(), err)
+	}
+
+	var response ParserPluginResponse
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		return nil, fmt.Errorf("parser plugin %q returned invalid JSON: %w", a.Name(), err)
+	}
+	if response.Error != "" {
+		return nil, fmt.Errorf("parser plugin %q: %s", a.Name(), response.Error)
+	}
+	if response.Symbols == nil {
+		return nil, fmt.Errorf("parser plugin %q response is missing symbols", a.Name())
+	}
+	return response.Symbols, nil
+}

--- a/utils/codebaseindex/parser_plugin_test.go
+++ b/utils/codebaseindex/parser_plugin_test.go
@@ -1,0 +1,93 @@
+package codebaseindex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestParserPluginHelper is executed in a child test process by
+// TestParserPluginIndexesCustomExtension. It models a private executable
+// parser without putting one in the repository.
+func TestParserPluginHelper(t *testing.T) {
+	if os.Getenv("COMANDA_TEST_PARSER_PLUGIN") != "1" {
+		return
+	}
+	var request ParserPluginRequest
+	if err := json.NewDecoder(os.Stdin).Decode(&request); err != nil {
+		os.Exit(2)
+	}
+	if request.Version != 1 || request.Path == "" {
+		os.Exit(3)
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(ParserPluginResponse{Symbols: &SymbolInfo{
+		Package: "private-context",
+		Functions: []FunctionInfo{{
+			Name:      "CustomDirective",
+			Signature: "directive CustomDirective()",
+		}},
+	}})
+	os.Exit(0)
+}
+
+func TestParserPluginIndexesCustomExtension(t *testing.T) {
+	t.Setenv("COMANDA_TEST_PARSER_PLUGIN", "1")
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "sample.ctx"), []byte("directive custom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Root = root
+	cfg.ParserPlugins = []ParserPluginConfig{{
+		Name:       "private-context",
+		Command:    os.Args[0],
+		Args:       []string{"-test.run=^TestParserPluginHelper$", "--"},
+		Extensions: []string{"ctx"},
+	}}
+	manager, err := NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scan, languages, err := manager.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(languages) != 1 || languages[0] != "private-context" {
+		t.Fatalf("languages = %v, want private-context", languages)
+	}
+	if len(scan.Candidates) != 1 || scan.Candidates[0].Symbols == nil {
+		t.Fatalf("candidates = %#v, want indexed plugin file", scan.Candidates)
+	}
+	if got := scan.Candidates[0].Symbols.Functions[0].Name; got != "CustomDirective" {
+		t.Fatalf("plugin function = %q, want CustomDirective", got)
+	}
+}
+
+func TestLoadParserPluginManifest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "private-parser.yaml")
+	manifest := []byte("name: private-template\ncommand: echo\nextensions: [templatex]\ntimeout_ms: 250\n")
+	if err := os.WriteFile(path, manifest, 0600); err != nil {
+		t.Fatal(err)
+	}
+	plugins, err := LoadParserPluginManifests([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plugins) != 1 || plugins[0].Extensions[0] != ".templatex" || plugins[0].TimeoutMS != 250 {
+		t.Fatalf("plugins = %#v", plugins)
+	}
+}
+
+func TestParserPluginRejectsBuiltinName(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ParserPlugins = []ParserPluginConfig{{
+		Name:       "go",
+		Command:    os.Args[0],
+		Extensions: []string{".privatego"},
+	}}
+	if _, err := NewManager(cfg, false); err == nil {
+		t.Fatal("expected built-in adapter conflict")
+	}
+}

--- a/utils/codebaseindex/types.go
+++ b/utils/codebaseindex/types.go
@@ -67,6 +67,11 @@ type Config struct {
 	// Adapter overrides per language
 	AdapterOverrides map[string]*AdapterOverride
 
+	// ParserPlugins adds local executable parsers for project-specific source
+	// formats. Plugins are opt-in and run only on the machine indexing the repo.
+	ParserPlugins     []ParserPluginConfig
+	ParserPluginPaths []string
+
 	// Processing options
 	MaxOutputKB   int
 	HashAlgorithm HashAlgorithm
@@ -135,6 +140,24 @@ type AdapterOverride struct {
 	IgnoreGlobs     []string
 	PriorityFiles   []string
 	ReplaceDefaults bool
+}
+
+// ParserPluginConfig declares a locally installed parser plugin. The command is
+// executed directly (never through a shell) once per matching source file.
+// It receives a JSON request on stdin and must write one JSON response on
+// stdout; see docs for the protocol.
+type ParserPluginConfig struct {
+	Name               string   `yaml:"name" json:"name"`
+	Command            string   `yaml:"command" json:"command"`
+	Args               []string `yaml:"args,omitempty" json:"args,omitempty"`
+	Extensions         []string `yaml:"extensions" json:"extensions"`
+	DetectionFiles     []string `yaml:"detection_files,omitempty" json:"detection_files,omitempty"`
+	IgnoreDirs         []string `yaml:"ignore_dirs,omitempty" json:"ignore_dirs,omitempty"`
+	IgnoreGlobs        []string `yaml:"ignore_globs,omitempty" json:"ignore_globs,omitempty"`
+	EntrypointPatterns []string `yaml:"entrypoint_patterns,omitempty" json:"entrypoint_patterns,omitempty"`
+	ConfigPatterns     []string `yaml:"config_patterns,omitempty" json:"config_patterns,omitempty"`
+	Priority           int      `yaml:"priority,omitempty" json:"priority,omitempty"`
+	TimeoutMS          int      `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
 }
 
 // Result represents the output of index generation

--- a/utils/config/env.go
+++ b/utils/config/env.go
@@ -83,6 +83,10 @@ type IndexEntry struct {
 	VarPrefix   string `yaml:"var_prefix"`          // Variable prefix for workflows
 	Encrypted   bool   `yaml:"encrypted,omitempty"` // Whether index is encrypted
 	Languages   string `yaml:"languages,omitempty"` // Detected languages
+	// ParserPluginManifests are local paths used when the index was captured.
+	// They contain launch configuration only; private parser source stays out of
+	// Comanda's registry and repository.
+	ParserPluginManifests []string `yaml:"parser_plugin_manifests,omitempty"`
 }
 
 // EnvConfig represents the complete environment configuration

--- a/utils/processor/codebase_index_handler.go
+++ b/utils/processor/codebase_index_handler.go
@@ -296,6 +296,10 @@ func (p *Processor) buildCodebaseIndexConfigWithError(stepConfig StepConfig) (*c
 			}
 		}
 
+		if len(ci.ParserPlugins) > 0 {
+			config.ParserPlugins = append([]codebaseindex.ParserPluginConfig(nil), ci.ParserPlugins...)
+		}
+
 		// Convert qmd integration config
 		if ci.Qmd != nil {
 			config.Qmd = &codebaseindex.QmdConfig{

--- a/utils/processor/dsl_test.go
+++ b/utils/processor/dsl_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/models"
 	"gopkg.in/yaml.v3"
@@ -467,6 +468,36 @@ index:
 	maxFiles := config.Steps[0].Config.CodebaseIndex.MaxFiles
 	if maxFiles == nil || *maxFiles != 2500 {
 		t.Fatalf("max_files = %v, want 2500", maxFiles)
+	}
+}
+
+func TestCodebaseIndexParserPluginsYAML(t *testing.T) {
+	var config DSLConfig
+	err := yaml.Unmarshal([]byte(`
+index:
+  step_type: codebase-index
+  codebase_index:
+    root: .
+    parser_plugins:
+      - name: private-template
+        command: /opt/private/template-parser
+        extensions: [.templatex]
+        timeout_ms: 1500
+`), &config)
+	if err != nil {
+		t.Fatalf("unmarshal workflow: %v", err)
+	}
+	plugin := config.Steps[0].Config.CodebaseIndex.ParserPlugins[0]
+	if plugin.Name != "private-template" || plugin.Command != "/opt/private/template-parser" || plugin.TimeoutMS != 1500 {
+		t.Fatalf("plugin = %#v", plugin)
+	}
+
+	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), createTestServerConfig(), false, "")
+	indexConfig := processor.buildCodebaseIndexConfig(StepConfig{CodebaseIndex: &CodebaseIndexConfig{
+		ParserPlugins: []codebaseindex.ParserPluginConfig{plugin},
+	}})
+	if len(indexConfig.ParserPlugins) != 1 || indexConfig.ParserPlugins[0].Name != "private-template" {
+		t.Fatalf("index parser plugins = %#v", indexConfig.ParserPlugins)
 	}
 }
 

--- a/utils/processor/types.go
+++ b/utils/processor/types.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
 	"gopkg.in/yaml.v3"
 )
 
@@ -249,15 +250,16 @@ type PerformanceMetrics struct {
 
 // CodebaseIndexConfig represents the configuration for codebase-index step
 type CodebaseIndexConfig struct {
-	Root         string                      `yaml:"root"`                    // Repository path (defaults to current directory)
-	Output       *CodebaseIndexOutputConfig  `yaml:"output,omitempty"`        // Output configuration
-	Expose       *CodebaseIndexExposeConfig  `yaml:"expose,omitempty"`        // Variable/memory exposure configuration
-	Adapters     map[string]*AdapterOverride `yaml:"adapters,omitempty"`      // Per-adapter overrides
-	MaxOutputKB  int                         `yaml:"max_output_kb,omitempty"` // Maximum output size in KB
-	MaxFiles     *int                        `yaml:"max_files,omitempty"`     // Maximum source files to include (0 = unlimited)
-	Enhance      bool                        `yaml:"enhance,omitempty"`       // Run second-pass AI macro analysis
-	EnhanceModel string                      `yaml:"enhance_model,omitempty"` // Model for enhancement (default_generation_model if empty)
-	Qmd          *QmdIntegrationConfig       `yaml:"qmd,omitempty"`           // qmd integration configuration
+	Root          string                             `yaml:"root"`                     // Repository path (defaults to current directory)
+	Output        *CodebaseIndexOutputConfig         `yaml:"output,omitempty"`         // Output configuration
+	Expose        *CodebaseIndexExposeConfig         `yaml:"expose,omitempty"`         // Variable/memory exposure configuration
+	Adapters      map[string]*AdapterOverride        `yaml:"adapters,omitempty"`       // Per-adapter overrides
+	ParserPlugins []codebaseindex.ParserPluginConfig `yaml:"parser_plugins,omitempty"` // Local parser plugins for project-specific source formats
+	MaxOutputKB   int                                `yaml:"max_output_kb,omitempty"`  // Maximum output size in KB
+	MaxFiles      *int                               `yaml:"max_files,omitempty"`      // Maximum source files to include (0 = unlimited)
+	Enhance       bool                               `yaml:"enhance,omitempty"`        // Run second-pass AI macro analysis
+	EnhanceModel  string                             `yaml:"enhance_model,omitempty"`  // Model for enhancement (default_generation_model if empty)
+	Qmd           *QmdIntegrationConfig              `yaml:"qmd,omitempty"`            // qmd integration configuration
 
 	// Registry integration
 	Use       interface{} `yaml:"use,omitempty"`       // Load from registry: string or []string


### PR DESCRIPTION
## Summary
- add explicitly configured local parser executables for project-specific code-context formats
- support manifests for CLI capture/update and inline workflow configuration
- preserve local manifest paths in the index registry and document the JSON parser protocol

## Validation
- Full Go test suite and vet pass on latest main

## Worked on by
- Kris Hansen