### PR TITLE
Fix index and graph discovery from subdirectories; add graph list

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -50,6 +50,8 @@ Graph data lives in the project's semantic memory database
 memory recall (types: [graph_node]) see graph concepts too.
 
 Examples:
+  comanda graph list                        # List available graphs
+  comanda graph build                       # Build graph for the current project
   comanda graph build myproject              # Build graph from a registered index
   comanda graph build myproject --enhance    # Add AI-inferred concept nodes/edges
   comanda graph explain Store                # Show a node and its connections
@@ -61,20 +63,24 @@ Examples:
 }
 
 var graphBuildCmd = &cobra.Command{
-	Use:   "build <index-name>",
+	Use:   "build [index-name]",
 	Short: "Build (or rebuild) the knowledge graph for a registered index",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runGraphBuild,
+	Long: `Build the knowledge graph for a registered index. With no name, use
+--namespace or the nearest registered project containing the current directory.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runGraphBuild,
 }
 
 var graphUpdateCmd = &cobra.Command{
-	Use:   "update <index-name>",
+	Use:   "update [index-name]",
 	Short: "Rebuild the knowledge graph from a fresh scan of the index",
 	Long: `Rebuild the knowledge graph for a registered index.
 
 The graph is rebuilt from a fresh deterministic scan and replaces the stored
-graph for the namespace (stale nodes from deleted files are removed).`,
-	Args: cobra.ExactArgs(1),
+graph for the namespace (stale nodes from deleted files are removed).
+With no name, use --namespace or the nearest registered project containing
+the current directory.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runGraphBuild,
 }
 
@@ -241,9 +247,9 @@ clients such as Canvas:
 
 func init() {
 	rootCmd.AddCommand(graphCmd)
-	graphCmd.AddCommand(graphBuildCmd, graphUpdateCmd, graphExplainCmd, graphPathCmd, graphQueryCmd, graphStatsCmd, graphExportCmd, graphVisualizeCmd)
+	graphCmd.AddCommand(graphBuildCmd, graphUpdateCmd, graphListCmd, graphExplainCmd, graphPathCmd, graphQueryCmd, graphStatsCmd, graphExportCmd, graphVisualizeCmd)
 
-	graphCmd.PersistentFlags().StringVarP(&graphNamespace, "namespace", "n", "", "Graph namespace (default: index registered for current directory)")
+	graphCmd.PersistentFlags().StringVarP(&graphNamespace, "namespace", "n", "", "Graph namespace (default: nearest registered project; list: all)")
 	graphCmd.PersistentFlags().StringVar(&graphDBPath, "db", "", "Path to the graph/memory SQLite database (default: project-local)")
 
 	graphBuildCmd.Flags().BoolVar(&graphEnhance, "enhance", false, "Add AI-inferred concept nodes and edges using default_generation_model")
@@ -254,6 +260,7 @@ func init() {
 	graphExplainCmd.Flags().BoolVar(&graphJSON, "json", false, "Output JSON subgraph")
 	graphPathCmd.Flags().BoolVar(&graphJSON, "json", false, "Output JSON hop list")
 	graphQueryCmd.Flags().BoolVar(&graphJSON, "json", false, "Output JSON subgraph")
+	graphListCmd.Flags().Bool("json", false, "Output available graphs as JSON")
 
 	graphExportCmd.Flags().StringVarP(&graphExportOutput, "output", "o", "", "Write export to a file instead of stdout")
 	graphVisualizeCmd.Flags().IntVar(&graphVisualizePort, "port", 0, "Local port to listen on (0 selects a free port)")
@@ -412,7 +419,11 @@ func compactProgressDetail(detail string) string {
 }
 
 func runGraphBuild(_ *cobra.Command, args []string) error {
-	entry, name, err := findIndex(args[0])
+	requestedName := graphNamespace
+	if len(args) > 0 {
+		requestedName = args[0]
+	}
+	entry, name, err := findIndex(requestedName)
 	if err != nil {
 		return err
 	}

--- a/cmd/graph_discovery_test.go
+++ b/cmd/graph_discovery_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+	"github.com/spf13/cobra"
+)
+
+func TestGraphBuildAndUpdateInferProject(t *testing.T) {
+	previousConfig, previousNamespace, previousDB := envConfig, graphNamespace, graphDBPath
+	previousEnhance, previousPlugins := graphEnhance, indexParserPlugins
+	t.Cleanup(func() {
+		envConfig, graphNamespace, graphDBPath = previousConfig, previousNamespace, previousDB
+		graphEnhance, indexParserPlugins = previousEnhance, previousPlugins
+	})
+	graphNamespace, graphDBPath, graphEnhance, indexParserPlugins = "", "", false, nil
+	root, other := t.TempDir(), t.TempDir()
+	for _, dir := range []string{root, other} {
+		if err := os.MkdirAll(filepath.Join(dir, ".comanda"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\ntype Store struct {}\nfunc main() {}\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	envConfig = &config.EnvConfig{Indexes: map[string]*config.IndexEntry{
+		"project": {Path: root}, "other": {Path: other},
+	}}
+	t.Chdir(filepath.Join(root, ".comanda"))
+	for _, tc := range []struct {
+		name, namespace, want string
+		cmd                   *cobra.Command
+		args                  []string
+	}{
+		{name: "build from subdirectory", cmd: graphBuildCmd, want: "project"},
+		{name: "update from subdirectory", cmd: graphUpdateCmd, want: "project"},
+		{name: "namespace override", cmd: graphBuildCmd, namespace: "other", want: "other"},
+		{name: "explicit name overrides namespace", cmd: graphBuildCmd, namespace: "other", args: []string{"project"}, want: "project"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			graphNamespace = tc.namespace
+			if err := tc.cmd.ValidateArgs(tc.args); err != nil {
+				t.Fatal(err)
+			}
+			if err := tc.cmd.RunE(tc.cmd, tc.args); err != nil {
+				t.Fatal(err)
+			}
+			q, closeStore, err := openGraphQuerierFor(tc.want, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer closeStore()
+			if _, err := q.Resolve(context.Background(), "Store"); err != nil {
+				t.Fatalf("graph missing built source: %v", err)
+			}
+		})
+	}
+	graphNamespace = ""
+	q, closeStore, err := openGraphQuerier()
+	if err != nil {
+		t.Fatalf("query from .comanda: %v", err)
+	}
+	defer closeStore()
+	if _, err := q.Resolve(context.Background(), "Store"); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range []*cobra.Command{graphBuildCmd, graphUpdateCmd} {
+		if err := cmd.ValidateArgs([]string{"one", "two"}); err == nil {
+			t.Fatalf("%s accepted extra arguments", cmd.Name())
+		}
+	}
+}
+
+func TestGraphList(t *testing.T) {
+	previousConfig, previousNamespace, previousDB := envConfig, graphNamespace, graphDBPath
+	t.Cleanup(func() { envConfig, graphNamespace, graphDBPath = previousConfig, previousNamespace, previousDB })
+	graphNamespace, graphDBPath = "", ""
+	root := t.TempDir()
+	envConfig = &config.EnvConfig{Indexes: map[string]*config.IndexEntry{
+		"zeta": {Path: root}, "alpha": {Path: root}, "unbuilt": {Path: root},
+		"memory_only": {Path: root}, "invalid": nil,
+	}}
+	ctx := context.Background()
+	for _, name := range []string{"zeta", "alpha", "memory_only"} {
+		path := semanticmemory.DefaultPath(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		store, err := semanticmemory.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if name != "memory_only" {
+			if _, err := store.UpsertGraphNode(ctx, semanticmemory.GraphNode{ID: name, Namespace: name, Name: "Store", Kind: "type"}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := listGraphs(ctx, "", "")
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("list = %+v, %v", entries, err)
+	}
+	if entries[0].Namespace != "alpha" || entries[1].Namespace != "zeta" || entries[0].Nodes != 1 || entries[0].Edges != 0 {
+		t.Fatalf("unexpected graph summaries: %+v", entries)
+	}
+	if _, err := os.Stat(semanticmemory.DefaultPath(root, "unbuilt")); !os.IsNotExist(err) {
+		t.Fatalf("listing created an unbuilt graph: %v", err)
+	}
+	filtered, err := listGraphs(ctx, "zeta", "")
+	if err != nil || len(filtered) != 1 || filtered[0].Namespace != "zeta" {
+		t.Fatalf("filtered list = %+v, %v", filtered, err)
+	}
+	custom, err := listGraphs(ctx, "", entries[0].Database)
+	if err != nil || len(custom) != 1 || custom[0] != entries[0] {
+		t.Fatalf("custom database list = %+v, %v", custom, err)
+	}
+	if _, err := listGraphs(ctx, "", filepath.Join(root, "missing.db")); err == nil {
+		t.Fatal("explicit missing database should report an error")
+	}
+	badDB := filepath.Join(root, "corrupt.db")
+	if err := os.WriteFile(badDB, []byte("not a database"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := listGraphs(ctx, "", badDB); err == nil {
+		t.Fatal("corrupt database should report an error")
+	}
+	for _, asJSON := range []bool{false, true} {
+		cmd := &cobra.Command{}
+		cmd.SetContext(ctx)
+		cmd.Flags().Bool("json", asJSON, "")
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		if err := runGraphList(cmd, nil); err != nil {
+			t.Fatal(err)
+		}
+		if asJSON {
+			var decoded []graphListEntry
+			if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || len(decoded) != 2 {
+				t.Fatalf("invalid list JSON: %q, %v", out.String(), err)
+			}
+		} else if !strings.Contains(out.String(), "NAME") || !strings.Contains(out.String(), "alpha") || strings.Contains(out.String(), "unbuilt") {
+			t.Fatalf("unexpected table: %s", out.String())
+		}
+	}
+	envConfig = nil
+	empty, err := listGraphs(ctx, "", "")
+	if err != nil || empty == nil || len(empty) != 0 {
+		t.Fatalf("empty list = %+v, %v", empty, err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	cmd.Flags().Bool("json", false, "")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runGraphList(cmd, nil); err != nil || !strings.Contains(out.String(), "No graphs found") {
+		t.Fatalf("empty table = %q, %v", out.String(), err)
+	}
+}

--- a/cmd/graph_list.go
+++ b/cmd/graph_list.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/kris-hansen/comanda/utils/semanticmemory"
+	"github.com/spf13/cobra"
+)
+
+var graphListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available knowledge graphs",
+	Long: `List built graphs in the project-local databases of registered indexes.
+Use --db to list graphs in a custom database, or --namespace to filter by name.
+Indexes with no graph are omitted.`,
+	Args: cobra.NoArgs,
+	RunE: runGraphList,
+}
+
+type graphListEntry struct {
+	semanticmemory.GraphSummary
+	Database string `json:"database"`
+}
+
+func runGraphList(cmd *cobra.Command, _ []string) error {
+	entries, err := listGraphs(cmd.Context(), graphNamespace, graphDBPath)
+	if err != nil {
+		return err
+	}
+	asJSON, err := cmd.Flags().GetBool("json")
+	if err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if asJSON {
+		return json.NewEncoder(out).Encode(entries)
+	}
+	if len(entries) == 0 {
+		_, err := fmt.Fprintln(out, "No graphs found. Use 'comanda graph build [index-name]' to build one.")
+		return err
+	}
+	w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tNODES\tEDGES\tDATABASE")
+	for _, entry := range entries {
+		fmt.Fprintf(w, "%s\t%d\t%d\t%s\n", entry.Namespace, entry.Nodes, entry.Edges, entry.Database)
+	}
+	return w.Flush()
+}
+
+func listGraphs(ctx context.Context, namespace, dbPath string) ([]graphListEntry, error) {
+	entries := make([]graphListEntry, 0)
+	read := func(path, filter string, allowMissing bool) error {
+		// Listing must not create databases for indexes without a graph.
+		if _, err := os.Stat(path); err != nil {
+			if allowMissing && os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("inspect graph database %q: %w", path, err)
+		}
+		store, err := semanticmemory.Open(path)
+		if err != nil {
+			return fmt.Errorf("open graph database %q: %w", path, err)
+		}
+		defer store.Close()
+		summaries, err := store.GraphSummaries(ctx)
+		if err != nil {
+			return fmt.Errorf("list graphs in %q: %w", path, err)
+		}
+		for _, summary := range summaries {
+			if filter == "" || summary.Namespace == filter {
+				entries = append(entries, graphListEntry{GraphSummary: summary, Database: path})
+			}
+		}
+		return nil
+	}
+	if dbPath != "" {
+		if err := read(dbPath, namespace, false); err != nil {
+			return nil, err
+		}
+	} else if envConfig != nil {
+		var names []string
+		for name := range envConfig.Indexes {
+			if namespace == "" || name == namespace {
+				names = append(names, name)
+			}
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			entry := envConfig.Indexes[name]
+			if entry == nil || entry.Path == "" {
+				continue
+			}
+			if err := read(semanticmemory.DefaultPath(entry.Path, name), name, true); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return entries, nil
+}

--- a/cmd/graph_test.go
+++ b/cmd/graph_test.go
@@ -62,7 +62,8 @@ func TestIndexUpdateRefreshesExistingGraphWithoutSourceChanges(t *testing.T) {
 	if refresh, err := shouldRefreshIndexGraph("project", root, true); err != nil || refresh {
 		t.Fatal("encrypted index would create a plaintext graph")
 	}
-	if err := runUpdate(updateCmd, []string{"project"}); err != nil {
+	t.Chdir(filepath.Join(root, ".comanda"))
+	if err := runUpdate(updateCmd, nil); err != nil {
 		t.Fatal(err)
 	}
 	querier, closeStore, err := openGraphQuerierFor("project", dbPath)

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -93,7 +94,8 @@ var updateCmd = &cobra.Command{
 	Short: "Incrementally update an existing index",
 	Long: `Update an existing index by re-indexing only changed files.
 
-If no name is provided, updates the index for the current directory.
+If no name is provided, updates the nearest registered index containing the
+current directory. This also works from project subdirectories such as .comanda.
 
 Examples:
   comanda index update           # Update index for current dir
@@ -839,7 +841,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// findIndex finds an index by name, or by current directory if name is empty
+// findIndex finds an index by name, or by the nearest registered ancestor root.
 func findIndex(name string) (*config.IndexEntry, string, error) {
 	if envConfig == nil || envConfig.Indexes == nil || len(envConfig.Indexes) == 0 {
 		return nil, "", fmt.Errorf("no indexes registered (use 'comanda index capture' first)")
@@ -853,19 +855,48 @@ func findIndex(name string) (*config.IndexEntry, string, error) {
 		return entry, name, nil
 	}
 
-	// Find by current directory
+	// Resolve symlinks so registered aliases and the physical working directory
+	// select the same project (including macOS /var and /private/var aliases).
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get current directory: %w", err)
 	}
-
-	for n, entry := range envConfig.Indexes {
-		if entry.Path == cwd {
-			return entry, n, nil
-		}
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to resolve current directory: %w", err)
 	}
 
-	return nil, "", fmt.Errorf("no index found for current directory (use 'comanda index capture' or specify name)")
+	var matches []string
+	nearestRootLength := -1
+	for n, entry := range envConfig.Indexes {
+		if entry == nil || entry.Path == "" {
+			continue
+		}
+		root, err := filepath.EvalSymlinks(entry.Path)
+		if err != nil {
+			continue
+		}
+		relative, err := filepath.Rel(root, cwd)
+		if err != nil || !filepath.IsLocal(relative) {
+			continue
+		}
+		if len(root) > nearestRootLength {
+			nearestRootLength = len(root)
+			matches = []string{n}
+		} else if len(root) == nearestRootLength {
+			matches = append(matches, n)
+		}
+	}
+	if len(matches) == 1 {
+		name := matches[0]
+		return envConfig.Indexes[name], name, nil
+	}
+	if len(matches) > 1 {
+		sort.Strings(matches)
+		return nil, "", fmt.Errorf("multiple indexes match the nearest project root: %s (specify an index name)", strings.Join(matches, ", "))
+	}
+
+	return nil, "", fmt.Errorf("no registered index contains current directory %q (use 'comanda index list' to find a name, or 'comanda index capture' to create one)", cwd)
 }
 
 // Config helpers - use config.LoadEnvConfig and config.SaveEnvConfig directly

--- a/cmd/index_lookup_test.go
+++ b/cmd/index_lookup_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kris-hansen/comanda/utils/config"
+)
+
+func TestFindIndexFromSubdirectories(t *testing.T) {
+	workspace := t.TempDir()
+	root := filepath.Join(workspace, "pyrogy-popper")
+	nested := filepath.Join(root, "packages", "nested")
+	for _, dir := range []string{filepath.Join(root, ".comanda"), filepath.Join(nested, "src"), root + "-other"} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	previous := envConfig
+	t.Cleanup(func() { envConfig = previous })
+	envConfig = &config.EnvConfig{Indexes: map[string]*config.IndexEntry{
+		"pyrogy_popper": {Path: root}, "nested": {Path: nested},
+		"stale": {Path: filepath.Join(workspace, "missing")}, "nil": nil,
+	}}
+	for _, tc := range []struct{ name, dir, want string }{
+		{"root", root, "pyrogy_popper"},
+		{"metadata directory", filepath.Join(root, ".comanda"), "pyrogy_popper"},
+		{"deep subdirectory", filepath.Join(root, "packages"), "pyrogy_popper"},
+		{"nested project", nested, "nested"},
+		{"nested subdirectory", filepath.Join(nested, "src"), "nested"},
+		{"sibling prefix", root + "-other", ""},
+		{"outside project", workspace, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(tc.dir)
+			entry, name, err := findIndex("")
+			if tc.want == "" {
+				if err == nil || !strings.Contains(err.Error(), "no registered index contains current directory") {
+					t.Fatalf("unexpected lookup: %q, %v", name, err)
+				}
+				return
+			}
+			if err != nil || name != tc.want || entry != envConfig.Indexes[tc.want] {
+				t.Fatalf("lookup = %q, %v; want %q", name, err, tc.want)
+			}
+		})
+	}
+	t.Run("explicit name overrides nearest project", func(t *testing.T) {
+		t.Chdir(nested)
+		_, name, err := findIndex("pyrogy_popper")
+		if err != nil || name != "pyrogy_popper" {
+			t.Fatalf("explicit lookup = %q, %v", name, err)
+		}
+	})
+	t.Run("ambiguous root", func(t *testing.T) {
+		t.Chdir(nested)
+		envConfig.Indexes["nested_copy"] = &config.IndexEntry{Path: nested}
+		defer delete(envConfig.Indexes, "nested_copy")
+		_, _, err := findIndex("")
+		if err == nil || !strings.Contains(err.Error(), "nested, nested_copy") {
+			t.Fatalf("ambiguous lookup = %v", err)
+		}
+	})
+}
+
+func TestFindIndexThroughRegisteredSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges")
+	}
+	workspace := t.TempDir()
+	root, alias := filepath.Join(workspace, "project"), filepath.Join(workspace, "alias")
+	if err := os.MkdirAll(filepath.Join(root, ".comanda"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, alias); err != nil {
+		t.Fatal(err)
+	}
+	previous := envConfig
+	t.Cleanup(func() { envConfig = previous })
+	envConfig = &config.EnvConfig{Indexes: map[string]*config.IndexEntry{"project": {Path: alias}}}
+	t.Chdir(filepath.Join(root, ".comanda"))
+	_, name, err := findIndex("")
+	if err != nil || name != "project" {
+		t.Fatalf("symlink lookup = %q, %v", name, err)
+	}
+}

