### PR TITLE
Improve shared index structure for knowledge graphs

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -285,6 +285,25 @@ func buildKnowledgeGraph(indexName, repoPath string, enhance bool, enhanceModel 
 	// symbols when size and mtime prove a candidate has not changed.
 	cfg.SkipFileHash = true
 	cfg.SymbolCache = codebaseindex.LoadSymbolCache(repoPath, indexName)
+	pluginPaths := indexParserPlugins
+	if envConfig != nil {
+		if entry := envConfig.Indexes[indexName]; entry != nil {
+			if len(pluginPaths) == 0 {
+				pluginPaths = entry.ParserPluginManifests
+			}
+			if cfg.SymbolCache == nil {
+				cfg.SymbolCache = make(map[string]codebaseindex.SymbolCacheEntry)
+			}
+			for path, symbols := range codebaseindex.LoadIndexSymbolCache(entry.IndexPath, repoPath) {
+				if cached, exists := cfg.SymbolCache[path]; !exists || symbols.ModTime > cached.ModTime {
+					cfg.SymbolCache[path] = symbols
+				}
+			}
+		}
+	}
+	if err := configureParserPlugins(cfg, pluginPaths); err != nil {
+		return err
+	}
 	progress := newGraphBuildProgress(indexName)
 	defer progress.Stop()
 	cfg.Progress = progress.UpdateIndex
@@ -302,11 +321,11 @@ func buildKnowledgeGraph(indexName, repoPath string, enhance bool, enhanceModel 
 	if err != nil {
 		return fmt.Errorf("graph scan failed: %w", err)
 	}
-	if err := codebaseindex.SaveSymbolCache(repoPath, indexName, scan.Candidates); err != nil && verbose {
+	if err := codebaseindex.SaveSymbolCache(repoPath, indexName, scan.GraphFiles); err != nil && verbose {
 		log.Printf("Warning: could not save graph symbol cache: %v\n", err)
 	}
 
-	progress.Update("Building graph relationships", fmt.Sprintf("%d indexed files", len(scan.Candidates)), 0, 0)
+	progress.Update("Building graph relationships", fmt.Sprintf("%d indexed files", len(scan.GraphFiles)), 0, 0)
 	graph := knowledgegraph.Build(scan, indexName)
 
 	if enhance {

--- a/cmd/graph_test.go
+++ b/cmd/graph_test.go
@@ -1,15 +1,88 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/semanticmemory"
 )
+
+func TestIndexUpdateRefreshesExistingGraphWithoutSourceChanges(t *testing.T) {
+	root := t.TempDir()
+	for name, content := range map[string]string{"go.mod": "module example.org/project\ngo 1.25\n", "main.go": "package main\ntype Store struct {}\nfunc main() {}\n"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := codebaseindex.DefaultConfig()
+	cfg.Root = root
+	m, err := codebaseindex.NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := m.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousConfig, previousGraph, previousFull := envConfig, indexGraph, updateFull
+	previousEnhance, previousPlugins, previousDB := indexEnhance, indexParserPlugins, graphDBPath
+	t.Cleanup(func() {
+		envConfig, indexGraph, updateFull = previousConfig, previousGraph, previousFull
+		indexEnhance, indexParserPlugins, graphDBPath = previousEnhance, previousPlugins, previousDB
+	})
+	indexGraph, updateFull, indexEnhance = false, false, false
+	indexParserPlugins, graphDBPath = nil, ""
+	envConfig = &config.EnvConfig{Indexes: map[string]*config.IndexEntry{"project": {Path: root, IndexPath: result.OutputPath, Format: "structured"}}}
+	if refresh, err := shouldRefreshIndexGraph("project", root, false); err != nil || refresh {
+		t.Fatal("must not create a graph implicitly")
+	}
+	dbPath := semanticmemory.DefaultPath(root, "project")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refresh, err := shouldRefreshIndexGraph("project", root, false); err != nil || refresh {
+		t.Fatal("ordinary memory database should not opt into graphs")
+	}
+	if _, err := store.UpsertGraphNode(context.Background(), semanticmemory.GraphNode{ID: "project|file:deleted.go", Namespace: "project", Name: "deleted.go", Kind: "file"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if refresh, err := shouldRefreshIndexGraph("project", root, true); err != nil || refresh {
+		t.Fatal("encrypted index would create a plaintext graph")
+	}
+	if err := runUpdate(updateCmd, []string{"project"}); err != nil {
+		t.Fatal(err)
+	}
+	querier, closeStore, err := openGraphQuerierFor("project", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore()
+	if _, err := querier.Resolve(context.Background(), "Store"); err != nil {
+		t.Fatalf("unchanged update did not refresh graph: %v", err)
+	}
+	exported, err := querier.Export(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, node := range exported.Nodes {
+		if node.ID == "project|file:deleted.go" {
+			t.Fatal("graph retained a stale file")
+		}
+	}
+}
 
 func TestOpenGraphQuerierMissingGraphGuidesBuildWithoutCreatingMemoryDirectory(t *testing.T) {
 	root := t.TempDir()

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/kris-hansen/comanda/utils/config"
 	"github.com/kris-hansen/comanda/utils/fileutil"
 	"github.com/kris-hansen/comanda/utils/models"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
 	"github.com/spf13/cobra"
 )
 
@@ -340,7 +342,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	}
 
 	// Optionally build the knowledge graph into semantic memory
-	if indexGraph {
+	if indexGraph && !cfg.Encrypt {
 		if err := buildKnowledgeGraph(name, absPath, indexEnhance, indexEnhanceModel); err != nil {
 			log.Printf("Warning: knowledge graph build failed: %v\n", err)
 		}
@@ -526,6 +528,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	var result *codebaseindex.Result
+	refreshGraph, err := shouldRefreshIndexGraph(name, entry.Path, entry.Encrypted)
+	if err != nil {
+		return err
+	}
 
 	if updateFull {
 		// Force full regeneration
@@ -543,6 +549,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		}
 		if !result.Updated {
 			log.Printf("\nIndex is up to date (no changes detected)\n")
+			if refreshGraph {
+				return buildKnowledgeGraph(name, entry.Path, indexEnhance, indexEnhanceModel)
+			}
 			return nil
 		}
 		if wasIncremental {
@@ -557,10 +566,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		log.Printf("Warning: failed to update registry: %v\n", err)
 	}
 
-	// Optionally rebuild the knowledge graph
-	if indexGraph {
+	// Keep an existing graph synchronized, including during schema upgrades.
+	if refreshGraph {
 		if err := buildKnowledgeGraph(name, entry.Path, indexEnhance, indexEnhanceModel); err != nil {
-			log.Printf("Warning: knowledge graph rebuild failed: %v\n", err)
+			return fmt.Errorf("index updated but knowledge graph rebuild failed: %w", err)
 		}
 	}
 
@@ -569,6 +578,29 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	log.Printf("  Duration: %v\n", result.Duration)
 
 	return nil
+}
+
+func shouldRefreshIndexGraph(name, root string, encrypted bool) (bool, error) {
+	if encrypted {
+		return false, nil
+	}
+	if indexGraph {
+		return true, nil
+	}
+	dbPath := semanticmemory.DefaultPath(root, name)
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect graph database: %w", err)
+	}
+	store, err := semanticmemory.Open(dbPath)
+	if err != nil {
+		return false, err
+	}
+	defer store.Close()
+	counts, err := store.GraphNodeKindCounts(context.Background(), name)
+	return len(counts) > 0, err
 }
 
 func runDiff(cmd *cobra.Command, args []string) error {

--- a/docs/design/knowledge-graph.md
+++ b/docs/design/knowledge-graph.md
@@ -38,6 +38,39 @@ comanda graph update myproject                   # rebuild from a fresh scan
 run — nodes and edges have stable IDs, so rebuilds upsert in place and stale
 nodes from deleted files are removed.
 
+Index updates automatically refresh an existing graph in the project's memory database,
+including updates with no source changes. Use `--graph` to create a graph when
+one does not exist. Graphs built with a custom `graph --db` path still require an
+explicit `graph update --db <path>`.
+
+## Shared Index Structure
+
+The indexer produces two views from one scan: bounded markdown for LLM context
+and complete structural metadata for graph construction. `--max-files` limits
+the markdown file selection; graph extraction covers every source/config file
+included by the adapters and ignore rules. Source extraction and update hashes
+read complete files, so declarations after 32 KB and changes after 1 MB are no
+longer silently missed.
+
+The existing `.meta.json` sidecar retains its original fields and adds a schema
+version, repository root, per-file language, package identity, and extracted
+symbols. Old markdown indexes remain readable. The next `index update`
+automatically regenerates legacy metadata, even with no source changes; no
+recapture or `--full` is required. Subsequent updates reuse content-validated
+symbols for unchanged files and rebuild component information. Encrypted indexes
+omit source-derived symbols from the plaintext sidecar.
+
+Go package identities use the nearest `go.mod`, including nested modules, so
+same-named packages stay distinct and external imports are not linked to a local
+package merely because their last path segment matches. Go declarations retain
+complete signatures, field types, interface methods, and documentation. Receiver
+types link to their methods across files. Root components contain their files,
+and duplicate component names are distinguished by root. Existing file, type,
+and function IDs are preserved; package IDs with resolved module paths become
+qualified on rebuild. Parser plugins configured for an index also run in graph
+builds. Other languages continue to use their existing adapters, and name-based
+type references remain marked `inferred`.
+
 The graph lives in the project's semantic memory database,
 `.comanda/memory/<index-name>.db`, in `graph_nodes` / `graph_edges` tables.
 Every node is additionally mirrored as a `graph_node` memory record, so

--- a/docs/design/knowledge-graph.md
+++ b/docs/design/knowledge-graph.md
@@ -71,6 +71,16 @@ qualified on rebuild. Parser plugins configured for an index also run in graph
 builds. Other languages continue to use their existing adapters, and name-based
 type references remain marked `inferred`.
 
+Workflow indexing on the HTTP server is confined to the selected registered
+project, or to the configured data directory when no project is selected.
+An omitted `codebase_index.root` selects that same approved root. The
+`/yaml/process` endpoint accepts the same `?project=<registered-name>` selection
+as `/process`; `runtimeDir` does not grant access to additional source trees.
+Preflight and nested workflows apply the same rules. CLI indexing continues to
+accept an explicitly chosen repository anywhere the local user can access.
+Go module reads are confined to the index root, including symlink resolution;
+an escaping module symlink fails the scan instead of reading outside the tree.
+
 The graph lives in the project's semantic memory database,
 `.comanda/memory/<index-name>.db`, in `graph_nodes` / `graph_edges` tables.
 Every node is additionally mirrored as a `graph_node` memory record, so

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/image v0.41.0
+	golang.org/x/mod v0.35.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	google.golang.org/api v0.232.0
@@ -121,7 +122,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/utils/codebaseindex/diff.go
+++ b/utils/codebaseindex/diff.go
@@ -11,20 +11,29 @@ import (
 
 // IndexMetadata stores metadata about an index for diffing
 type IndexMetadata struct {
-	GeneratedAt time.Time      `json:"generated_at"`
-	RepoName    string         `json:"repo_name"`
-	ContentHash string         `json:"content_hash"`
-	FileCount   int            `json:"file_count"`
-	Files       []FileMetadata `json:"files"`
-	Languages   []string       `json:"languages"`
+	MaxFiles       int            `json:"max_files"`
+	MaxFilesPerDir int            `json:"max_files_per_dir"`
+	Format         OutputFormat   `json:"format,omitempty"`
+	Version        int            `json:"version,omitempty"`
+	Root           string         `json:"root,omitempty"`
+	GeneratedAt    time.Time      `json:"generated_at"`
+	RepoName       string         `json:"repo_name"`
+	ContentHash    string         `json:"content_hash"`
+	FileCount      int            `json:"file_count"`
+	Files          []FileMetadata `json:"files"`
+	Languages      []string       `json:"languages"`
 }
 
 // FileMetadata stores per-file metadata for diffing
 type FileMetadata struct {
-	Path    string `json:"path"`
-	Hash    string `json:"hash"`
-	Size    int64  `json:"size"`
-	ModTime int64  `json:"mod_time"` // Unix timestamp
+	PackagePath string      `json:"package_path,omitempty"`
+	ModTimeNano int64       `json:"mod_time_nano,omitempty"`
+	Language    string      `json:"language,omitempty"`
+	Symbols     *SymbolInfo `json:"symbols,omitempty"`
+	Path        string      `json:"path"`
+	Hash        string      `json:"hash"`
+	Size        int64       `json:"size"`
+	ModTime     int64       `json:"mod_time"` // Unix timestamp
 }
 
 // DiffResult contains the results of comparing current state to stored index
@@ -62,7 +71,7 @@ func (m *Manager) Diff(storedIndexPath string) (*DiffResult, error) {
 
 	// Build map of current files
 	currentFiles := make(map[string]*FileEntry)
-	for _, f := range scanResult.Candidates {
+	for _, f := range scanResult.Files {
 		currentFiles[f.Path] = f
 	}
 
@@ -104,20 +113,32 @@ func (m *Manager) Diff(storedIndexPath string) (*DiffResult, error) {
 // SaveMetadata saves index metadata for future diffing
 func (m *Manager) SaveMetadata(result *Result, candidates []*FileEntry) error {
 	meta := IndexMetadata{
-		GeneratedAt: result.GeneratedAt,
-		RepoName:    result.RepoName,
-		ContentHash: result.ContentHash,
-		FileCount:   result.FileCount,
-		Languages:   result.Languages,
-		Files:       make([]FileMetadata, len(candidates)),
+		MaxFiles:       m.config.MaxFiles,
+		MaxFilesPerDir: m.config.MaxFilesPerDir,
+		Format:         m.config.OutputFormat,
+		Version:        symbolCacheVersion,
+		Root:           m.config.Root,
+		GeneratedAt:    result.GeneratedAt,
+		RepoName:       result.RepoName,
+		ContentHash:    result.ContentHash,
+		FileCount:      result.FileCount,
+		Languages:      result.Languages,
+		Files:          make([]FileMetadata, len(candidates)),
 	}
 
 	for i, f := range candidates {
 		meta.Files[i] = FileMetadata{
-			Path:    f.Path,
-			Hash:    f.Hash,
-			Size:    f.Size,
-			ModTime: f.ModTime.Unix(),
+			ModTimeNano: f.ModTime.UnixNano(),
+			Language:    f.Language,
+			Path:        f.Path,
+			Hash:        f.Hash,
+			Size:        f.Size,
+			ModTime:     f.ModTime.Unix(),
+		}
+		// Encrypted indexes must not expose source-derived symbols in plaintext.
+		if !m.config.Encrypt {
+			meta.Files[i].PackagePath = f.PackagePath
+			meta.Files[i].Symbols = f.Symbols
 		}
 	}
 
@@ -128,6 +149,22 @@ func (m *Manager) SaveMetadata(result *Result, candidates []*FileEntry) error {
 	}
 
 	return os.WriteFile(metaPath, data, 0644)
+}
+
+// LoadIndexSymbolCache reuses the structured part of an index without requiring
+// callers to understand its markdown format. Legacy indexes are cache misses.
+func LoadIndexSymbolCache(indexPath, root string) map[string]SymbolCacheEntry {
+	meta, err := loadMetadata(indexPath + ".meta.json")
+	if err != nil || meta.Version != symbolCacheVersion || meta.Root != root {
+		return nil
+	}
+	cache := make(map[string]SymbolCacheEntry, len(meta.Files))
+	for _, f := range meta.Files {
+		if f.Symbols != nil {
+			cache[f.Path] = SymbolCacheEntry{Language: f.Language, Hash: f.Hash, Size: f.Size, ModTime: f.ModTimeNano, Symbols: f.Symbols}
+		}
+	}
+	return cache
 }
 
 // loadMetadata loads stored metadata from a JSON file

--- a/utils/codebaseindex/extract.go
+++ b/utils/codebaseindex/extract.go
@@ -3,9 +3,9 @@ package codebaseindex
 import (
 	"fmt"
 	"go/ast"
+	"go/format"
 	"go/parser"
 	"go/token"
-	"io"
 	"os"
 	"regexp"
 	"runtime"
@@ -50,7 +50,7 @@ func (m *Manager) extractSymbols(candidates []*FileEntry) error {
 					path = m.config.Root + "/" + path
 				}
 				result := extractionResult{path: entry.Path}
-				if content, err := readFilePartial(path, maxSymbolReadSize); err == nil {
+				if content, err := os.ReadFile(path); err == nil {
 					if adapter := adapterByLanguage[entry.Language]; adapter != nil {
 						if symbols, err := adapter.ExtractSymbols(entry.Path, content); err == nil {
 							entry.Symbols = symbols
@@ -74,7 +74,9 @@ func (m *Manager) extractSymbols(candidates []*FileEntry) error {
 		if cacheable {
 			if cached, ok := m.config.SymbolCache[entry.Path]; ok &&
 				cached.Language == entry.Language && cached.Size == entry.Size &&
-				cached.ModTime == entry.ModTime.UnixNano() {
+				cached.Symbols != nil &&
+				((entry.Hash != "" && cached.Hash == entry.Hash) ||
+					(entry.Hash == "" && cached.ModTime == entry.ModTime.UnixNano())) {
 				entry.Symbols = cached.Symbols
 				completed++
 				m.reportExtractionProgress(entry.Path, completed, len(candidates))
@@ -121,6 +123,7 @@ func BuildSymbolCache(candidates []*FileEntry) map[string]SymbolCacheEntry {
 			continue
 		}
 		cache[entry.Path] = SymbolCacheEntry{
+			Hash:     entry.Hash,
 			Language: entry.Language,
 			Size:     entry.Size,
 			ModTime:  entry.ModTime.UnixNano(),
@@ -135,17 +138,6 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
-}
-
-// readFilePartial reads up to maxBytes from a file
-func readFilePartial(path string, maxBytes int64) ([]byte, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	return io.ReadAll(io.LimitReader(f, maxBytes))
 }
 
 // extractGoSymbols extracts symbols from Go source code using AST
@@ -175,17 +167,14 @@ func extractGoSymbols(path string, content []byte) (*SymbolInfo, error) {
 				Name:       d.Name.Name,
 				IsExported: ast.IsExported(d.Name.Name),
 			}
+			if d.Doc != nil {
+				fn.Comments = strings.TrimSpace(d.Doc.Text())
+			}
 
 			// Check if it's a method
 			if d.Recv != nil && len(d.Recv.List) > 0 {
 				fn.IsMethod = true
-				if t, ok := d.Recv.List[0].Type.(*ast.StarExpr); ok {
-					if ident, ok := t.X.(*ast.Ident); ok {
-						fn.Receiver = ident.Name
-					}
-				} else if ident, ok := d.Recv.List[0].Type.(*ast.Ident); ok {
-					fn.Receiver = ident.Name
-				}
+				fn.Receiver = goReceiverName(d.Recv.List[0].Type)
 			}
 
 			// Build signature
@@ -201,14 +190,23 @@ func extractGoSymbols(path string, content []byte) (*SymbolInfo, error) {
 						Name:       s.Name.Name,
 						IsExported: ast.IsExported(s.Name.Name),
 					}
+					if s.Doc != nil {
+						ti.Comments = strings.TrimSpace(s.Doc.Text())
+					} else if d.Doc != nil {
+						ti.Comments = strings.TrimSpace(d.Doc.Text())
+					}
 
 					switch t := s.Type.(type) {
 					case *ast.StructType:
 						ti.Kind = "struct"
 						if t.Fields != nil {
 							for _, field := range t.Fields.List {
+								fieldType := goNodeText(field.Type)
+								if len(field.Names) == 0 {
+									ti.Fields = append(ti.Fields, fieldType)
+								}
 								for _, name := range field.Names {
-									ti.Fields = append(ti.Fields, name.Name)
+									ti.Fields = append(ti.Fields, name.Name+" "+fieldType)
 								}
 							}
 						}
@@ -216,8 +214,11 @@ func extractGoSymbols(path string, content []byte) (*SymbolInfo, error) {
 						ti.Kind = "interface"
 						if t.Methods != nil {
 							for _, method := range t.Methods.List {
+								if len(method.Names) == 0 {
+									ti.Methods = append(ti.Methods, goNodeText(method.Type))
+								}
 								for _, name := range method.Names {
-									ti.Methods = append(ti.Methods, name.Name)
+									ti.Methods = append(ti.Methods, name.Name+strings.TrimPrefix(goNodeText(method.Type), "func"))
 								}
 							}
 						}
@@ -249,26 +250,30 @@ func extractGoSymbols(path string, content []byte) (*SymbolInfo, error) {
 
 // buildGoFuncSignature builds a function signature string
 func buildGoFuncSignature(d *ast.FuncDecl) string {
-	var sb strings.Builder
-	sb.WriteString("func ")
+	declaration := *d
+	declaration.Body = nil
+	declaration.Doc = nil
+	return goNodeText(&declaration)
+}
 
-	if d.Recv != nil && len(d.Recv.List) > 0 {
-		sb.WriteString("(")
-		if t, ok := d.Recv.List[0].Type.(*ast.StarExpr); ok {
-			if ident, ok := t.X.(*ast.Ident); ok {
-				sb.WriteString("*")
-				sb.WriteString(ident.Name)
-			}
-		} else if ident, ok := d.Recv.List[0].Type.(*ast.Ident); ok {
-			sb.WriteString(ident.Name)
-		}
-		sb.WriteString(") ")
+func goNodeText(node ast.Node) string {
+	var text strings.Builder
+	_ = format.Node(&text, token.NewFileSet(), node)
+	return text.String()
+}
+
+func goReceiverName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return goReceiverName(t.X)
+	case *ast.IndexExpr:
+		return goReceiverName(t.X)
+	case *ast.IndexListExpr:
+		return goReceiverName(t.X)
 	}
-
-	sb.WriteString(d.Name.Name)
-	sb.WriteString("()")
-
-	return sb.String()
+	return ""
 }
 
 // extractGoSymbolsRegex is a fallback when AST parsing fails

--- a/utils/codebaseindex/manager.go
+++ b/utils/codebaseindex/manager.go
@@ -108,7 +108,9 @@ func (m *Manager) Scan() (*ScanResult, []string, error) {
 	// frontend/backend/package boundaries in the generated index.
 	m.reportProgress(ProgressEvent{Phase: "Mapping repository components"})
 	m.analyzeComponents(scanResult)
-	m.resolvePackagePaths(scanResult.GraphFiles)
+	if err := m.resolvePackagePaths(scanResult.GraphFiles); err != nil {
+		return nil, nil, err
+	}
 
 	return scanResult, languages, nil
 }

--- a/utils/codebaseindex/manager.go
+++ b/utils/codebaseindex/manager.go
@@ -98,8 +98,9 @@ func (m *Manager) Scan() (*ScanResult, []string, error) {
 
 	// Step 3: Extract symbols from candidates
 	m.logf("Extracting symbols...")
-	m.reportProgress(ProgressEvent{Phase: "Extracting symbols", Total: len(scanResult.Candidates)})
-	if err := m.extractSymbols(scanResult.Candidates); err != nil {
+	m.reportProgress(ProgressEvent{Phase: "Extracting symbols", Total: len(scanResult.Files)})
+	scanResult.GraphFiles = scanResult.Files
+	if err := m.extractSymbols(scanResult.GraphFiles); err != nil {
 		return nil, nil, fmt.Errorf("symbol extraction failed: %w", err)
 	}
 
@@ -107,6 +108,7 @@ func (m *Manager) Scan() (*ScanResult, []string, error) {
 	// frontend/backend/package boundaries in the generated index.
 	m.reportProgress(ProgressEvent{Phase: "Mapping repository components"})
 	m.analyzeComponents(scanResult)
+	m.resolvePackagePaths(scanResult.GraphFiles)
 
 	return scanResult, languages, nil
 }
@@ -168,8 +170,8 @@ func (m *Manager) Generate() (*Result, error) {
 		Languages:   languages,
 		FileCount:   len(scanResult.Candidates),
 	}
-	if err := m.SaveMetadata(result, scanResult.Candidates); err != nil {
-		m.logf("Warning: failed to save metadata: %v", err)
+	if err := m.SaveMetadata(result, scanResult.GraphFiles); err != nil {
+		return nil, fmt.Errorf("failed to save index metadata: %w", err)
 	}
 
 	// Step 7: Register with qmd (if configured)
@@ -290,6 +292,12 @@ func (m *Manager) GenerateIncremental(storedIndexPath string) (*Result, bool, er
 		result, err := m.Generate()
 		return result, false, err
 	}
+	if storedMeta.Version != symbolCacheVersion || storedMeta.Root != m.config.Root {
+		m.logf("Upgrading index structure metadata")
+		result, err := m.Generate()
+		return result, false, err
+	}
+	m.config.SymbolCache = LoadIndexSymbolCache(storedIndexPath, m.config.Root)
 
 	// Detect adapters
 	m.adapters = m.detectAdapters()
@@ -310,7 +318,9 @@ func (m *Manager) GenerateIncremental(storedIndexPath string) (*Result, bool, er
 		len(diffResult.Added), len(diffResult.Modified), len(diffResult.Deleted), diffResult.Unchanged)
 
 	// If no changes, return early
-	if totalChanges == 0 {
+	if totalChanges == 0 && !m.config.EnhanceIndex && len(m.config.ParserPlugins) == 0 &&
+		storedMeta.MaxFiles == m.config.MaxFiles && storedMeta.MaxFilesPerDir == m.config.MaxFilesPerDir &&
+		storedMeta.Format == m.config.OutputFormat {
 		m.logf("No changes detected, index is up to date")
 		return &Result{
 			OutputPath:  storedIndexPath,
@@ -325,121 +335,10 @@ func (m *Manager) GenerateIncremental(storedIndexPath string) (*Result, bool, er
 		}, true, nil
 	}
 
-	// If more than 50% of files changed, do a full regeneration (more efficient)
-	changeRatio := float64(totalChanges) / float64(storedMeta.FileCount+len(diffResult.Added))
-	if changeRatio > 0.5 {
-		m.logf("More than 50%% of files changed (%.1f%%), performing full regeneration", changeRatio*100)
-		result, err := m.Generate()
-		return result, false, err
-	}
-
-	// Build set of unchanged file paths for quick lookup
-	unchangedPaths := make(map[string]bool)
-	changedPaths := make(map[string]bool)
-
-	for _, p := range diffResult.Added {
-		changedPaths[p] = true
-	}
-	for _, p := range diffResult.Modified {
-		changedPaths[p] = true
-	}
-	for _, p := range diffResult.Deleted {
-		changedPaths[p] = true
-	}
-
-	for _, f := range storedMeta.Files {
-		if !changedPaths[f.Path] {
-			unchangedPaths[f.Path] = true
-		}
-	}
-
-	m.logf("Processing %d changed files incrementally...", len(diffResult.Added)+len(diffResult.Modified))
-
-	// Scan only the changed/added files
-	changedFiles := make([]*FileEntry, 0, len(diffResult.Added)+len(diffResult.Modified))
-	for _, path := range append(diffResult.Added, diffResult.Modified...) {
-		fullPath := filepath.Join(m.config.Root, path)
-		entry := m.processFile(fullPath)
-		if entry != nil {
-			changedFiles = append(changedFiles, entry)
-		}
-	}
-
-	// Extract symbols for changed files only
-	m.logf("Extracting symbols for %d changed files...", len(changedFiles))
-	if err := m.extractSymbols(changedFiles); err != nil {
-		return nil, false, fmt.Errorf("symbol extraction failed: %w", err)
-	}
-
-	// Now we need to scan unchanged files (for synthesis) but skip symbol extraction
-	// This is the key optimization: we don't re-extract symbols for unchanged files
-	unchangedFiles := make([]*FileEntry, 0, len(unchangedPaths))
-	for path := range unchangedPaths {
-		fullPath := filepath.Join(m.config.Root, path)
-		entry := m.processFile(fullPath)
-		if entry != nil {
-			// Mark as unchanged so synthesis can use cached data if available
-			unchangedFiles = append(unchangedFiles, entry)
-		}
-	}
-
-	// Combine all candidates
-	allCandidates := append(changedFiles, unchangedFiles...)
-
-	// Build scan result for synthesis
-	scanResult := &ScanResult{
-		Candidates: allCandidates,
-		Files:      allCandidates,
-		TotalFiles: len(allCandidates),
-	}
-
-	// Rebuild directory tree
-	scanResult.DirTree = m.buildDirTree(allCandidates)
-
-	// Synthesize markdown
-	m.logf("Synthesizing index...")
-	content, err := m.synthesize(scanResult)
-	if err != nil {
-		return nil, false, fmt.Errorf("synthesis failed: %w", err)
-	}
-
-	// Compute hash
-	contentHash := m.computeHash([]byte(content))
-
-	// Write output
-	outputPath, err := m.writeOutput(content)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to write output: %w", err)
-	}
-	m.logf("Index written to: %s", outputPath)
-
-	languages := make([]string, len(m.adapters))
-	for i, a := range m.adapters {
-		languages[i] = a.Name()
-	}
-
-	result := &Result{
-		Content:     content,
-		OutputPath:  outputPath,
-		ContentHash: contentHash,
-		Updated:     true,
-		Format:      m.config.OutputFormat,
-		GeneratedAt: time.Now(),
-		RepoName:    m.config.RepoFileSlug,
-		Languages:   languages,
-		FileCount:   len(allCandidates),
-	}
-
-	// Save metadata for future diffing
-	if err := m.SaveMetadata(result, allCandidates); err != nil {
-		m.logf("Warning: failed to save metadata: %v", err)
-	}
-
-	duration := time.Since(startTime)
-	result.Duration = duration
-	m.logf("Incremental index update completed in %v", duration)
-
-	return result, true, nil
+	// Regenerate both views from the same scan, reusing content-validated symbols
+	// for unchanged files. This also refreshes components and directory structure.
+	result, err := m.Generate()
+	return result, true, err
 }
 
 // buildDirTree constructs a directory tree from file entries

--- a/utils/codebaseindex/package_paths.go
+++ b/utils/codebaseindex/package_paths.go
@@ -1,6 +1,7 @@
 package codebaseindex
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -12,29 +13,46 @@ import (
 // Resolve Go packages through their nearest module, including nested modules.
 // Other adapters retain their package declarations and get directory scoping
 // in the graph builder when a canonical import path is unavailable.
-func (m *Manager) resolvePackagePaths(files []*FileEntry) {
+func (m *Manager) resolvePackagePaths(files []*FileEntry) error {
+	root, err := os.OpenRoot(m.config.Root)
+	if err != nil {
+		return fmt.Errorf("open index root for module resolution: %w", err)
+	}
+	defer root.Close()
 	type module struct{ root, name string }
 	modules := make(map[string]module)
-	var findModule func(string) module
-	findModule = func(dir string) module {
+	var findModule func(string) (module, error)
+	findModule = func(dir string) (module, error) {
 		if found, ok := modules[dir]; ok {
-			return found
+			return found, nil
 		}
 		var found module
-		if data, err := os.ReadFile(filepath.Join(m.config.Root, filepath.FromSlash(dir), "go.mod")); err == nil {
+		modulePath := filepath.Join(filepath.FromSlash(dir), "go.mod")
+		if data, err := readModuleInRoot(root, modulePath); err == nil {
 			found = module{dir, modfile.ModulePath(data)}
+		} else if !os.IsNotExist(err) {
+			return module{}, fmt.Errorf("read module %q within index root: %w", modulePath, err)
 		} else if dir != "." {
-			found = findModule(path.Dir(dir))
+			found, err = findModule(path.Dir(dir))
+			if err != nil {
+				return module{}, err
+			}
 		}
 		modules[dir] = found
-		return found
+		return found, nil
 	}
 	for _, f := range files {
 		if f.Language != "go" || f.Symbols == nil {
 			continue
 		}
+		if !filepath.IsLocal(f.Path) {
+			return fmt.Errorf("source path %q escapes the index root", f.Path)
+		}
 		dir := path.Dir(filepath.ToSlash(f.Path))
-		mod := findModule(dir)
+		mod, err := findModule(dir)
+		if err != nil {
+			return err
+		}
 		if mod.name == "" {
 			continue
 		}
@@ -46,4 +64,28 @@ func (m *Manager) resolvePackagePaths(files []*FileEntry) {
 			}
 		}
 	}
+	return nil
+}
+
+func readModuleInRoot(root *os.Root, name string) ([]byte, error) {
+	data, err := root.ReadFile(name)
+	if err == nil || os.IsNotExist(err) {
+		return data, err
+	}
+	// os.Root rejects absolute symlinks, including safe in-tree targets. Resolve
+	// that spelling, then read its relative target through the same confined
+	// handle so a subsequent symlink swap cannot redirect the read outside it.
+	canonicalRoot, rootErr := filepath.EvalSymlinks(root.Name())
+	if rootErr != nil {
+		return nil, err
+	}
+	target, targetErr := filepath.EvalSymlinks(filepath.Join(root.Name(), name))
+	if targetErr != nil {
+		return nil, err
+	}
+	relative, relErr := filepath.Rel(canonicalRoot, target)
+	if relErr != nil || !filepath.IsLocal(relative) {
+		return nil, err
+	}
+	return root.ReadFile(relative)
 }

--- a/utils/codebaseindex/package_paths.go
+++ b/utils/codebaseindex/package_paths.go
@@ -1,0 +1,49 @@
+package codebaseindex
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+// Resolve Go packages through their nearest module, including nested modules.
+// Other adapters retain their package declarations and get directory scoping
+// in the graph builder when a canonical import path is unavailable.
+func (m *Manager) resolvePackagePaths(files []*FileEntry) {
+	type module struct{ root, name string }
+	modules := make(map[string]module)
+	var findModule func(string) module
+	findModule = func(dir string) module {
+		if found, ok := modules[dir]; ok {
+			return found
+		}
+		var found module
+		if data, err := os.ReadFile(filepath.Join(m.config.Root, filepath.FromSlash(dir), "go.mod")); err == nil {
+			found = module{dir, modfile.ModulePath(data)}
+		} else if dir != "." {
+			found = findModule(path.Dir(dir))
+		}
+		modules[dir] = found
+		return found
+	}
+	for _, f := range files {
+		if f.Language != "go" || f.Symbols == nil {
+			continue
+		}
+		dir := path.Dir(filepath.ToSlash(f.Path))
+		mod := findModule(dir)
+		if mod.name == "" {
+			continue
+		}
+		rel, err := filepath.Rel(filepath.FromSlash(mod.root), filepath.FromSlash(dir))
+		if err == nil {
+			f.PackagePath = path.Join(mod.name, filepath.ToSlash(rel))
+			if strings.HasSuffix(f.Symbols.Package, "_test") {
+				f.PackagePath += "_test"
+			}
+		}
+	}
+}

--- a/utils/codebaseindex/package_paths_test.go
+++ b/utils/codebaseindex/package_paths_test.go
@@ -1,0 +1,108 @@
+package codebaseindex
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestPackagePathsRejectEscapingModuleSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require extra privileges")
+	}
+	for _, nested := range []bool{false, true} {
+		t.Run(map[bool]string{false: "root", true: "nested"}[nested], func(t *testing.T) {
+			root, outside := t.TempDir(), t.TempDir()
+			writeStructureFixture(t, outside, "go.mod", "module private.example/secret\ngo 1.25\n")
+			dir := root
+			if nested {
+				writeStructureFixture(t, root, "go.mod", "module example.org/project\ngo 1.25\n")
+				dir = filepath.Join(root, "nested")
+			}
+			writeStructureFixture(t, dir, "main.go", "package main\nfunc main() {}\n")
+			if err := os.Symlink(filepath.Join(outside, "go.mod"), filepath.Join(dir, "go.mod")); err != nil {
+				t.Fatal(err)
+			}
+			cfg := DefaultConfig()
+			cfg.Root = root
+			m, err := NewManager(cfg, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := m.Scan(); err == nil {
+				t.Fatal("accepted go.mod symlink outside index root")
+			}
+		})
+	}
+}
+
+func TestPackagePathsAllowInternalModuleSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require extra privileges")
+	}
+	root := t.TempDir()
+	writeStructureFixture(t, root, "module.txt", "module example.org/project\ngo 1.25\n")
+	writeStructureFixture(t, root, "pkg/main.go", "package main\nfunc main() {}\n")
+	if err := os.Symlink("module.txt", filepath.Join(root, "go.mod")); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig()
+	cfg.Root = root
+	m, err := NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scan, _, err := m.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range scan.GraphFiles {
+		if f.Path == "pkg/main.go" && f.PackagePath == "example.org/project/pkg" {
+			return
+		}
+	}
+	t.Fatal("internal module symlink did not resolve")
+}
+
+func TestPackagePathsAllowAbsoluteInternalModuleSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require extra privileges")
+	}
+	root := t.TempDir()
+	writeStructureFixture(t, root, "module.txt", "module example.org/project\ngo 1.25\n")
+	writeStructureFixture(t, root, "main.go", "package main\nfunc main() {}\n")
+	if err := os.Symlink(filepath.Join(root, "module.txt"), filepath.Join(root, "go.mod")); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig()
+	cfg.Root = root
+	m, err := NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scan, _, err := m.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range scan.GraphFiles {
+		if f.Path == "main.go" && f.PackagePath == "example.org/project" {
+			return
+		}
+	}
+	t.Fatal("absolute internal module symlink did not resolve")
+}
+
+func TestPackagePathsRejectNonlocalEntries(t *testing.T) {
+	root := t.TempDir()
+	writeStructureFixture(t, root, "go.mod", "module example.org/project\ngo 1.25\n")
+	m, err := NewManager(&Config{Root: root}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"../outside/main.go", filepath.Join(root, "main.go"), ""} {
+		if err := m.resolvePackagePaths([]*FileEntry{{Path: name, Language: "go", Symbols: &SymbolInfo{Package: "main"}}}); err == nil {
+			t.Fatalf("accepted nonlocal entry %q", name)
+		}
+	}
+}

--- a/utils/codebaseindex/parser_plugin.go
+++ b/utils/codebaseindex/parser_plugin.go
@@ -154,7 +154,7 @@ func (a *ParserPluginAdapter) ExtractSymbols(path string, content []byte) (*Symb
 		Root:     a.root,
 		Path:     path,
 		Content:  string(content),
-		MaxBytes: maxSymbolReadSize,
+		MaxBytes: int64(len(content)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encode request: %w", err)

--- a/utils/codebaseindex/scan.go
+++ b/utils/codebaseindex/scan.go
@@ -21,12 +21,6 @@ const (
 	// DefaultMaxFiles is the number of source files included in an index unless
 	// callers override Config.MaxFiles. 0 or a negative value means unlimited.
 	DefaultMaxFiles = 10000
-
-	// maxHashReadSize is the maximum bytes to read for hashing (1MB)
-	maxHashReadSize = 1024 * 1024
-
-	// maxSymbolReadSize is the maximum bytes to read for symbol extraction (32KB)
-	maxSymbolReadSize = 32 * 1024
 )
 
 // scanRepository walks the repository and collects file information
@@ -237,6 +231,9 @@ func (m *Manager) processFile(path string) *FileEntry {
 func (m *Manager) selectCandidates(files []*FileEntry) []*FileEntry {
 	// Sort by score descending
 	sort.Slice(files, func(i, j int) bool {
+		if files[i].Score == files[j].Score {
+			return files[i].Path < files[j].Path
+		}
 		return files[i].Score > files[j].Score
 	})
 
@@ -421,12 +418,9 @@ func (m *Manager) computeFileHash(path string) string {
 	}
 	defer f.Close()
 
-	// Limit read size for performance
-	limitReader := io.LimitReader(f, maxHashReadSize)
-
 	if m.config.HashAlgorithm == HashSHA256 {
 		h := sha256.New()
-		if _, err := io.Copy(h, limitReader); err != nil {
+		if _, err := io.Copy(h, f); err != nil {
 			return ""
 		}
 		return hex.EncodeToString(h.Sum(nil))
@@ -434,7 +428,7 @@ func (m *Manager) computeFileHash(path string) string {
 
 	// Default: xxhash
 	h := xxhash.New()
-	if _, err := io.Copy(h, limitReader); err != nil {
+	if _, err := io.Copy(h, f); err != nil {
 		return ""
 	}
 	return hex.EncodeToString(h.Sum(nil))

--- a/utils/codebaseindex/store.go
+++ b/utils/codebaseindex/store.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -33,7 +34,10 @@ func (m *Manager) writeOutput(content string) (string, error) {
 			return "", fmt.Errorf("encryption enabled but no encryption key provided")
 		}
 
-		encPath := outputPath + ".enc"
+		encPath := outputPath
+		if !strings.HasSuffix(encPath, ".enc") {
+			encPath += ".enc"
+		}
 		if err := encryptToFile([]byte(content), m.config.EncryptionKey, encPath); err != nil {
 			return "", fmt.Errorf("failed to encrypt output: %w", err)
 		}

--- a/utils/codebaseindex/structure_test.go
+++ b/utils/codebaseindex/structure_test.go
@@ -1,0 +1,185 @@
+package codebaseindex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeStructureFixture(t *testing.T, root, name, content string) {
+	t.Helper()
+	file := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStructureMigrationAndIncrementalRetention(t *testing.T) {
+	root := t.TempDir()
+	writeStructureFixture(t, root, "go.mod", "module example.org/project\ngo 1.25\n")
+	writeStructureFixture(t, root, "main.go", "package main\nfunc main() {}\n")
+	writeStructureFixture(t, root, "store/store.go", "package store\n// Store keeps records.\ntype Store struct { Value string }\n")
+	cfg := DefaultConfig()
+	cfg.Root = root
+	cfg.MaxFiles = 1
+	m, err := NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, err := m.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := loadMetadata(initial.OutputPath + ".meta.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initial.FileCount != 1 || len(meta.Files) != 3 {
+		t.Fatalf("markdown count %d, structural count %d", initial.FileCount, len(meta.Files))
+	}
+	// Simulate metadata written by an older binary. No source file changes.
+	meta.Version = 0
+	for i := range meta.Files {
+		meta.Files[i].Symbols = nil
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(initial.OutputPath+".meta.json", data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	upgraded, incremental, err := m.GenerateIncremental(initial.OutputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !upgraded.Updated || incremental {
+		t.Fatal("legacy metadata must trigger a full upgrade")
+	}
+	cache := LoadIndexSymbolCache(initial.OutputPath, root)
+	if cache["store/store.go"].Symbols == nil {
+		t.Fatal("upgrade omitted symbols outside markdown limit")
+	}
+	writeStructureFixture(t, root, "main.go", "package main\nfunc main() {}\nfunc Run() {}\n")
+	updated, incremental, err := m.GenerateIncremental(initial.OutputPath)
+	if err != nil || !updated.Updated || !incremental {
+		t.Fatalf("update: %v, %v", updated, err)
+	}
+	cache = LoadIndexSymbolCache(initial.OutputPath, root)
+	if len(cache["store/store.go"].Symbols.Types) != 1 {
+		t.Fatal("unchanged type lost")
+	}
+	if len(cache["main.go"].Symbols.Functions) != 2 {
+		t.Fatal("changed functions not refreshed")
+	}
+	if err := os.Remove(filepath.Join(root, "store/store.go")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := m.GenerateIncremental(initial.OutputPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := LoadIndexSymbolCache(initial.OutputPath, root)["store/store.go"]; exists {
+		t.Fatal("deleted file retained")
+	}
+	cfg.MaxFiles = 0
+	unlimited, _, err := m.GenerateIncremental(initial.OutputPath)
+	if err != nil || !unlimited.Updated || unlimited.FileCount != 2 {
+		t.Fatalf("markdown limit change was not applied: %+v, %v", unlimited, err)
+	}
+}
+
+func TestCompleteGoStructureAndNestedModules(t *testing.T) {
+	root := t.TempDir()
+	writeStructureFixture(t, root, "go.mod", "module example.org/project\ngo 1.25\n")
+	writeStructureFixture(t, root, "pkg/store.go", "package store\nimport \"io\"\n// Store keeps data.\ntype Store[T any] struct { Reader io.Reader; Value T }\n"+strings.Repeat("// padding\n", 4000)+"\n// Read fetches data.\nfunc (s *Store[T]) Read(p []byte) (int, error) { return 0, nil }\n")
+	writeStructureFixture(t, root, "nested/go.mod", "module example.org/nested\ngo 1.25\n")
+	writeStructureFixture(t, root, "nested/store.go", "package store\ntype Store struct {}\n")
+	cfg := DefaultConfig()
+	cfg.Root = root
+	m, err := NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scan, _, err := m.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range scan.GraphFiles {
+		switch f.Path {
+		case "pkg/store.go":
+			if f.PackagePath != "example.org/project/pkg" {
+				t.Fatal(f.PackagePath)
+			}
+			if len(f.Symbols.Functions) != 1 {
+				t.Fatal("function after 32KB missing")
+			}
+			fn := f.Symbols.Functions[0]
+			if fn.Receiver != "Store" || !strings.Contains(fn.Signature, "(p []byte) (int, error)") || fn.Comments != "Read fetches data." {
+				t.Fatalf("incomplete method: %+v", fn)
+			}
+			if f.Symbols.Types[0].Fields[0] != "Reader io.Reader" {
+				t.Fatal(f.Symbols.Types)
+			}
+		case "nested/store.go":
+			if f.PackagePath != "example.org/nested" {
+				t.Fatal(f.PackagePath)
+			}
+		}
+	}
+}
+
+func TestEncryptedStructureUpgrade(t *testing.T) {
+	root := t.TempDir()
+	writeStructureFixture(t, root, "go.mod", "module example.org/project\ngo 1.25\n")
+	writeStructureFixture(t, root, "main.go", "package main\ntype PrivateSourceType struct {}\n")
+	cfg := DefaultConfig()
+	cfg.Root = root
+	cfg.Encrypt = true
+	cfg.EncryptionKey = "test-key"
+	m, err := NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := m.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.OutputPath = result.OutputPath
+	if err := os.Remove(result.OutputPath + ".meta.json"); err != nil {
+		t.Fatal(err)
+	}
+	updated, _, err := m.GenerateIncremental(result.OutputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.OutputPath != result.OutputPath {
+		t.Fatalf("encrypted path changed: %s", updated.OutputPath)
+	}
+	data, err := os.ReadFile(updated.OutputPath + ".meta.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "PrivateSourceType") {
+		t.Fatal("plaintext metadata leaked symbols")
+	}
+	if _, err := DecryptFromFile(updated.OutputPath, cfg.EncryptionKey); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFileHashIncludesTail(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Repeat("x", 1024*1024)
+	writeStructureFixture(t, root, "large.go", content+"a")
+	m := &Manager{config: DefaultConfig()}
+	first := m.computeFileHash(filepath.Join(root, "large.go"))
+	writeStructureFixture(t, root, "large.go", content+"b")
+	if first == m.computeFileHash(filepath.Join(root, "large.go")) {
+		t.Fatal("tail change was missed")
+	}
+}

--- a/utils/codebaseindex/symbol_cache.go
+++ b/utils/codebaseindex/symbol_cache.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 )
 
-const symbolCacheVersion = 1
+const symbolCacheVersion = 2
 
 type symbolCacheFile struct {
 	Version int                         `json:"version"`

--- a/utils/codebaseindex/types.go
+++ b/utils/codebaseindex/types.go
@@ -83,7 +83,7 @@ type Config struct {
 	SkipFileHash bool
 
 	// SymbolCache lets repeat consumers reuse symbols for unchanged files. The
-	// cache is validated against path, language, size, and modification time;
+	// cache is validated against path, language, size, and hash or modification time;
 	// missing or stale entries are extracted normally.
 	SymbolCache map[string]SymbolCacheEntry
 
@@ -95,8 +95,8 @@ type Config struct {
 	// Repository Layout tree. 0 or negative means unlimited (list every file).
 	MaxFilesPerDir int
 
-	// MaxFiles caps how many source files are selected for symbol extraction and
-	// inclusion in the index. 0 or negative means unlimited.
+	// MaxFiles caps markdown candidate selection. Structural extraction covers
+	// all scanned files for graph consumers. 0 or negative means unlimited.
 	MaxFiles int
 
 	// Optional second-pass AI enhancement. The normal high-performance scan still
@@ -115,10 +115,10 @@ type Config struct {
 }
 
 // SymbolCacheEntry is the durable, content-derived portion of a file scan.
-// It intentionally excludes hashes: callers that use the cache already have a
-// cheaper freshness key (size + modification time) and do not need to reread
-// each file just to compute one.
+// Index updates validate the content hash; graph-only scans can use size and
+// modification time when no hash is requested.
 type SymbolCacheEntry struct {
+	Hash     string      `json:"hash,omitempty"`
 	Language string      `json:"language"`
 	Size     int64       `json:"size"`
 	ModTime  int64       `json:"mod_time"`
@@ -195,6 +195,8 @@ type Result struct {
 
 // ScanResult holds the results of repository scanning
 type ScanResult struct {
+	// GraphFiles contains all scanned files, independent of markdown limits.
+	GraphFiles []*FileEntry
 	// All files found (before candidate selection)
 	Files []*FileEntry
 
@@ -237,6 +239,8 @@ type CodebaseComponent struct {
 
 // FileEntry represents a single file in the repository
 type FileEntry struct {
+	// PackagePath is a repository-resolved package identity, when available.
+	PackagePath string `json:",omitempty"`
 	// Relative path from repo root
 	Path string
 

--- a/utils/knowledgegraph/builder.go
+++ b/utils/knowledgegraph/builder.go
@@ -23,15 +23,22 @@ const minInferredNameLen = 3
 // `uses` edges between files and uniquely-named types are inferred from symbol
 // name references.
 func Build(scan *codebaseindex.ScanResult, namespace string) *Graph {
+	if scan.GraphFiles != nil {
+		copy := *scan
+		copy.Candidates = scan.GraphFiles
+		scan = &copy
+	}
 	g := NewGraph(namespace)
+	packages := packageKeys(scan.Candidates)
 
 	// Pass 1: file and package nodes, belongs_to edges.
 	for _, f := range scan.Candidates {
 		summary := fileSummary(f)
-		g.AddNode("file:"+f.Path, NodeFile, path.Base(f.Path), f.Path, symbolPackage(f), summary)
+		g.AddNode("file:"+f.Path, NodeFile, path.Base(f.Path), f.Path, packages[f.Path], summary)
 		if pkg := symbolPackage(f); pkg != "" {
-			g.AddNode("pkg:"+pkg, NodePackage, pkg, "", pkg, "")
-			g.AddEdge(NodeID(namespace, "file:"+f.Path), NodeID(namespace, "pkg:"+pkg),
+			key := packages[f.Path]
+			g.AddNode("pkg:"+key, NodePackage, pkg, path.Dir(f.Path), key, "")
+			g.AddEdge(NodeID(namespace, "file:"+f.Path), NodeID(namespace, "pkg:"+key),
 				EdgeBelongsTo, ConfidenceExtracted, "package declaration")
 		}
 	}
@@ -45,7 +52,7 @@ func Build(scan *codebaseindex.ScanResult, namespace string) *Graph {
 		for _, t := range f.Symbols.Types {
 			local := fmt.Sprintf("type:%s@%s", t.Name, f.Path)
 			summary := typeSummary(t)
-			g.AddNode(local, NodeType, t.Name, f.Path, f.Symbols.Package, summary)
+			g.AddNode(local, NodeType, t.Name, f.Path, packages[f.Path], summary)
 			g.AddEdge(fileID, NodeID(namespace, local), EdgeDefines, ConfidenceExtracted, "type declaration")
 		}
 		for _, fn := range f.Symbols.Functions {
@@ -54,18 +61,27 @@ func Build(scan *codebaseindex.ScanResult, namespace string) *Graph {
 				name = fn.Receiver + "." + fn.Name
 			}
 			local := fmt.Sprintf("func:%s@%s", name, f.Path)
-			g.AddNode(local, NodeFunction, name, f.Path, f.Symbols.Package, functionSummary(fn))
+			g.AddNode(local, NodeFunction, name, f.Path, packages[f.Path], functionSummary(fn))
 			g.AddEdge(fileID, NodeID(namespace, local), EdgeDefines, ConfidenceExtracted, "function declaration")
 		}
 	}
+	linkMethods(g, scan, namespace, packages)
 
 	// Pass 3: component contains edges.
+	componentNames := make(map[string]int)
 	for _, c := range scan.Components {
-		g.AddNode("component:"+c.Name, NodeComponent, c.Name, c.Root, "",
+		componentNames[c.Name]++
+	}
+	for _, c := range scan.Components {
+		local := "component:" + c.Name
+		if componentNames[c.Name] > 1 {
+			local += "@" + path.Clean(c.Root)
+		}
+		g.AddNode(local, NodeComponent, c.Name, c.Root, "",
 			fmt.Sprintf("%s component (%d files)", c.Kind, c.FileCount))
-		componentID := NodeID(namespace, "component:"+c.Name)
+		componentID := NodeID(namespace, local)
 		for _, f := range scan.Candidates {
-			if f.Path == c.Root || strings.HasPrefix(f.Path, strings.TrimSuffix(c.Root, "/")+"/") {
+			if path.Clean(c.Root) == "." || f.Path == c.Root || strings.HasPrefix(f.Path, strings.TrimSuffix(c.Root, "/")+"/") {
 				g.AddEdge(componentID, NodeID(namespace, "file:"+f.Path), EdgeContains, ConfidenceExtracted, "component root")
 			}
 		}
@@ -74,13 +90,18 @@ func Build(scan *codebaseindex.ScanResult, namespace string) *Graph {
 	// Pass 4: import edges. An import that resolves to a known local package
 	// links to that package node; anything else becomes an external package
 	// node so the graph keeps a record of third-party dependencies.
+	legacyImports := legacyImportPaths(scan, packages, namespace)
 	for _, f := range scan.Candidates {
 		if f.Symbols == nil {
 			continue
 		}
 		fileID := NodeID(namespace, "file:"+f.Path)
 		for _, imp := range f.Symbols.Imports {
-			target := resolveImport(g, namespace, imp)
+			imp = strings.Trim(strings.TrimSpace(imp), "\"`")
+			if imp == "" {
+				continue
+			}
+			target := resolveImport(g, namespace, imp, legacyImports)
 			g.AddEdge(fileID, target, EdgeImports, ConfidenceExtracted, "import "+imp)
 		}
 	}
@@ -93,23 +114,25 @@ func Build(scan *codebaseindex.ScanResult, namespace string) *Graph {
 
 // resolveImport maps an import string to a package node ID, creating the
 // package node when it is not defined locally.
-func resolveImport(g *Graph, namespace, imp string) string {
+func resolveImport(g *Graph, namespace, imp string, legacyImports map[string]string) string {
 	imp = strings.Trim(imp, "\"`")
 	if imp == "" {
 		return NodeID(namespace, "pkg:unknown")
 	}
-	// Local packages are keyed by their package clause name; the last path
-	// segment of an import usually matches it.
-	last := imp
-	if idx := strings.LastIndex(imp, "/"); idx >= 0 {
-		last = imp[idx+1:]
-	}
-	// Strip version suffixes like /v2 and dashed variants are kept as-is.
-	if id := NodeID(namespace, "pkg:"+last); g.Nodes[id] != nil {
-		return id
-	}
 	if id := NodeID(namespace, "pkg:"+imp); g.Nodes[id] != nil {
 		return id
+	}
+	// Legacy scans lack module paths. Resolve only a unique directory suffix,
+	// never a basename that could silently link an external package locally.
+	for suffix := imp; ; {
+		if id := legacyImports[suffix]; id != "" {
+			return id
+		}
+		index := strings.IndexByte(suffix, '/')
+		if index < 0 {
+			break
+		}
+		suffix = suffix[index+1:]
 	}
 	g.AddNode("pkg:"+imp, NodePackage, imp, "", "", "external dependency")
 	return NodeID(namespace, "pkg:"+imp)

--- a/utils/knowledgegraph/structure.go
+++ b/utils/knowledgegraph/structure.go
@@ -1,0 +1,78 @@
+package knowledgegraph
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
+)
+
+func legacyImportPaths(scan *codebaseindex.ScanResult, packages map[string]string, namespace string) map[string]string {
+	paths := make(map[string]string)
+	for _, f := range scan.Candidates {
+		if f.PackagePath != "" || symbolPackage(f) == "" || path.Dir(f.Path) == "." {
+			continue
+		}
+		dir := path.Dir(f.Path)
+		id := NodeID(namespace, "pkg:"+packages[f.Path])
+		if previous, exists := paths[dir]; exists && previous != id {
+			paths[dir] = ""
+		} else if !exists {
+			paths[dir] = id
+		}
+	}
+	return paths
+}
+
+func packageKeys(files []*codebaseindex.FileEntry) map[string]string {
+	roots := make(map[string]map[string]bool)
+	for _, f := range files {
+		pkg := symbolPackage(f)
+		if roots[pkg] == nil {
+			roots[pkg] = make(map[string]bool)
+		}
+		roots[pkg][f.Language+":"+path.Dir(f.Path)] = true
+	}
+	keys := make(map[string]string, len(files))
+	for _, f := range files {
+		key := f.PackagePath
+		if key == "" {
+			key = symbolPackage(f)
+			if len(roots[key]) > 1 {
+				key += "@" + f.Language + ":" + path.Dir(f.Path)
+			}
+		}
+		keys[f.Path] = key
+	}
+	return keys
+}
+
+// A receiver type can live in another file in the same package. Ambiguous
+// declarations are skipped instead of connecting a method to an arbitrary type.
+func linkMethods(g *Graph, scan *codebaseindex.ScanResult, namespace string, packages map[string]string) {
+	types := make(map[string][]string)
+	for _, f := range scan.Candidates {
+		if f.Symbols == nil {
+			continue
+		}
+		for _, t := range f.Symbols.Types {
+			key := packages[f.Path] + "|" + t.Name
+			types[key] = append(types[key], NodeID(namespace, fmt.Sprintf("type:%s@%s", t.Name, f.Path)))
+		}
+	}
+	for _, f := range scan.Candidates {
+		if f.Symbols == nil {
+			continue
+		}
+		for _, fn := range f.Symbols.Functions {
+			if !fn.IsMethod || fn.Receiver == "" {
+				continue
+			}
+			owners := types[packages[f.Path]+"|"+fn.Receiver]
+			if len(owners) == 1 {
+				id := NodeID(namespace, fmt.Sprintf("func:%s.%s@%s", fn.Receiver, fn.Name, f.Path))
+				g.AddEdge(owners[0], id, EdgeDefines, ConfidenceExtracted, "method receiver "+fn.Receiver)
+			}
+		}
+	}
+}

--- a/utils/knowledgegraph/structure_test.go
+++ b/utils/knowledgegraph/structure_test.go
@@ -1,0 +1,93 @@
+package knowledgegraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/codebaseindex"
+)
+
+func TestBuildCompleteStructureFromScan(t *testing.T) {
+	root := t.TempDir()
+	for name, content := range map[string]string{
+		"go.mod":             "module example.org/project\ngo 1.25\n",
+		"main.go":            "package main\nimport (\"example.org/project/a/store\"; \"example.org/third-party/store\")\nfunc main() {}\n",
+		"a/store/store.go":   "package store\ntype Store struct {}\n",
+		"a/store/methods.go": "package store\nfunc (s *Store) Open() {}\n",
+		"b/store/store.go":   "package store\ntype Store struct {}\n",
+	} {
+		file := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := codebaseindex.DefaultConfig()
+	cfg.Root = root
+	cfg.MaxFiles = 1
+	m, err := codebaseindex.NewManager(cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scan, _, err := m.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scan.Candidates) != 1 {
+		t.Fatal("markdown selection was not capped")
+	}
+	g := Build(scan, "project")
+	for _, local := range []string{"file:b/store/store.go", "pkg:example.org/project/a/store", "pkg:example.org/project/b/store", "pkg:example.org/third-party/store"} {
+		if g.Nodes[NodeID("project", local)] == nil {
+			t.Fatalf("missing %s", local)
+		}
+	}
+	for _, edge := range []struct{ source, target, kind string }{
+		{"file:main.go", "pkg:example.org/project/a/store", EdgeImports},
+		{"file:main.go", "pkg:example.org/third-party/store", EdgeImports},
+		{"type:Store@a/store/store.go", "func:Store.Open@a/store/methods.go", EdgeDefines},
+	} {
+		id := EdgeID("project", NodeID("project", edge.source), NodeID("project", edge.target), edge.kind)
+		if g.Edges[id] == nil {
+			t.Fatalf("missing edge %+v", edge)
+		}
+	}
+	contained := false
+	for _, edge := range g.Edges {
+		if edge.Kind == EdgeContains && edge.TargetID == NodeID("project", "file:b/store/store.go") {
+			contained = true
+		}
+		if g.Nodes[edge.SourceID] == nil || g.Nodes[edge.TargetID] == nil {
+			t.Fatalf("dangling edge %+v", edge)
+		}
+	}
+	if !contained {
+		t.Fatal("root component does not contain nested files")
+	}
+}
+
+func TestBuildLegacyPackageAndComponentCollisions(t *testing.T) {
+	scan := &codebaseindex.ScanResult{
+		Candidates: []*codebaseindex.FileEntry{
+			{Path: "a/store.go", Language: "go", Symbols: &codebaseindex.SymbolInfo{Package: "store"}},
+			{Path: "b/store.go", Language: "go", Symbols: &codebaseindex.SymbolInfo{Package: "store"}},
+		},
+		Components: []*codebaseindex.CodebaseComponent{{Name: "app", Root: "a"}, {Name: "app", Root: "b"}},
+	}
+	g := Build(scan, "legacy")
+	packages, components := 0, 0
+	for _, node := range g.Nodes {
+		if node.Kind == NodePackage {
+			packages++
+		}
+		if node.Kind == NodeComponent {
+			components++
+		}
+	}
+	if packages != 2 || components != 2 {
+		t.Fatalf("collisions: %d packages, %d components", packages, components)
+	}
+}

--- a/utils/processor/codebase_index_handler.go
+++ b/utils/processor/codebase_index_handler.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -190,29 +191,19 @@ func (p *Processor) buildCodebaseIndexConfig(stepConfig StepConfig) *codebaseind
 
 func (p *Processor) buildCodebaseIndexConfigWithError(stepConfig StepConfig) (*codebaseindex.Config, error) {
 	config := codebaseindex.DefaultConfig()
+	requestedRoot := ""
+	if stepConfig.CodebaseIndex != nil {
+		requestedRoot = stepConfig.CodebaseIndex.Root
+	}
+	root, err := p.resolveCodebaseIndexRoot(requestedRoot)
+	if err != nil {
+		return nil, err
+	}
+	config.Root = root
 
 	// Use step-level config if available
 	if stepConfig.CodebaseIndex != nil {
 		ci := stepConfig.CodebaseIndex
-
-		if ci.Root != "" {
-			if p.sourceRoot != "" {
-				projectRoot, err := ResolveProjectPath(p.sourceRoot, ci.Root)
-				if err != nil {
-					return nil, err
-				}
-				config.Root = projectRoot
-			} else {
-				// Expand ~ in root path
-				expandedRoot, err := fileutil.ExpandPath(ci.Root)
-				if err != nil {
-					p.debugf("Warning: failed to expand root path %s: %v", ci.Root, err)
-					config.Root = ci.Root // Fall back to unexpanded path
-				} else {
-					config.Root = expandedRoot
-				}
-			}
-		}
 
 		if ci.Output != nil {
 			if ci.Output.Path != "" {
@@ -316,6 +307,30 @@ func (p *Processor) buildCodebaseIndexConfigWithError(stepConfig StepConfig) (*c
 	config.Verbose = p.verbose
 
 	return config, nil
+}
+
+// Index roots are source locations, not runtime output paths. A request's
+// runtimeDir must never expand the set of repositories it may index.
+func (p *Processor) resolveCodebaseIndexRoot(requested string) (string, error) {
+	if requested == "" {
+		requested = "."
+	}
+	if p.sourceRoot != "" {
+		return ResolveProjectPath(p.sourceRoot, requested)
+	}
+	// Enabled controls authentication; a server with authentication disabled
+	// still has a configured data directory and needs the same confinement.
+	if p.serverConfig != nil && (p.serverConfig.Enabled || p.serverConfig.DataDir != "") {
+		if p.serverConfig.DataDir == "" {
+			return "", fmt.Errorf("codebase indexing requires a server data directory or a selected project")
+		}
+		base, err := filepath.Abs(p.serverConfig.DataDir)
+		if err != nil {
+			return "", fmt.Errorf("resolve server data directory: %w", err)
+		}
+		return ResolveProjectPath(base, requested)
+	}
+	return fileutil.ExpandPath(requested)
 }
 
 func (p *Processor) buildCodebaseIndexEnhancer(requestedModel string) (string, func(string) (string, error), error) {

--- a/utils/processor/dsl.go
+++ b/utils/processor/dsl.go
@@ -2070,6 +2070,7 @@ func (p *Processor) processProcessStep(step Step, isParallel bool, parallelID st
 	// 2. Create a new Processor for the sub-workflow
 	//    It inherits verbose settings and envConfig, but has its own DSLConfig and variables.
 	subProcessor := NewProcessor(&subDSLConfig, p.envConfig, p.serverConfig, p.verbose, p.runtimeDir)
+	subProcessor.SetSourceRoot(p.sourceRoot)
 	subProcessor.SetWorkflowFile(subWorkflowPath)
 	if p.progress != nil { // Propagate progress writer if available
 		subProcessor.SetProgressWriter(p.progress)

--- a/utils/processor/dsl_test.go
+++ b/utils/processor/dsl_test.go
@@ -314,7 +314,9 @@ func TestValidateStepConfig(t *testing.T) {
 }
 
 func TestBuildCodebaseIndexConfigEncryptionKey(t *testing.T) {
-	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), createTestServerConfig(), false, "")
+	serverConfig := createTestServerConfig()
+	serverConfig.DataDir = t.TempDir()
+	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), serverConfig, false, "")
 
 	// Test that encryption key is picked up from environment
 	t.Run("encryption key from env var", func(t *testing.T) {
@@ -386,7 +388,7 @@ func TestBuildCodebaseIndexConfigEncryptionKey(t *testing.T) {
 		// Create a processor with config that has IndexEncryptionKey
 		envCfg := createTestEnvConfig()
 		envCfg.IndexEncryptionKey = "config-secret-key"
-		procWithKey := NewProcessor(&DSLConfig{}, envCfg, createTestServerConfig(), false, "")
+		procWithKey := NewProcessor(&DSLConfig{}, envCfg, serverConfig, false, "")
 
 		stepConfig := StepConfig{
 			CodebaseIndex: &CodebaseIndexConfig{
@@ -411,7 +413,7 @@ func TestBuildCodebaseIndexConfigEncryptionKey(t *testing.T) {
 		// Create a processor with config that has IndexEncryptionKey
 		envCfg := createTestEnvConfig()
 		envCfg.IndexEncryptionKey = "config-secret-key"
-		procWithKey := NewProcessor(&DSLConfig{}, envCfg, createTestServerConfig(), false, "")
+		procWithKey := NewProcessor(&DSLConfig{}, envCfg, serverConfig, false, "")
 
 		stepConfig := StepConfig{
 			CodebaseIndex: &CodebaseIndexConfig{
@@ -431,7 +433,9 @@ func TestBuildCodebaseIndexConfigEncryptionKey(t *testing.T) {
 }
 
 func TestBuildCodebaseIndexConfigMaxFiles(t *testing.T) {
-	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), createTestServerConfig(), false, "")
+	serverConfig := createTestServerConfig()
+	serverConfig.DataDir = t.TempDir()
+	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), serverConfig, false, "")
 
 	limit := 500
 	config := processor.buildCodebaseIndexConfig(StepConfig{
@@ -492,7 +496,9 @@ index:
 		t.Fatalf("plugin = %#v", plugin)
 	}
 
-	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), createTestServerConfig(), false, "")
+	serverConfig := createTestServerConfig()
+	serverConfig.DataDir = t.TempDir()
+	processor := NewProcessor(&DSLConfig{}, createTestEnvConfig(), serverConfig, false, "")
 	indexConfig := processor.buildCodebaseIndexConfig(StepConfig{CodebaseIndex: &CodebaseIndexConfig{
 		ParserPlugins: []codebaseindex.ParserPluginConfig{plugin},
 	}})

--- a/utils/processor/index_root_test.go
+++ b/utils/processor/index_root_test.go
@@ -1,0 +1,120 @@
+package processor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCodebaseIndexRootConfinement(t *testing.T) {
+	dataDir, project, outside := t.TempDir(), t.TempDir(), t.TempDir()
+	for _, base := range []string{dataDir, project} {
+		if err := os.Mkdir(filepath.Join(base, "src"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, enabled := range []bool{false, true} {
+		for _, selected := range []bool{false, true} {
+			base := dataDir
+			p := NewProcessor(&DSLConfig{}, &config.EnvConfig{}, &config.ServerConfig{Enabled: enabled, DataDir: dataDir}, false, "../../untrusted-runtime")
+			if selected {
+				base = project
+				p.SetSourceRoot(project)
+			}
+			canonical, err := filepath.EvalSymlinks(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, requested := range []string{"", ".", "src", filepath.Join(base, "src"), "../outside", outside} {
+				got, err := p.buildCodebaseIndexConfigWithError(StepConfig{CodebaseIndex: &CodebaseIndexConfig{Root: requested}})
+				preflightErr := p.preflightCodebaseIndex(Step{Name: "index", Config: StepConfig{CodebaseIndex: &CodebaseIndexConfig{Root: requested}}})
+				if requested == "../outside" || requested == outside {
+					if err == nil || preflightErr == nil {
+						t.Fatalf("accepted outside root %q (auth=%v, selected=%v)", requested, enabled, selected)
+					}
+					continue
+				}
+				if err != nil || preflightErr != nil {
+					t.Fatalf("legitimate root %q: runtime %v, preflight %v", requested, err, preflightErr)
+				}
+				want := canonical
+				if requested != "" && requested != "." {
+					want = filepath.Join(canonical, "src")
+				}
+				if got.Root != want {
+					t.Fatalf("root %q resolved to %q, want %q", requested, got.Root, want)
+				}
+			}
+			got, err := p.buildCodebaseIndexConfigWithError(StepConfig{})
+			if err != nil || got.Root != canonical {
+				t.Fatalf("omitted config escaped approved root: %+v, %v", got, err)
+			}
+		}
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Symlink(outside, filepath.Join(dataDir, "escape")); err != nil {
+			t.Fatal(err)
+		}
+		p := NewProcessor(&DSLConfig{}, &config.EnvConfig{}, &config.ServerConfig{Enabled: true, DataDir: dataDir}, false, "")
+		if _, err := p.buildCodebaseIndexConfigWithError(StepConfig{CodebaseIndex: &CodebaseIndexConfig{Root: "escape"}}); err == nil {
+			t.Fatal("accepted root symlink outside data directory")
+		}
+	}
+}
+
+func TestNestedWorkflowPreservesIndexRoot(t *testing.T) {
+	project, dataDir := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "go.mod"), []byte("module example.test/nested\ngo 1.25\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "main.go"), []byte("package main\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(project, "child.yaml")
+	if err := os.WriteFile(child, []byte("index:\n  step_type: codebase-index\n  codebase_index: {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	var dsl DSLConfig
+	workflow, err := yaml.Marshal(map[string]any{"child": map[string]any{"process": map[string]any{"workflow_file": child}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := yaml.Unmarshal(workflow, &dsl); err != nil {
+		t.Fatal(err)
+	}
+	p := NewProcessor(&dsl, &config.EnvConfig{}, &config.ServerConfig{Enabled: true, DataDir: dataDir}, false, "")
+	p.SetSourceRoot(project)
+	if err := p.Preflight(); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Process(); err != nil {
+		t.Fatal(err)
+	}
+	files, err := filepath.Glob(filepath.Join(project, ".comanda", "*.meta.json"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("child index left selected project: %v, %v", files, err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, ".comanda")); !os.IsNotExist(err) {
+		t.Fatalf("child index was written under data directory: %v", err)
+	}
+}
+
+func TestCodebaseIndexRejectsUnconfiguredServerRoot(t *testing.T) {
+	p := NewProcessor(&DSLConfig{}, &config.EnvConfig{}, &config.ServerConfig{Enabled: true}, false, "")
+	if _, err := p.buildCodebaseIndexConfigWithError(StepConfig{}); err == nil {
+		t.Fatal("unconfigured server indexed working directory")
+	}
+}
+
+func TestCodebaseIndexCLIRootRemainsUnrestricted(t *testing.T) {
+	root := t.TempDir()
+	p := NewProcessor(&DSLConfig{}, &config.EnvConfig{}, &config.ServerConfig{Enabled: false}, false, "")
+	got, err := p.buildCodebaseIndexConfigWithError(StepConfig{CodebaseIndex: &CodebaseIndexConfig{Root: root}})
+	if err != nil || got.Root != root {
+		t.Fatalf("CLI root changed: %+v, %v", got, err)
+	}
+}

--- a/utils/processor/preflight.go
+++ b/utils/processor/preflight.go
@@ -189,6 +189,7 @@ func (p *Processor) preflightWorkflowFile(stepName, path string) error {
 		return fmt.Errorf("step %q: parse sub-workflow %q: %w", stepName, resolved, err)
 	}
 	childProcessor := NewProcessor(&child, p.envConfig, p.serverConfig, p.verbose, p.runtimeDir, p.cliVariables)
+	childProcessor.SetSourceRoot(p.sourceRoot)
 	childProcessor.SetWorkflowFile(resolved)
 	return childProcessor.Preflight()
 }
@@ -201,11 +202,7 @@ func (p *Processor) preflightCodebaseIndex(step Step) error {
 	if ci.Use != nil {
 		return nil // Registry loading is validated when the index is read during processing.
 	}
-	root := ci.Root
-	if root == "" {
-		root = "."
-	}
-	resolved, err := p.preflightResolvePath(root)
+	resolved, err := p.resolveCodebaseIndexRoot(ci.Root)
 	if err != nil {
 		return fmt.Errorf("step %q: resolve codebase root: %w", step.Name, err)
 	}

--- a/utils/server/file_handlers.go
+++ b/utils/server/file_handlers.go
@@ -798,6 +798,12 @@ func (s *Server) handleYAMLProcess(w http.ResponseWriter, r *http.Request) {
 
 	// Create processor instance with validation enabled and runtime directory
 	proc := processor.NewProcessor(&dslConfig, s.envConfig, s.config, true, runtimeDir)
+	if sourceRoot, err := projectSourceRoot(s.envConfig, r.URL.Query().Get("project")); err != nil {
+		sendJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	} else if sourceRoot != "" {
+		proc.SetSourceRoot(sourceRoot)
+	}
 
 	// Set input if provided
 	if req.Input != "" {

--- a/utils/server/index_security_test.go
+++ b/utils/server/index_security_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+)
+
+func TestYAMLProcessConfinesIndexRoots(t *testing.T) {
+	for _, tc := range []struct {
+		name, root, project string
+		auth, allowed       bool
+	}{
+		{name: "outside absolute root", root: "outside", auth: true},
+		{name: "relative traversal", root: "../outside", auth: true},
+		{name: "outside root without authentication", root: "outside"},
+		{name: "registered project escape", root: "outside", project: "approved", auth: true},
+		{name: "default data directory", allowed: true, auth: true},
+		{name: "default data directory without authentication", allowed: true},
+		{name: "default registered project", project: "approved", allowed: true, auth: true},
+		{name: "unknown project", project: "unknown", auth: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir, projectDir, outside := t.TempDir(), t.TempDir(), t.TempDir()
+			for _, dir := range []string{dataDir, projectDir, outside} {
+				if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.test/project\ngo 1.25\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\nfunc main() {}\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			root := tc.root
+			if root == "outside" {
+				root = outside
+			}
+			workflow := "index:\n  step_type: codebase-index\n"
+			if root != "" {
+				workflow += fmt.Sprintf("  codebase_index:\n    root: %q\n", root)
+			} else {
+				workflow += "  codebase_index: {}\n"
+			}
+			body, err := json.Marshal(map[string]any{"content": workflow})
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := &Server{config: &config.ServerConfig{Enabled: tc.auth, BearerToken: "test-token", DataDir: dataDir}, envConfig: &config.EnvConfig{Indexes: map[string]*config.IndexEntry{"approved": {Path: projectDir}}}}
+			req := httptest.NewRequest(http.MethodPost, "/yaml/process?runtimeDir=../../outside&project="+tc.project, bytes.NewReader(body))
+			req.Header.Set("Authorization", "Bearer test-token")
+			w := httptest.NewRecorder()
+			s.handleYAMLProcess(w, req)
+			var response ProcessResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v: %s", err, w.Body.String())
+			}
+			if response.Success != tc.allowed {
+				t.Fatalf("allowed=%v: status %d response %+v", tc.allowed, w.Code, response)
+			}
+			if !tc.allowed && tc.project != "unknown" && !strings.Contains(response.Error, "escapes the selected project root") {
+				t.Fatalf("unexpected rejection: %s", response.Error)
+			}
+			if _, err := os.Stat(filepath.Join(outside, ".comanda")); !os.IsNotExist(err) {
+				t.Fatalf("outside index was written: %v", err)
+			}
+			if tc.allowed {
+				base := dataDir
+				if tc.project != "" {
+					base = projectDir
+				}
+				matches, err := filepath.Glob(filepath.Join(base, ".comanda", "*.meta.json"))
+				if err != nil || len(matches) != 1 {
+					t.Fatalf("legitimate index not generated: %v, %v", matches, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The graph builder previously inherited the indexer's markdown file limits, merged packages by short name, and missed root-component membership. Incremental index updates also discarded symbols for unchanged files. This change gives LLM context and graph construction a shared structural scan while retaining bounded markdown output.

- Extract and persist symbols for all scanned files, read complete source files, and hash complete contents during index updates.
- Resolve Go package identities through the nearest module, retain full signatures, field types, and documentation, and connect receiver types to methods across files.
- Preserve unchanged symbols during incremental updates and reuse index metadata during graph builds, including configured parser plugins.
- Upgrade legacy metadata automatically on the next index update, even without source changes. Existing markdown indexes remain readable.
- Refresh existing project-local graphs during index updates, remove stale nodes, and keep encrypted indexes from exposing extracted symbols in plaintext metadata or graphs.
- Address CodeQL alert #116 by authorizing server workflow index roots and confining module reads to the index tree, including symlink resolution.

## Compatibility

The first update of legacy metadata performs a full regeneration; later updates reuse content-validated symbols. `--max-files` now limits markdown selection independently of structural extraction. Existing file, type, and function IDs remain stable; resolved package IDs become module-qualified on rebuild. Custom `--db` graphs still require an explicit graph update.

HTTP workflow indexing uses the selected registered project or the configured data directory, including omitted roots. `/yaml/process` accepts `?project=<registered-name>`. Preflight and child workflows use the same boundary. CLI repository selection remains unrestricted, and both relative and absolute module symlinks are supported when their targets remain inside the index root.

## Validation

- Passed tests for `utils/codebaseindex`, `utils/knowledgegraph`, `utils/semanticmemory`, `utils/graphviewer`, `utils/server`, and `cmd`.
- Passed the full affected-package suites after the security fix: `env TMPDIR=/private/tmp go test ./utils/codebaseindex ./utils/knowledgegraph ./utils/processor ./utils/server ./cmd`. The canonical temporary path avoids an existing macOS `/var` versus `/private/var` assertion mismatch.
- Added regression coverage for legacy migration without source changes, unchanged-symbol retention, deleted files, markdown limits, large-file extraction and hashing, nested modules, package/component collisions, method ownership, encrypted updates, and automatic graph refresh.
- `git diff --check` passed.
- Reproduced escaping module symlinks and omitted-root behavior before the fix; regression tests now pass. HTTP tests reject outside roots/traversal and preserve approved default roots. Independent review caught an absolute internal symlink regression, which was reproduced and fixed.
