### PR TITLE
fix(index): recognize uppercase and mixed-case source extensions

### DIFF
--- a/utils/codebaseindex/parser_plugin_test.go
+++ b/utils/codebaseindex/parser_plugin_test.go
@@ -34,8 +34,10 @@ func TestParserPluginHelper(t *testing.T) {
 func TestParserPluginIndexesCustomExtension(t *testing.T) {
 	t.Setenv("COMANDA_TEST_PARSER_PLUGIN", "1")
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "sample.ctx"), []byte("directive custom"), 0644); err != nil {
-		t.Fatal(err)
+	for _, name := range []string{"sample.ctx", "uppercase.CTX", "mixed.CtX"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("directive custom"), 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	cfg := DefaultConfig()
@@ -57,11 +59,16 @@ func TestParserPluginIndexesCustomExtension(t *testing.T) {
 	if len(languages) != 1 || languages[0] != "private-context" {
 		t.Fatalf("languages = %v, want private-context", languages)
 	}
-	if len(scan.Candidates) != 1 || scan.Candidates[0].Symbols == nil {
-		t.Fatalf("candidates = %#v, want indexed plugin file", scan.Candidates)
+	if len(scan.Candidates) != 3 {
+		t.Fatalf("candidates = %#v, want all three extension variants", scan.Candidates)
 	}
-	if got := scan.Candidates[0].Symbols.Functions[0].Name; got != "CustomDirective" {
-		t.Fatalf("plugin function = %q, want CustomDirective", got)
+	for _, candidate := range scan.Candidates {
+		if candidate.Language != "private-context" || candidate.Symbols == nil || len(candidate.Symbols.Functions) != 1 {
+			t.Fatalf("candidate = %#v, want plugin language and extracted symbols", candidate)
+		}
+		if got := candidate.Symbols.Functions[0].Name; got != "CustomDirective" {
+			t.Fatalf("plugin function = %q, want CustomDirective", got)
+		}
 	}
 }
 

--- a/utils/codebaseindex/scan.go
+++ b/utils/codebaseindex/scan.go
@@ -147,7 +147,7 @@ func (m *Manager) walkDir(
 			}
 		} else {
 			// Check if file should be processed
-			ext := filepath.Ext(name)
+			ext := strings.ToLower(filepath.Ext(name))
 			isValidExt := validExts[ext]
 			isConfig := m.matchesConfigPattern(name, configPatterns)
 
@@ -197,7 +197,7 @@ func (m *Manager) processFile(path string) *FileEntry {
 	}
 
 	// Determine language
-	ext := filepath.Ext(path)
+	ext := strings.ToLower(filepath.Ext(path))
 	for _, adapter := range m.adapters {
 		for _, adapterExt := range adapter.FileExtensions() {
 			if ext == adapterExt {


### PR DESCRIPTION
Comanda normalizes parser-plugin extensions to lowercase, but the scanner compares them with the filename's original case. As a result, `.CBL` and `.CPY` files are silently omitted from indexes and knowledge graphs; an AWS CardDemo capture included only 80 of its 106 COBOL source files.

Normalize source-file extensions during both file selection and language assignment. Extend the parser-plugin regression test to require lowercase, uppercase, and mixed-case files to receive the correct language and extracted symbols.

Validation:
- `go test ./utils/codebaseindex ./utils/knowledgegraph` passed.
- Rebuilt the CardDemo index and graph with the fix: all 106 files, 1,728 graph nodes, and 2,227 edges.
- Verified graph file coverage, edge endpoints, COPY dependency resolution, cross-file record usage, and extraction near the end of a 182KB source file.