--- a/docs/design/knowledge-graph.md
+++ b/docs/design/knowledge-graph.md
@@ -31,7 +31,23 @@ comanda index capture -n myproject --graph
 comanda graph build myproject
 comanda graph build myproject --enhance          # add AI-inferred concepts/edges
 comanda graph update myproject                   # rebuild from a fresh scan
+
+# From the project root or any subdirectory (including .comanda)
+comanda index update
+comanda graph build
+comanda graph update
 ```
+
+Unnamed index and graph commands select the nearest registered project root.
+Nested registered projects take precedence over their parents. If multiple
+indexes share that nearest root, specify the exact registered name from
+`comanda index list`. Explicit names remain valid from any directory.
+
+`comanda graph list` shows built graphs with node/edge counts and database paths
+across registered indexes; indexes without graphs are omitted. Use `--json` for
+machine-readable output, `-n <namespace>` to filter, or `--db <path>` to list all
+graphs in a custom database. Custom database locations are not registered
+automatically, so they require `--db` when listing or querying.
 
 `--graph` also works on `comanda index update`. Encrypted indexes are skipped
 (graph data is plain SQLite). The graph is rebuilt deterministically on each
@@ -97,7 +113,7 @@ comanda graph export -o graph.json           # graphify-style JSON
 ```
 
 `-n <namespace>` selects a graph (default: the index registered for the
-current directory); `--db <path>` points at a specific database.
+current directory or its nearest registered ancestor); `--db <path>` points at a specific database.
 `explain`, `path`, and `query` accept `--json`.
 
 ## Workflow recall

--- a/utils/semanticmemory/graph.go
+++ b/utils/semanticmemory/graph.go
@@ -50,6 +50,34 @@ func graphAnnotationSourceRef(namespace, nodeID string) string {
 	return "graph-annotation/" + namespace + "/" + nodeID
 }
 
+// GraphSummary describes a namespace with stored graph nodes.
+type GraphSummary struct {
+	Namespace string `json:"namespace"`
+	Nodes     int    `json:"nodes"`
+	Edges     int    `json:"edges"`
+}
+
+// GraphSummaries counts available graphs without loading their nodes or edges.
+func (s *Store) GraphSummaries(ctx context.Context) ([]GraphSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT n.namespace, n.nodes, COALESCE(e.edges, 0)
+        FROM (SELECT namespace, COUNT(*) AS nodes FROM graph_nodes GROUP BY namespace) n
+        LEFT JOIN (SELECT namespace, COUNT(*) AS edges FROM graph_edges GROUP BY namespace) e
+        ON e.namespace = n.namespace ORDER BY n.namespace`)
+	if err != nil {
+		return nil, fmt.Errorf("query graph summaries: %w", err)
+	}
+	defer rows.Close()
+	summaries := make([]GraphSummary, 0)
+	for rows.Next() {
+		var summary GraphSummary
+		if err := rows.Scan(&summary.Namespace, &summary.Nodes, &summary.Edges); err != nil {
+			return nil, err
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, rows.Err()
+}
+
 // GraphNode is one vertex in a knowledge graph stored alongside durable memory.
 type GraphNode struct {
 	ID        string

--- a/utils/semanticmemory/graph_test.go
+++ b/utils/semanticmemory/graph_test.go
@@ -3,8 +3,38 @@ package semanticmemory
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
+
+func TestGraphSummaries(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "memory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if summaries, err := store.GraphSummaries(ctx); err != nil || len(summaries) != 0 {
+		t.Fatalf("empty graph summaries = %+v, %v", summaries, err)
+	}
+	for _, node := range []GraphNode{
+		{ID: "z1", Namespace: "zeta", Name: "Z", Kind: "type"},
+		{ID: "a1", Namespace: "alpha", Name: "A", Kind: "type"},
+		{ID: "a2", Namespace: "alpha", Name: "B", Kind: "function"},
+	} {
+		if _, err := store.UpsertGraphNode(ctx, node); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.UpsertGraphEdge(ctx, GraphEdge{ID: "e1", Namespace: "alpha", SourceID: "a1", TargetID: "a2", Kind: "uses"}); err != nil {
+		t.Fatal(err)
+	}
+	summaries, err := store.GraphSummaries(ctx)
+	want := []GraphSummary{{Namespace: "alpha", Nodes: 2, Edges: 1}, {Namespace: "zeta", Nodes: 1, Edges: 0}}
+	if err != nil || !reflect.DeepEqual(summaries, want) {
+		t.Fatalf("graph summaries = %+v, %v; want %+v", summaries, err, want)
+	}
+}
 
 func TestGraphNodeUpsertMirrorsIntoMemorySearch(t *testing.T) {
 	store, err := Open(filepath.Join(t.TempDir(), "memory.db"))


### PR DESCRIPTION
## Summary

- Resolve unnamed index commands from the nearest registered ancestor root, including `.comanda` and deeper subdirectories. Respect nested projects, canonicalize symlink aliases, reject ambiguous registrations, and provide actionable errors outside indexed projects.
- Make `comanda graph build` and `comanda graph update` accept an optional index name. Default to `--namespace` or the current project; existing graph queries and visualization inherit subdirectory discovery.
- Add `comanda graph list` with namespace, node/edge counts, and database paths. Support `--json`, `--namespace`, and listing namespaces in a custom `--db` database. Omit indexes without graphs and do not create missing databases while listing.
- Preserve exact explicit index names and existing index/database formats. No recapture or migration is needed for discovery.

## Reproduction Fixed

From a registered project's `.comanda` directory, these now resolve the project automatically:

```sh
comanda index update
comanda graph build
comanda graph update
comanda graph stats
```

`comanda graph list` shows which registered projects already have graphs. Custom database locations still require `--db` because they are not recorded in the index registry.

## Verification

- `go test ./cmd ./utils/semanticmemory ./utils/codebaseindex ./utils/knowledgegraph -count=1 -timeout 120s`
- `go vet ./cmd ./utils/semanticmemory ./utils/codebaseindex ./utils/knowledgegraph`
- `go run . graph list --help`
- `git diff --check`
- Regression coverage includes nearest/nested roots, `.comanda`, sibling-prefix exclusion, symlink aliases, ambiguous roots, explicit name/namespace overrides, unnamed index update refreshing a graph, graph build/update/query from subdirectories, list ordering/filtering/JSON, empty and corrupt databases, and namespace-specific counts.
